### PR TITLE
fix(staking): use Chainlink price checker for compound() slippage

### DIFF
--- a/addresses/8453.json
+++ b/addresses/8453.json
@@ -145,6 +145,11 @@
     "isContract": true
   },
   {
+    "addr": "0xeF7541b388a77C1709a3d44BfBfC5c1ED3F0Ac94",
+    "name": "CHAINLINK_MAMO_USD",
+    "isContract": true
+  },
+  {
     "addr": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "name": "SAFE_PROXY",
     "isContract": true

--- a/multisig/mamo-multisig/005_MamoStakingDeployment.sol
+++ b/multisig/mamo-multisig/005_MamoStakingDeployment.sol
@@ -65,13 +65,23 @@ contract MamoStakingDeployment is MultisigProposal {
         address mamoToken = addresses.getAddress("MAMO");
         address dexRouter = addresses.getAddress("AERODROME_ROUTER");
         address quoter = addresses.getAddress("AERODROME_QUOTER");
+        address slippagePriceChecker = addresses.getAddress("CHAINLINK_SWAP_CHECKER_PROXY");
         address mamoStrategyRegistry = addresses.getAddress("MAMO_STRATEGY_REGISTRY");
         address multiRewards = addresses.getAddress("MAMO_MULTI_REWARDS");
 
         vm.startBroadcast(deployer);
 
         address mamoStakingRegistry = address(
-            new MamoStakingRegistry(deployer, deployer, guardian, mamoToken, dexRouter, quoter, DEFAULT_SLIPPAGE_IN_BPS)
+            new MamoStakingRegistry(
+                deployer,
+                deployer,
+                guardian,
+                mamoToken,
+                dexRouter,
+                quoter,
+                slippagePriceChecker,
+                DEFAULT_SLIPPAGE_IN_BPS
+            )
         );
 
         address mamoStakingStrategy = address(new MamoStakingStrategy());

--- a/multisig/mamo-multisig/008_MamoStakingV2Deployment.sol
+++ b/multisig/mamo-multisig/008_MamoStakingV2Deployment.sol
@@ -7,6 +7,7 @@ import {MamoStakingStrategyFactory} from "@contracts/MamoStakingStrategyFactory.
 import {MamoStrategyRegistry} from "@contracts/MamoStrategyRegistry.sol";
 
 import {RewardsDistributorSafeModule} from "@contracts/RewardsDistributorSafeModule.sol";
+import {ISlippagePriceChecker} from "@contracts/interfaces/ISlippagePriceChecker.sol";
 import {IMultiRewards} from "@contracts/interfaces/IMultiRewards.sol";
 
 import {Addresses} from "@fps/addresses/Addresses.sol";
@@ -66,6 +67,7 @@ contract MamoStakingV2Deployment is MultisigProposal {
         address mamoToken = addresses.getAddress("MAMO");
         address dexRouter = addresses.getAddress("AERODROME_ROUTER");
         address quoter = addresses.getAddress("AERODROME_QUOTER");
+        address slippagePriceChecker = addresses.getAddress("CHAINLINK_SWAP_CHECKER_PROXY");
         address mamoStrategyRegistry = addresses.getAddress("MAMO_STRATEGY_REGISTRY");
         address multiRewards = addresses.getAddress("MAMO_MULTI_REWARDS");
 
@@ -78,7 +80,16 @@ contract MamoStakingV2Deployment is MultisigProposal {
         vm.startBroadcast(deployer);
 
         address mamoStakingRegistry = address(
-            new MamoStakingRegistry(deployer, deployer, guardian, mamoToken, dexRouter, quoter, DEFAULT_SLIPPAGE_IN_BPS)
+            new MamoStakingRegistry(
+                deployer,
+                deployer,
+                guardian,
+                mamoToken,
+                dexRouter,
+                quoter,
+                slippagePriceChecker,
+                DEFAULT_SLIPPAGE_IN_BPS
+            )
         );
 
         address mamoStakingStrategy = address(new MamoStakingStrategy());
@@ -146,6 +157,37 @@ contract MamoStakingV2Deployment is MultisigProposal {
 
         // Remove backend role from deprecated staking factory
         registry.revokeRole(registry.BACKEND_ROLE(), deprecatedStakingStrategyFactory);
+
+        _configureCbBtcToMamoOracle();
+    }
+
+    /**
+     * @notice Configures the SlippagePriceChecker for the cbBTC -> MAMO swap path used by compound()
+     * @dev Chain: cbBTC * (BTC/USD) / (MAMO/USD) = MAMO equivalent.
+     *      The first feed is forward (multiply); the second is reverse (divide), since we want
+     *      to convert "USD value" back into "MAMO units."
+     */
+    function _configureCbBtcToMamoOracle() private {
+        ISlippagePriceChecker priceChecker =
+            ISlippagePriceChecker(addresses.getAddress("CHAINLINK_SWAP_CHECKER_PROXY"));
+        address cbBTC = addresses.getAddress("cbBTC");
+        address mamo = addresses.getAddress("MAMO");
+
+        ISlippagePriceChecker.TokenFeedConfiguration[] memory feeds =
+            new ISlippagePriceChecker.TokenFeedConfiguration[](2);
+        feeds[0] = ISlippagePriceChecker.TokenFeedConfiguration({
+            chainlinkFeed: addresses.getAddress("CHAINLINK_BTC_USD"),
+            reverse: false,
+            heartbeat: 3600
+        });
+        feeds[1] = ISlippagePriceChecker.TokenFeedConfiguration({
+            chainlinkFeed: addresses.getAddress("CHAINLINK_MAMO_USD"),
+            reverse: true,
+            heartbeat: 86400
+        });
+
+        priceChecker.addTokenConfiguration(cbBTC, mamo, feeds);
+        priceChecker.setMaxTimePriceValid(cbBTC, 3600);
     }
 
     function simulate() public override {

--- a/src/MamoStakingRegistry.sol
+++ b/src/MamoStakingRegistry.sol
@@ -7,6 +7,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 
 import {IQuoter} from "@interfaces/IQuoter.sol";
+import {ISlippagePriceChecker} from "@interfaces/ISlippagePriceChecker.sol";
 import {ISwapRouter} from "@interfaces/ISwapRouter.sol";
 
 /**
@@ -41,6 +42,12 @@ contract MamoStakingRegistry is AccessControlEnumerable, Pausable {
     ISwapRouter public dexRouter;
     IQuoter public quoter;
 
+    /// @notice Chainlink-based price checker used to compute swap reference prices
+    /// @dev Anchors compound()'s minimum-out calculation to an external oracle, preventing
+    ///      sandwich attacks that would bypass an in-pool quote (which is self-referential
+    ///      when the quoter and the swap router share the same pool in the same transaction)
+    ISlippagePriceChecker public slippagePriceChecker;
+
     /// @notice Global slippage configuration
     uint256 public defaultSlippageInBps;
 
@@ -52,6 +59,7 @@ contract MamoStakingRegistry is AccessControlEnumerable, Pausable {
     event RewardTokenPoolUpdated(address indexed token, address indexed oldPool, address indexed newPool);
     event DEXRouterUpdated(address indexed oldRouter, address indexed newRouter);
     event QuoterUpdated(address indexed oldQuoter, address indexed newQuoter);
+    event SlippagePriceCheckerUpdated(address indexed oldChecker, address indexed newChecker);
     event DefaultSlippageUpdated(uint256 oldSlippageInBps, uint256 newSlippageInBps);
     event TokenRecovered(address indexed token, address indexed to, uint256 amount);
 
@@ -63,6 +71,7 @@ contract MamoStakingRegistry is AccessControlEnumerable, Pausable {
      * @param _mamoToken The MAMO token address
      * @param _dexRouter The initial DEX router address
      * @param _quoter The initial quoter address
+     * @param _slippagePriceChecker The Chainlink-based slippage price checker
      * @param _defaultSlippageInBps The initial default slippage in basis points
      */
     constructor(
@@ -72,6 +81,7 @@ contract MamoStakingRegistry is AccessControlEnumerable, Pausable {
         address _mamoToken,
         address _dexRouter,
         address _quoter,
+        address _slippagePriceChecker,
         uint256 _defaultSlippageInBps
     ) {
         require(admin != address(0), "Invalid admin address");
@@ -80,6 +90,7 @@ contract MamoStakingRegistry is AccessControlEnumerable, Pausable {
         require(_mamoToken != address(0), "Invalid MAMO token address");
         require(_dexRouter != address(0), "Invalid DEX router address");
         require(_quoter != address(0), "Invalid quoter address");
+        require(_slippagePriceChecker != address(0), "Invalid slippage price checker address");
         require(_defaultSlippageInBps <= MAX_SLIPPAGE_IN_BPS, "Default slippage too high");
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
@@ -89,6 +100,7 @@ contract MamoStakingRegistry is AccessControlEnumerable, Pausable {
         mamoToken = _mamoToken;
         dexRouter = ISwapRouter(_dexRouter);
         quoter = IQuoter(_quoter);
+        slippagePriceChecker = ISlippagePriceChecker(_slippagePriceChecker);
         defaultSlippageInBps = _defaultSlippageInBps;
     }
 
@@ -208,6 +220,27 @@ contract MamoStakingRegistry is AccessControlEnumerable, Pausable {
         quoter = _quoter;
 
         emit QuoterUpdated(oldQuoter, address(_quoter));
+    }
+
+    /**
+     * @notice Set the slippage price checker contract (admin only)
+     * @dev Restricted to DEFAULT_ADMIN_ROLE because the price checker is the on-chain
+     *      reference price source for compound()'s minimum-out calculation. A malicious
+     *      or misconfigured checker could let swaps execute at arbitrary prices.
+     * @param _slippagePriceChecker The slippage price checker contract address
+     */
+    function setSlippagePriceChecker(ISlippagePriceChecker _slippagePriceChecker)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+        whenNotPaused
+    {
+        require(address(_slippagePriceChecker) != address(0), "Invalid slippage price checker");
+        require(address(_slippagePriceChecker) != address(slippagePriceChecker), "Slippage price checker already set");
+
+        address oldChecker = address(slippagePriceChecker);
+        slippagePriceChecker = _slippagePriceChecker;
+
+        emit SlippagePriceCheckerUpdated(oldChecker, address(_slippagePriceChecker));
     }
 
     // ==================== SLIPPAGE CONFIGURATION ====================

--- a/src/MamoStakingStrategy.sol
+++ b/src/MamoStakingStrategy.sol
@@ -10,7 +10,7 @@ import {IMamoStrategyRegistry} from "@interfaces/IMamoStrategyRegistry.sol";
 
 import {IMultiRewards} from "@interfaces/IMultiRewards.sol";
 import {IPool} from "@interfaces/IPool.sol";
-import {IQuoter} from "@interfaces/IQuoter.sol";
+import {ISlippagePriceChecker} from "@interfaces/ISlippagePriceChecker.sol";
 import {ISwapRouter} from "@interfaces/ISwapRouter.sol";
 
 import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
@@ -202,7 +202,9 @@ contract MamoStakingStrategy is Initializable, UUPSUpgradeable, BaseStrategy {
 
         MamoStakingRegistry.RewardToken[] memory rewardTokens = stakingRegistry.getRewardTokens();
         ISwapRouter dexRouter = stakingRegistry.dexRouter();
-        IQuoter quoter = stakingRegistry.quoter();
+        ISlippagePriceChecker priceChecker = stakingRegistry.slippagePriceChecker();
+        uint256 accountSlippage = getAccountSlippage();
+        address mamoTokenAddr = address(mamoToken);
 
         // Process each reward token by swapping to MAMO
         for (uint256 i = 0; i < rewardTokens.length; i++) {
@@ -216,20 +218,12 @@ contract MamoStakingStrategy is Initializable, UUPSUpgradeable, BaseStrategy {
             address poolAddress = rewardTokens[i].pool;
             int24 tickSpacing = IPool(poolAddress).tickSpacing();
 
-            // Get quote from quoter to calculate minimum amount out with slippage
-            (uint256 amountOut,,,) = quoter.quoteExactInputSingle(
-                IQuoter.QuoteExactInputSingleParams({
-                    tokenIn: address(rewardToken),
-                    tokenOut: address(mamoToken),
-                    amountIn: rewardBalance,
-                    tickSpacing: tickSpacing,
-                    sqrtPriceLimitX96: 0
-                })
-            );
-
-            // Apply slippage tolerance to get minimum amount out
-            uint256 accountSlippage = getAccountSlippage();
-            uint256 amountOutMinimum = (amountOut * (10000 - accountSlippage)) / 10000;
+            // Compute reference output from Chainlink-based price checker.
+            // This anchors the slippage check to an off-pool oracle so that pool-price
+            // manipulation (sandwich attacks) cannot bypass the minimum-out guard the
+            // way an in-pool quoter call would.
+            uint256 expectedOut = priceChecker.getExpectedOut(rewardBalance, address(rewardToken), mamoTokenAddr);
+            uint256 amountOutMinimum = (expectedOut * (10000 - accountSlippage)) / 10000;
 
             // Approve DEX router to spend reward tokens
             rewardToken.forceApprove(address(dexRouter), rewardBalance);


### PR DESCRIPTION
## Summary
- Replaces the self-referential Aerodrome quoter call in `MamoStakingStrategy.compound()` with `SlippagePriceChecker.getExpectedOut(rewardToken, MAMO)`. The minimum-out is now anchored to a Chainlink-derived reference price, preventing sandwich attacks that previously bypassed the slippage guard.
- Wires `slippagePriceChecker` into `MamoStakingRegistry` (constructor param + admin setter + event).
- The `008` multisig proposal now configures the cbBTC→MAMO oracle chain (BTC/USD forward × MAMO/USD reverse) on the existing `SlippagePriceChecker`.
- Adds `CHAINLINK_MAMO_USD = 0xeF7541b388a77C1709a3d44BfBfC5c1ED3F0Ac94` (8 decimals, "MAMO / USD") to `addresses/8453.json`.

## Why
Per [code-423n4/moonwell-bug-bounty-submissions#189](https://github.com/code-423n4/moonwell-bug-bounty-submissions/issues/189): the Aerodrome `QuoterV2` and `SwapRouter` share the same pool, so reading the quote and executing the swap in the same tx always agree — the slippage check was a tautology and offered zero MEV protection. Using `SlippagePriceChecker` matches the pattern already in `ERC20MoonwellMorphoStrategy` and anchors the check to an off-pool oracle.

## Risk / scope
- Constructor signature of `MamoStakingRegistry` changed (added `_slippagePriceChecker`). Both deployment proposals (`005`, `008`) updated.
- Requires fresh deployment of `MamoStakingRegistry` + `MamoStakingStrategy` implementation and migration of existing user proxies — followup multisig action.
- Existing 118 staking tests still pass (run against on-chain bytecode, so they don't yet exercise the new path; an `ERC20StrategyV2.t.sol`-style proposal-driven test is recommended as follow-up to validate end-to-end).

## Test plan
- [x] `forge build` clean
- [x] `forge fmt` applied
- [x] `make mamo-staking` (118/118 tests pass)
- [ ] Follow-up: redeploy-in-setUp test that exercises new compound() path against a sandwich-attack PoC

🤖 Generated with [Claude Code](https://claude.com/claude-code)