### PR TITLE
feat: vendor LeveragedAerodromeCL strategy for audit

### DIFF
--- a/docs/LEVERAGED_AERO_CL_AUDIT.md
+++ b/docs/LEVERAGED_AERO_CL_AUDIT.md
@@ -7,14 +7,15 @@ run by the Mamo backend as operator, on Sherwood's pooled-vault rails.
 
 ## Provenance
 
-The code in `src/leveraged-aero/` is **vendored byte-identical** (import-path rewrites only) from the
-public Sherwood protocol repo:
+The code in `src/leveraged-aero/` is **vendored identical modulo import-path rewrites and `forge fmt`**
+from the public Sherwood protocol repo — i.e. it compares equal to upstream after the import-path
+rewrites and this repo's `forge fmt` whitespace normalization:
 
 | | |
 |---|---|
 | Repo | https://github.com/sherwoodagent/sherwood-protocol |
 | Pinned commit | [`bb10bebff3cbf554e7538e42f1e876a47b09a6ac`](https://github.com/sherwoodagent/sherwood-protocol/tree/bb10bebff3cbf554e7538e42f1e876a47b09a6ac) (2026-07-10) |
-| Verified | 2026-07-13 — every vendored strategy file blob-compared equal to the mirror at the pinned commit |
+| Verified | 2026-07-13 — every vendored strategy file compared equal to the mirror at the pinned commit after import-path rewrites and `forge fmt` normalization |
 
 Where this package and the upstream repo disagree, upstream at the pinned commit is authoritative.
 
@@ -65,8 +66,10 @@ byte-identical in the manager" vs "…in the strategy" — while every storage-r
 
 **Bytecode margin note:** under this repo's optimizer profile (via_ir, runs=200), `LeveragedAeroManager`
 compiles to 23,996 runtime bytes — only **580 bytes under** the EIP-170 cap (`LeveragedAerodromeCLStrategy`
-is 19,514). Sherwood's CI gates this; this repo does not, so optimizer-setting changes can silently push
-it over. Re-check `forge build --sizes` after any toolchain change.
+is 19,514). Both Sherwood's CI and this repo's CI gate this — the build step runs `forge build --sizes`
+(`.github/workflows/test.yml`), which fails on an EIP-170 violation, so an optimizer-setting change that
+pushed the manager over the cap would break the build rather than slip through. Still re-check
+`forge build --sizes` locally after any toolchain change.
 
 ## Custody model in one paragraph
 
@@ -107,6 +110,38 @@ line references lives there:
    oracle; `selfManagesFees()` trust stopped by guardian review + owner veto; pending unclaimed AERO not
    in NAV; governance blast radius of the 3650-day duration ceiling; vault-side rescue dormancy under
    the indefinite proposal.
+10. **Hardcoded swap-route `tickSpacing`** — the auxiliary USDC↔leg swap helpers in
+    `LeveragedAeroManager.sol` (`_swapUsdcExactIn`, `_sweepLegToUsdc`, `_redeemCoverShortfall`) pin
+    `tickSpacing: int24(100)` for the USDC/cbBTC and USDC/WETH Slipstream routes, whereas the main LP
+    pool's spacing is config-driven (`$.tickSpacing`, used for range math and mint). This is a
+    single-venue assumption with no fallback: if the 100-spacing pool for a leg is the wrong or an
+    illiquid venue, the swap routes through it regardless. The slippage protection is uneven across
+    call sites: `_settleShortfall`'s `_swapUsdcExactIn` calls pass an oracle-derived
+    `minAmtOut = debtRem × (10000 − maxSlippageBps)/10000`; `_redeemCoverShortfall` is exact-output and
+    bounded by `amountInMax` (a `type(uint256).max`/idle-USDC cap on full redeem, the redeemer's own
+    budget on partial redeem, an oracle+slippage ceiling on the permissionless deleverage path); but the
+    two redeem-path residual-leg sweeps (`redeemUnwindImpl` → `_sweepLegToUsdc($.cbBTC/$.weth, …, 0)`)
+    pass `minOut = 0` and rely solely on the redeem's aggregate `minAssetsOut` floor rather than a
+    per-swap bound. Focus: whether the fixed spacing plus the `minOut = 0` residual sweeps are
+    exploitable under a manipulated/illiquid 100-spacing leg pool, and whether the aggregate floor is a
+    sufficient guard.
+
+## Accepted patterns / known non-issues
+
+Pre-declared so auditors don't re-report them; each is a deliberate, reviewed choice in the vendored code.
+
+- **No-op swap/mint deadlines.** Every Slipstream/Aerodrome swap and mint passes
+  `deadline: block.timestamp + 600`. Because the deadline is computed relative to the execution block,
+  it can never expire and provides no MEV/staleness protection. This is intentional: the real guards are
+  the per-swap min-outs / oracle floors (item 8, item 10) and the redeem/deploy aggregate min-out floors,
+  not the deadline. Accepted.
+- **CEI ordering in `fulfillRedeem` / `emergencyRedeem`.** Both settle via `_proportionalRedeem`, which
+  makes external calls — `IERC20(usdc).safeTransfer(recipient, assetsOut)` then
+  `ISyndicateVault(vault()).strategyBurn(shares)` — *before* the caller writes `r.settled = true`, so the
+  double-spend flag is set after the effects rather than before (a CEI-ordering deviation). Safe in
+  practice: both functions are `nonReentrant` under `ReentrancyGuardTransient`, USDC has no transfer
+  hooks, and the vault is a trusted in-scope contract, so no reentrant path can observe `settled == false`
+  and re-enter. Accepted.
 
 ## Specification & documentation
 

--- a/docs/LEVERAGED_AERO_CL_AUDIT.md
+++ b/docs/LEVERAGED_AERO_CL_AUDIT.md
@@ -1,0 +1,149 @@
+# LeveragedAerodromeCLStrategy — audit package
+
+This document is the entry point for auditing `src/leveraged-aero/`, the strategy contract of the
+joint Sherwood × Mamo **leveraged Aerodrome LP fund**: a net-short, leveraged Aerodrome Slipstream
+CL position (supply USDC to Moonwell → borrow cbBTC + WETH → concentrated LP → farm & compound AERO)
+run by the Mamo backend as operator, on Sherwood's pooled-vault rails.
+
+## Provenance
+
+The code in `src/leveraged-aero/` is **vendored byte-identical** (import-path rewrites only) from the
+public Sherwood protocol repo:
+
+| | |
+|---|---|
+| Repo | https://github.com/sherwoodagent/sherwood-protocol |
+| Pinned commit | [`bb10bebff3cbf554e7538e42f1e876a47b09a6ac`](https://github.com/sherwoodagent/sherwood-protocol/tree/bb10bebff3cbf554e7538e42f1e876a47b09a6ac) (2026-07-10) |
+| Verified | 2026-07-13 — every vendored strategy file blob-compared equal to the mirror at the pinned commit |
+
+Where this package and the upstream repo disagree, upstream at the pinned commit is authoritative.
+
+## Scope
+
+**Audit subject — the four contracts in `src/leveraged-aero/`:**
+
+| Contract | Role |
+|---|---|
+| `LeveragedAerodromeCLStrategy.sol` | Thin entrypoints + `nav()` + init + ERC-7201 `Layout`; owns everything touching the vault / shares / fees. ERC-1167 clone. |
+| `LeveragedAeroManager.sol` | All venue logic (supply/borrow/mint/stake/unwind/repay/swap), **delegatecalled** by the strategy. |
+| `LeveragedAeroValuation.sol` | Oracle net-equity NAV; fail-closed. |
+| `LeveragedAeroFees.sol` | Streaming management + high-water-mark performance fee math (`pure`). |
+
+**Supporting context — `src/leveraged-aero/sherwood/`:** the Sherwood framework pieces the strategy
+compiles against (`BaseStrategy`, interfaces, `ChainlinkReader` / `TickMath` / `LiquidityAmounts`,
+`FeeConstants`, `BatchExecutorLib`). Vendored so the package is self-contained and compiling; these are
+part of the already-reviewed Sherwood protocol and are context, not the primary subject.
+
+**Not vendored, but load-bearing** — read these in the upstream repo:
+
+- [`src/SyndicateVault.sol`](https://github.com/sherwoodagent/sherwood-protocol/blob/main/src/SyndicateVault.sol)
+  — the pooled ERC-4626 vault. The strategy mints/burns vault shares through two hooks:
+  `strategyMint(to, shares)` (`onlyActiveStrategy` + `whenNotPaused` + depositor whitelist) and
+  `strategyBurn(shares)` (`onlyActiveStrategy`, deliberately **not** pause-gated so user exits work
+  during an incident). The only thing standing between these hooks and arbitrary supply inflation is
+  the `onlyActiveStrategy` gate (the active proposal's strategy, resolved through the per-vault governor).
+- [`src/StrategyFactory.sol`](https://github.com/sherwoodagent/sherwood-protocol/blob/main/src/StrategyFactory.sol)
+  — `cloneAndInit` (template allowlist, `proposer == msg.sender`, one-shot init).
+- The per-vault governor lifecycle (propose → vote → guardian review → execute → settle) under which the
+  strategy lives as one **indefinite** proposal.
+
+## The corruption-critical invariant
+
+`LeveragedAeroManager`'s public functions are **delegatecalled** from the strategy clone, so both files
+declare the same diamond-storage triplet, which must stay **byte-identical** across the two files:
+
+- `Layout` struct (and `RedeemRequest`)
+- `STORAGE_SLOT` (`0x405ae0b1…844900`, ERC-7201 derived from `"leveraged.aero.cl.storage"`)
+- the `_layout()` assembly accessor
+
+Any field reorder/insert in one file without the other silently reads/writes wrong slots. There is no
+compile-time cross-file check; this repo adds `test/leveraged-aero/LayoutParity.t.sol` as a CI tripwire
+that textually compares the triplet between the two vendored files. (The comparison strips line comments:
+the upstream `Layout` blocks carry one intentionally asymmetric self-referential comment — "keep
+byte-identical in the manager" vs "…in the strategy" — while every storage-relevant token, the
+`RedeemRequest` struct, and the `STORAGE_SLOT` literal are compared verbatim.)
+
+**Bytecode margin note:** under this repo's optimizer profile (via_ir, runs=200), `LeveragedAeroManager`
+compiles to 23,996 runtime bytes — only **580 bytes under** the EIP-170 cap (`LeveragedAerodromeCLStrategy`
+is 19,514). Sherwood's CI gates this; this repo does not, so optimizer-setting changes can silently push
+it over. Re-check `forge build --sizes` after any toolchain change.
+
+## Custody model in one paragraph
+
+Users deposit and withdraw **at the strategy contract** (not the vault) while holding standard vault
+ERC-20 shares — "strategy-serviced custody". Deposits are priced at oracle net-equity NAV (`nav()`,
+fail-closed: a stale feed or shoved pool denies the deposit, never mints cheap shares). Exits have three
+entrypoints: fast oracle-priced `redeem` (LTV-gated, collateral-funded), async oracle-free
+`requestRedeem → fulfillRedeem` (proposer, exact proportional unwind), and a trustless
+`emergencyRedeem` deadman after 2 days. The operator (Mamo backend, the "proposer") manages the
+position through a bounded interface (`deployIdle` / `compound` / `rerange` / `adjustLeverage`) with
+hard LTV/health caps asserted after every action, plus a **permissionless** `deleverage` anyone can
+trigger when health slips. The agent can never withdraw user funds to itself.
+
+## Audit focus areas
+
+Condensed from the upstream spec (§ *Audit focus areas & known risks*) — the full treatment with code
+line references lives there:
+
+1. **Delegatecall layout drift** — the top structural risk (see above).
+2. **Oracle manipulation surface** — `nav()` prices deposits and the fast redeem. Focus on
+   `oracleSqrtPriceX96` bounds, the calm-gate TWAP rounding, and `_usdcValue` decimal scaling in
+   `LeveragedAeroValuation.sol`. CL legs split at an oracle-implied `sqrtP`, not pool `slot0`, so the
+   mint mark cannot be tick-shoved.
+3. **Deposit-side oracle-lag MEV (accepted, beta)** — a depositor front-running a pending Chainlink
+   update can skim up to the feed deviation threshold; bounded by `maxDelay` + calm-gate.
+4. **LTV-gate bypass attempts** — fast `redeem` predicts post-withdraw LTV on pre-withdraw prices;
+   `_assertHealthy` as belt; permissionless `deleverage` repays only to `minHealthBps × 1.05`.
+5. **Donation / inflation on strategy-side mint** — `nav()` excludes vault float but counts
+   strategy-held idle USDC and out-of-position legs; `NavUnpriceable` guards only the `navNet == 0` case.
+6. **IL-shortfall handling on full redeem** — the lone oracle dependency on the otherwise oracle-free
+   proportional path; partial redeems cap IL cover at the redeemer's own budget.
+7. **Fee paths** — fees crystallize on pre-action NAV (phantom-fee guard); protocol fee accrues as the
+   `protocolFeeOwed` USDC liability netted out of `nav()`; crystallize is best-effort on user-exit paths
+   (`FeeCrystallizeDeferred`) and hard-reverting on `compound`/`settle` — the asymmetry is intentional.
+8. **`compound` reward swap** — routes through a hardcoded Aerodrome v2 router; the hardened AERO/USD
+   oracle floor (`BelowOracleFloor`) is the honesty-independent guard.
+9. **Accepted residuals** (documented upstream): `deleverage` oracle-staleness window vs Moonwell's own
+   oracle; `selfManagesFees()` trust stopped by guardian review + owner veto; pending unclaimed AERO not
+   in NAV; governance blast radius of the 3650-day duration ceiling; vault-side rescue dormancy under
+   the indefinite proposal.
+
+## Specification & documentation
+
+- **Full spec + integration guide** (architecture, storage, authorization matrix, valuation & fees,
+  invariants, integrator flows, events, errors):
+  [`docs/LeveragedAerodromeCLStrategy.md`](https://github.com/sherwoodagent/sherwood-protocol/blob/main/docs/LeveragedAerodromeCLStrategy.md)
+  in the upstream repo. The spec was re-verified claim-by-claim against source on 2026-07-13; two known
+  minor errata at the pinned commit (a fix is upstream in review): the `ABSOLUTE_MAX_STRATEGY_DURATION`
+  reference should read `GovernorParameters.sol:50` (not `:39`), and `MIN_VOTING_PERIOD` is now a
+  constructor-set immutable (24h on mainnet, per-deployment) rather than a fixed 24h constant.
+- Product-level overview of the fund (roles, trust boundary, what Sherwood vs Mamo contributes) is
+  summarized in the PR description introducing this package.
+
+## Test evidence & how to reproduce
+
+**In this repo:**
+
+- `forge build` — the vendored package compiles against OZ 5.2.0, via_ir, cancun.
+- `forge test --match-path 'test/leveraged-aero/*' --ffi -vv` — the `Layout`/`RedeemRequest`/`STORAGE_SLOT`
+  parity tripwire.
+
+**Upstream (the full behavioral suite)** — the strategy's fork harness deploys the entire Sherwood
+protocol (governor + factory → vault → clone + init → propose/vote/execute → deposit / deployIdle /
+compound / rerange / deleverage / redeem → settle) against a Tenderly Base-fork vnet:
+
+```bash
+# in sherwoodagent/sherwood-protocol, with TENDERLY_FORK_RPC_URL in .env
+./script/tenderly/run-leveraged-aero.sh
+```
+
+Last verified run — **2026-07-13, 62/62 tests green, 0 failed, 0 skipped** across 9 suites:
+`LeveragedAeroCL.{deploy,deposit,leverage,redeem,rerange,compound,rescue,e2e}.fork.t.sol` +
+`LeveragedAeroValuation.fork.t.sol`. Coverage highlights: full e2e lifecycle; LTV/health bounds and
+permissionless deleverage recovery after an adverse Chainlink move; oracle-NAV invariance under a pool
+tick-shove (vs a drifting naive slot0 NAV); fail-closed valuation on sequencer-down/stale feeds with
+redeems still working; IL-shortfall cover at settle; performance fee on compounded yield.
+
+**Invariant suite** (upstream): `test/invariants/LeveragedAeroCL.invariant.t.sol` — stayer per-share NAV
+non-decreasing, health/LTV bounds after every op, `totalSupply` conservation across the mint/burn hooks,
+no-exfil (the strategy only ever pays the vault or a redeeming user), `protocolFeeOwed` monotonicity.

--- a/src/leveraged-aero/LeveragedAeroFees.sol
+++ b/src/leveraged-aero/LeveragedAeroFees.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+/// @title  LeveragedAeroFees
+/// @notice Streaming management fee + high-water-mark (HWM) performance fee for the
+///         leveraged Aerodrome CL strategy, both crystallised by minting fee-shares.
+///
+///         All functions are **pure** — the strategy passes state in and applies the
+///         returned deltas (`newHwmPerShareX`, `newLastAccrual`); it then calls
+///         `vault.strategyMint(feeRecipient, feeShares)`.  No storage is touched here.
+///
+///         ## Decimal context
+///         - `navPre`        USDC, 6 dp.
+///         - `totalSupply`   vault shares, 12 dp (`_decimalsOffset() = 6` on USDC 6 dp).
+///         - `hwmPerShareX`  = `navPre × 1e18 / totalSupply` — dimensionless, 1e18-scaled.
+///         - Fee rates (`managementFeeBps`, `performanceFeeBps`) are bps; 1% = 100.
+///
+///         ## Ordering
+///         `crystallize` computes management and performance fees against the **same**
+///         pre-action `navPre` / `totalSupply`.  Management shares are NOT applied before
+///         the performance computation — LP-favourable: avoids double-counting that
+///         dilution in the HWM basis.
+///
+///         The **protocol** slice is taken off the GROSS gain above the HWM *first*
+///         (`protocol = gain × protocolFeeBps / 10 000`), then the performance fee accrues
+///         on the reduced `gain − protocol` — mirroring the governor's "protocol before agent"
+///         ordering in `_distributeFees`. The protocol slice is a USDC LIABILITY the strategy
+///         discharges where USDC flows (redeem / compound / settle), NOT a fee-share mint.
+///         The **HWM still advances to the gross-peak `navPerShareX`** (computed on `navPre`),
+///         so no gain is ever charged twice and the next cycle measures from the gross peak
+///         (LP-favourable, consistent with the dilution approximation).
+///
+///         ## [1] review fix (phantom-fee guard)
+///         `crystallize` must be called with the *pre-deposit* NAV, before the vault
+///         pulls any USDC.  Calling it on the post-deposit NAV would let idle incoming
+///         USDC look like a profit above the HWM, silently over-charging existing LPs.
+///         The library enforces nothing about call ordering — that invariant is owned by
+///         the strategy (Tasks 3.6 / 3.7).  `test_noPhantomFee_whenIdleJustLanded`
+///         anchors the regression: given the correct pre-deposit input, this library
+///         produces zero performance fee.
+library LeveragedAeroFees {
+    /// @dev 1e18 fixed-point scale for per-share HWM and the management fee rate.
+    uint256 private constant WAD = 1e18;
+
+    /// @dev 365-day year in seconds (365 × 24 × 60 × 60 = 31 536 000).
+    uint256 private constant SECONDS_PER_YEAR = 365 days;
+
+    // =========================================================================
+    // Management fee
+    // =========================================================================
+
+    /// @notice Streaming management fee shares for an elapsed window `dt`.
+    ///
+    ///         `feeRate = managementFeeBps × dt / (10 000 × SECONDS_PER_YEAR)`
+    ///
+    ///         Minting `feeShares = totalSupply × feeRate / (1 − feeRate)` ensures the
+    ///         recipient owns exactly `feeRate` of the **post-mint** supply, i.e. the
+    ///         annualised dilution equals the bps fraction of AUM.
+    ///
+    ///         Rounds **down** (LP-favourable).
+    ///
+    /// @param totalSupply      Current vault share supply (12 dp).
+    /// @param managementFeeBps Annual management fee in bps (e.g. 100 = 1 %/yr).
+    /// @param dt               Seconds elapsed since last accrual.
+    /// @return feeShares       Shares to mint to the fee recipient.
+    function managementFeeShares(uint256 totalSupply, uint256 managementFeeBps, uint256 dt)
+        internal
+        pure
+        returns (uint256 feeShares)
+    {
+        if (totalSupply == 0 || managementFeeBps == 0 || dt == 0) return 0;
+
+        // feeRateX = managementFeeBps × dt × WAD / (10 000 × SECONDS_PER_YEAR).
+        // Math.mulDiv carries the 512-bit intermediate: the pre-multiply
+        // (managementFeeBps × dt) fits easily in uint256 for any realistic timestamp.
+        uint256 feeRateX = Math.mulDiv(managementFeeBps * dt, WAD, 10_000 * SECONDS_PER_YEAR);
+
+        // Absurd-dt guard: if feeRate ≥ 100 % the denominator (WAD − feeRateX) would
+        // underflow.  Return 0 (LP-favourable) rather than reverting — stale accruals
+        // must not brick the contract (e.g. extreme bps × impossible dt).
+        if (feeRateX >= WAD) return 0;
+
+        // feeShares = totalSupply × feeRateX / (WAD − feeRateX), rounded down.
+        // Post-mint invariant: feeShares / (totalSupply + feeShares) = feeRateX / WAD.
+        feeShares = Math.mulDiv(totalSupply, feeRateX, WAD - feeRateX);
+    }
+
+    // =========================================================================
+    // Performance fee
+    // =========================================================================
+
+    /// @notice HWM performance fee shares.
+    ///
+    ///         `navPerShareX = navPre × 1e18 / totalSupply`  (1e18-scaled ratio)
+    ///
+    ///         - If `hwmPerShareX == 0` (never set): seed the HWM to the current level,
+    ///           **no fee charged** — avoids a phantom fee on the first cycle after deploy.
+    ///         - If `navPerShareX ≤ hwmPerShareX`: no fee, HWM unchanged.
+    ///         - Else:
+    ///
+    ///             gain      = (navPerShareX − hwmPerShareX) × totalSupply / 1e18  (USDC 6 dp)
+    ///             protocol  = gain × protocolFeeBps / 10 000                       (off GROSS gain first)
+    ///             fee       = (gain − protocol) × performanceFeeBps / 10 000       (USDC 6 dp)
+    ///             feeShares = fee × totalSupply / (navPre − fee)                   (12 dp shares)
+    ///
+    ///           After mint the recipient holds value ≈ `fee` USDC; the HWM resets to the
+    ///           GROSS-peak `navPerShareX` (protocol slice NOT deducted from the basis) so future
+    ///           fees accrue only on NEW gains. The protocol slice is returned as a USDC LIABILITY
+    ///           the strategy discharges where USDC flows — never minted as shares.
+    ///
+    ///         If both fee rates are 0 but there is a gain, the HWM still advances
+    ///         (no retroactive back-charge when a rate is later set non-zero).
+    ///
+    ///         Rounds **down** (LP-favourable) on both slices.
+    ///
+    /// @param navPre            Pre-action strategy NAV (USDC, 6 dp).
+    /// @param totalSupply       Current vault share supply (12 dp).
+    /// @param hwmPerShareX      Stored HWM per share (1e18-scaled); 0 ⇒ first cycle.
+    /// @param performanceFeeBps Performance fee in bps (e.g. 1000 = 10 %).
+    /// @param protocolFeeBps    Protocol fee in bps, taken off the gross gain FIRST.
+    /// @return feeShares        Perf-fee shares to mint (0 if at/below HWM or unset).
+    /// @return newHwmPerShareX  Updated HWM (unchanged if no gain).
+    /// @return protocolUsdc     Protocol slice in USDC (6 dp) to accrue as a liability.
+    function performanceFeeShares(
+        uint256 navPre,
+        uint256 totalSupply,
+        uint256 hwmPerShareX,
+        uint256 performanceFeeBps,
+        uint256 protocolFeeBps
+    ) internal pure returns (uint256 feeShares, uint256 newHwmPerShareX, uint256 protocolUsdc) {
+        // No capital — nothing to charge or update.
+        if (totalSupply == 0 || navPre == 0) return (0, hwmPerShareX, 0);
+
+        uint256 navPerShareX = Math.mulDiv(navPre, WAD, totalSupply);
+
+        // First-time seeding: HWM was 0 (unset). Record current level, no fee charged —
+        // avoids a phantom performance fee on the first crystallize after deployment.
+        if (hwmPerShareX == 0) return (0, navPerShareX, 0);
+
+        // At or below the high-water mark → no fee, mark unchanged.
+        if (navPerShareX <= hwmPerShareX) return (0, hwmPerShareX, 0);
+
+        // Gain above the HWM is recognised; HWM always advances to the GROSS peak, even if both
+        // rates are zero, so future non-zero rates don't back-charge this gain.
+        // Gain in USDC 6 dp: (navPerShareX − hwmPerShareX) × totalSupply / WAD.
+        uint256 gainPerShareX = navPerShareX - hwmPerShareX;
+        uint256 totalGainUsdc = Math.mulDiv(gainPerShareX, totalSupply, WAD);
+
+        // Protocol slice off the GROSS gain FIRST (rounds down, LP-favourable). USDC liability,
+        // never minted; `min(., navPre)` is defensive against a malformed bps.
+        protocolUsdc = Math.mulDiv(totalGainUsdc, protocolFeeBps, 10_000);
+        if (protocolUsdc > navPre) protocolUsdc = navPre;
+
+        // HWM advances to the gross peak regardless of the perf rate.
+        if (performanceFeeBps == 0) return (0, navPerShareX, protocolUsdc);
+
+        // Perf fee accrues on the gain NET of the protocol slice.
+        uint256 feeValueUsdc = Math.mulDiv(totalGainUsdc - protocolUsdc, performanceFeeBps, 10_000);
+
+        // Degenerate guard: fee must be strictly less than NAV (else denominator ≤ 0).
+        // This can only trigger for extreme/malformed fee rates — fail safe, LP-favourable.
+        if (feeValueUsdc >= navPre) return (0, navPerShareX, protocolUsdc);
+
+        // Dilution: mint enough shares so the recipient's value ≈ feeValueUsdc.
+        // feeShares × navPre / (totalSupply + feeShares) = feeValueUsdc  (exact by algebra).
+        feeShares = Math.mulDiv(feeValueUsdc, totalSupply, navPre - feeValueUsdc);
+        newHwmPerShareX = navPerShareX;
+    }
+
+    // =========================================================================
+    // Combined entrypoint
+    // =========================================================================
+
+    /// @notice Crystallise management + performance fees before a user action.
+    ///
+    ///         **Call with the pre-action NAV** (before USDC is pulled in or shares are
+    ///         burned) so that no incoming deposit inflates the HWM basis ([1] fix).
+    ///
+    ///         The strategy:
+    ///         1. Calls `crystallize(nav(), vault.totalSupply(), ...)`.
+    ///         2. Calls `vault.strategyMint(feeRecipient, feeShares)` if `feeShares > 0`.
+    ///         3. Stores `hwmPerShareX = newHwmPerShareX` and `lastAccrual = newLastAccrual`.
+    ///         4. Proceeds with the user action (deposit / redeem).
+    ///
+    /// @param navPre            Strategy NAV before any user action (USDC, 6 dp).
+    /// @param totalSupply       Current vault share supply (12 dp).
+    /// @param hwmPerShareX      Stored HWM per share (1e18-scaled); 0 ⇒ first cycle.
+    /// @param lastAccrual       Timestamp of the previous crystallization.
+    /// @param nowTs             Current `block.timestamp`.
+    /// @param managementFeeBps  Annual management fee in bps.
+    /// @param performanceFeeBps Performance fee in bps.
+    /// @param protocolFeeBps    Protocol fee in bps, taken off the gross gain FIRST (before perf).
+    /// @return feeShares        Total shares to mint (management + performance).
+    /// @return newHwmPerShareX  Updated HWM to store.
+    /// @return newLastAccrual   Updated accrual timestamp (= `nowTs`).
+    /// @return protocolUsdc     Protocol slice in USDC (6 dp) to accrue as a liability.
+    function crystallize(
+        uint256 navPre,
+        uint256 totalSupply,
+        uint256 hwmPerShareX,
+        uint256 lastAccrual,
+        uint256 nowTs,
+        uint256 managementFeeBps,
+        uint256 performanceFeeBps,
+        uint256 protocolFeeBps
+    ) public pure returns (uint256 feeShares, uint256 newHwmPerShareX, uint256 newLastAccrual, uint256 protocolUsdc) {
+        // Always advance the accrual timestamp so management fees do not accumulate
+        // over periods when the vault held no capital.
+        newLastAccrual = nowTs;
+
+        // No capital: zero fees, HWM unchanged. `navPre == 0` (oracle down / calm-gate
+        // shut) is NOT short-circuited here — the management leg is price-free (D6): it
+        // still crystallises the elapsed `dt`, and `performanceFeeShares` defers on
+        // `navPre == 0` by returning the HWM unchanged, so no gain escapes the perf fee
+        // (the next priced cycle still measures gain vs the same HWM).
+        if (totalSupply == 0) {
+            newHwmPerShareX = hwmPerShareX;
+            return (0, newHwmPerShareX, newLastAccrual, 0);
+        }
+
+        // dt is 0 when called in the same block as the last accrual (e.g. two deposits).
+        uint256 dt = nowTs > lastAccrual ? nowTs - lastAccrual : 0;
+
+        // Management fee is price-free (supply × rate × dt) — accrues regardless of navPre.
+        uint256 mShares = managementFeeShares(totalSupply, managementFeeBps, dt);
+        // Performance + protocol need a price: navPre == 0 ⇒ (0 shares, HWM unchanged, 0 protocol) ⇒ defers.
+        (uint256 pShares, uint256 newHwm, uint256 protoUsdc) =
+            performanceFeeShares(navPre, totalSupply, hwmPerShareX, performanceFeeBps, protocolFeeBps);
+
+        // feeShares = mShares + pShares; overflow impossible (both << totalSupply).
+        feeShares = mShares + pShares;
+        newHwmPerShareX = newHwm;
+        protocolUsdc = protoUsdc;
+    }
+}

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -1,0 +1,1169 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import {LeveragedAeroValuation} from "./LeveragedAeroValuation.sol";
+import {ICToken, IComptroller, IMoonwellMarket} from "./sherwood/interfaces/IMoonwellMarket.sol";
+import {ICLGauge, ICLPool, ICLSwapRouter, INonfungiblePositionManager} from "./sherwood/interfaces/ISlipstream.sol";
+import {ChainlinkReader} from "./sherwood/libraries/ChainlinkReader.sol";
+import {LiquidityAmounts} from "./sherwood/libraries/LiquidityAmounts.sol";
+import {TickMath} from "./sherwood/libraries/TickMath.sol";
+
+/// @dev Minimal WETH9 interface — wraps native ETH into ERC-20 WETH.
+interface IWETH9 {
+    function deposit() external payable;
+}
+
+/// @dev Minimal Aerodrome v2 (AMM) Router — used for the `compoundImpl` AERO→USDC reward swap
+///      (see `AERO_V2_ROUTER`). The CL SwapRouter only serves Slipstream pools.
+interface IAeroRouter {
+    struct Route {
+        address from;
+        address to;
+        bool stable;
+        address factory;
+    }
+
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        Route[] calldata routes,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+}
+
+/// @title  LeveragedAeroManager
+/// @notice DEPLOYED, delegatecalled venue library for `LeveragedAerodromeCLStrategy`. The clone is at
+///         the EIP-170 margin, so the heavy on-venue sequences (supply / borrow / mint / stake /
+///         unwind / repay / swap) live here. A `public` library call compiles to `DELEGATECALL`, so
+///         this runs in the clone's context: `address(this)` is the clone and `_layout()` resolves to
+///         the clone's diamond storage.
+///
+///         CORRUPTION-CRITICAL slot discipline: `Layout`, `STORAGE_SLOT`, and `_layout()` are
+///         byte-identical to the strategy's — they MUST stay in lockstep or a delegatecall reads/
+///         writes the wrong slots. Do not reorder `Layout` fields in one file without the other.
+///
+///         Never touches `vault()` / `proposer()` / shares / fees (those stay in the strategy
+///         entrypoints); it only reads config + position state and performs venue calls.
+library LeveragedAeroManager {
+    using SafeERC20 for IERC20;
+
+    // ── Errors (selectors match the strategy's 1:1, so a test's
+    //    vm.expectRevert(LeveragedAerodromeCLStrategy.X.selector) matches a revert thrown here) ──
+    error UnhealthyPosition(uint256 ltvBps, uint256 limitBps);
+    error InvalidNpmReturn();
+    error ExecuteZeroBalance();
+    error MoonwellMintFailed(uint256 errCode);
+    error MoonwellBorrowFailed(uint256 errCode);
+    error NpmMintFailed();
+    error NpmApproveFailed();
+    error MoonwellRepayFailed(uint256 errCode);
+    error MoonwellRedeemFailed(uint256 errCode);
+    error InsufficientLiquidity();
+    error InsufficientIdle();
+    error HealthyNoDeleverage();
+    error FeedDecimalsMismatch();
+    error ZeroMinOut();
+    error BelowOracleFloor(); // compound swap fill < AERO/USD oracle floor (L9)
+    error FastRedeemExceedsLtv(uint256 ltvBps, uint256 maxLtvBps); // fast-path redeem would breach maxLtvBps
+
+    // ── Constants (compile-time literals, duplicated from the strategy) ──
+    uint8 private constant CBBTC_DECIMALS = 8; // cbBTC is 8dp wrapped Bitcoin
+    uint8 private constant WETH_DECIMALS = 18; // WETH9 on Base is 18dp
+    uint8 private constant RANGE_TICK_SPACINGS = 20; // tick-spacings each side of tick for the initial range
+    /// @dev `deleverage()` repays down to `minHealthBps × (1 + this/1e4)` — a small buffer above the
+    ///      minimum so a rescue doesn't land on the threshold and immediately re-trigger.
+    uint16 private constant DELEVERAGE_BUFFER_BPS = 500; // +5% above minHealthBps
+
+    /// @dev Aerodrome v2 (AMM) Router on Base — the `compoundImpl` AERO→USDC swap routes through its
+    ///      volatile pool, the deepest AERO/USDC liquidity on Base (~$10.4M vs ~$1.2M for the deepest
+    ///      Slipstream CL pool, fork-measured). Canonical immutable Base infra.
+    address private constant AERO_V2_ROUTER = 0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43;
+    /// @dev Aerodrome v2 PoolFactory on Base (`router.defaultFactory()`), required by the Route.
+    address private constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
+
+    // ── Diamond storage — Layout/STORAGE_SLOT/_layout()/RedeemRequest byte-identical to
+    //    LeveragedAerodromeCLStrategy (delegatecall slot discipline) ──
+
+    /// @dev Escrowed async-redeem request (Lane-B-style, but NO price freeze — shares keep bearing
+    ///      PnL until execution, so `cancelRedeem` is not a free look-back option).
+    struct RedeemRequest {
+        address owner; // request creator; the only address that can cancel / emergency-redeem it
+        uint256 shares; // vault shares escrowed in the strategy at request time
+        uint256 minAssetsOut; // slippage floor enforced at fulfill (fresh arg at emergencyRedeem)
+        uint40 requestedAt; // request timestamp; FULFILL_WINDOW deadman clock anchor
+        bool settled; // set once fulfilled / cancelled / emergency-redeemed (double-spend guard)
+    }
+
+    /// @custom:storage-location erc7201:leveraged.aero.cl.storage
+    struct Layout {
+        // valuation config: token / venue / feed addresses
+        address usdc;
+        address mUsdc;
+        address mCbBTC; // LeveragedAeroValuation.Config.cbBTCMarket
+        address mWeth; // LeveragedAeroValuation.Config.wethMarket
+        address cbBTC;
+        address weth;
+        address pool;
+        address cbBTCFeed;
+        address wethFeed;
+        address usdcFeed;
+        address sequencerFeed;
+        uint256 maxDelay;
+        uint256 gracePeriod;
+        uint16 calmDeviationTicks;
+        uint32 twapWindow;
+        // venue / protocol addresses (not in Config)
+        address comptroller;
+        address npm;
+        address gauge;
+        address swapRouter;
+        int24 tickSpacing;
+        // risk params
+        uint16 targetLtvBps;
+        uint16 maxLtvBps;
+        uint16 minHealthBps;
+        uint16 maxSlippageBps;
+        uint16 usdcCollateralFactorBps; // USDC collateral factor from Moonwell at init (8800 = 88%)
+        // position state (all zero pre-deploy / post-settle)
+        uint256 tokenId; // active CL position; 0 == flat book
+        int24 posTickLower;
+        int24 posTickUpper;
+        // fee params + state
+        uint16 managementFeeBps;
+        uint16 performanceFeeBps;
+        address feeRecipient;
+        uint256 hwmPerShare; // HWM nav-per-share (1e18 WAD), 0 until first deposit
+        uint256 lastFeeAccrualTimestamp;
+        uint256 protocolFeeOwed; // accrued protocol-fee USDC liability (6dp); discharged in redeem/compound/settle
+        // ── appended for the L9 compound oracle floor (keep byte-identical in the strategy) ──
+        address aeroUsdFeed; // AERO/USD aggregator (8dp) — floors compound()'s AERO→USDC swap
+        // ── LAST fields: appended for the escrowed async-redeem queue (keep byte-identical) ──
+        uint256 nextRedeemRequestId; // monotonic id cursor for `redeemRequests`
+        mapping(uint256 => RedeemRequest) redeemRequests; // id → escrowed async redeem
+    }
+
+    /// @dev keccak256(abi.encode(uint256(keccak256("leveraged.aero.cl.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant STORAGE_SLOT = 0x405ae0b144079093e970849fdffdcb2a514e44968598c6c5c73444496e844900;
+
+    /// @dev ERC-7201 diamond-storage accessor (byte-identical across strategy + manager).
+    function _layout() private pure returns (Layout storage $) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            $.slot := STORAGE_SLOT
+        }
+    }
+
+    // ── PUBLIC IMPLS (delegatecalled by the strategy entrypoints) ──
+
+    /// @notice Open the levered cbBTC/WETH CL position (body of the strategy's `_execute`).
+    ///         supply USDC → enterMarkets → borrow cbBTC+WETH → wrap → mint CL → stake gauge.
+    function executeImpl() public {
+        uint256 usdcAmt = _supplyCollateral();
+        (uint256 cbBTCAmt, uint256 wethAmt) = _computeAndBorrow(usdcAmt);
+        _wrapNativeEth();
+        _mintAndStake(cbBTCAmt, wethAmt);
+        _assertHealthy();
+    }
+
+    /// @notice Full proportional unwind to the strategy (body of the strategy's `_settle`). The
+    ///         strategy forwards the realized USDC to the vault afterward.
+    /// @return realizedUsdc USDC held by the strategy after the unwind.
+    function settleImpl() public returns (uint256 realizedUsdc) {
+        Layout storage $ = _layout();
+        // 1+2. Unstake + remove 100% liquidity + collect (num==den → no restake)
+        _unwindLiquidity(1, 1);
+        // 3. Repay both Moonwell borrows (handles shortfall)
+        _settleRepayDebts();
+        // 4. Redeem all remaining mUSDC collateral (debt = 0 now)
+        uint256 mBal = ICToken($.mUsdc).balanceOf(address(this));
+        if (mBal > 0) {
+            uint256 err = ICToken($.mUsdc).redeem(mBal);
+            if (err != 0) revert MoonwellRedeemFailed(err);
+        }
+        // 5. Sweep residual WETH + cbBTC → USDC (Chainlink-bounded min-out)
+        {
+            (uint256 pBTC, uint256 pETH, uint256 pUsdc) = _readAllPrices();
+            uint256 slip = uint256($.maxSlippageBps);
+            _swapTokenToUsdc(
+                $.weth,
+                _tokenToUsdc(IERC20($.weth).balanceOf(address(this)), WETH_DECIMALS, pETH, pUsdc) * (10000 - slip)
+                    / 10000
+            );
+            _swapTokenToUsdc(
+                $.cbBTC,
+                _tokenToUsdc(IERC20($.cbBTC).balanceOf(address(this)), CBBTC_DECIMALS, pBTC, pUsdc) * (10000 - slip)
+                    / 10000
+            );
+        }
+        // 6. Clear position state (flat-book invariant: nav() reads tokenId==0 branch)
+        $.tokenId = 0;
+        $.posTickLower = 0;
+        $.posTickUpper = 0;
+        realizedUsdc = IERC20($.usdc).balanceOf(address(this));
+    }
+
+    /// @notice Oracle-free proportional unwind: remove f = shares/supply of every leg (body of the
+    ///         strategy's `redeem`). Returns the redeemer's USDC.
+    /// @dev Idle USDC: the strategy may hold idle USDC from undeployed deposits — the redeemer gets f
+    ///      of it, stayers keep (1-f). We snapshot `idleUsdcBefore` and subtract `stayersIdle` at the end.
+    function redeemUnwindImpl(uint256 shares, uint256 supply) public returns (uint256) {
+        Layout storage $ = _layout();
+        // Snapshot idle USDC — stayers keep (1-f) of it.
+        uint256 idleUsdcBefore = IERC20($.usdc).balanceOf(address(this));
+        uint256 stayersIdle = idleUsdcBefore - Math.mulDiv(idleUsdcBefore, shares, supply);
+        // Snapshot the stayers' (1-f) share of any PRE-EXISTING idle leg. A `rerange` recenter
+        // leaves a remainder of one borrowed leg (cbBTC or WETH) idle in the strategy — the leg
+        // sweep at step E would otherwise hand a partial redeemer 100% of it, skimming the stayers'
+        // share. Reserving (1-f) of it keeps redeem oracle-free (stayers' share stays as LEGS, not
+        // oracle-valued). Both are ~0 (clean no-op) outside a post-rerange partial redeem.
+        uint256 stayersCb = _stayerLeg($.cbBTC, shares, supply);
+        uint256 stayersWeth = _stayerLeg($.weth, shares, supply);
+
+        // A — partial CL unwind (pool-based mins, oracle-free).
+        _unwindLiquidity(shares, supply);
+
+        // B — repay f of each debt from collected tokens; capture any IL shortfall. The repay is
+        // capped at the REDEEMER's own per-leg budget (`legBal − stayersLeg`) so a severe IL
+        // shortfall can never consume the stayers' reserved `(1-f)` idle-leg share to over-repay
+        // the redeemer's debt. Passing `stayersCb`/`stayersWeth` keeps the genuine shortfall flowing
+        // to `cbShort`/`wethShort` → covered from the redeemer's OWN collateral (step C), upholding
+        // the §7 invariant ("stayers keep (1-f) of every leg, regardless of price").
+        (uint256 cbShort, uint256 wethShort) = _redeemRepayFromCollected(shares, supply, stayersCb, stayersWeth);
+
+        if (shares == supply) {
+            // Full redemption — two-phase debt clearance before 100 % collateral redeem.
+            //
+            // Phase 1 (oracle-free): cover IL shortfall from idle USDC via exact-output swap.
+            //   When idle == 0 the calls are safe no-ops (amountInMaximum = 0 → early return).
+            if (cbShort > 0) _redeemCoverShortfall($.cbBTC, $.mCbBTC, cbShort, type(uint256).max);
+            if (wethShort > 0) _redeemCoverShortfall($.weth, $.mWeth, wethShort, type(uint256).max);
+            // Phase 2 (self-fund fallback): if residual debt remains after Phase 1 (idle == 0 case),
+            //   redeem mUSDC collateral → swap to deficit token → repay (settle-shortfall pattern).
+            //   _settleShortfall reads the oracle only when borrowBalance > 0, so it is a no-op
+            //   (oracle-free) when Phase 1 fully covered the shortfall.
+            _settleShortfall();
+            // Phase 3: all debt cleared — Moonwell now permits 100 % collateral redemption.
+            _redeemCollateral(shares, supply);
+            // Clear position state (flat-book invariant: no stayers remain after a full redeem).
+            $.tokenId = 0;
+            $.posTickLower = 0;
+            $.posTickUpper = 0;
+        } else {
+            // Partial redemption: redeem f*collateral first (Finding 1 fix). Each cover buy is
+            // capped at the redeemer's OWN budget (`balance − stayersIdle`), recomputed before each
+            // call since the first spends USDC. A shortfall (or sandwiched buy) that would need more
+            // than the redeemer's slice reverts the whole redeem — fail-safe, never touches stayer idle.
+            _redeemCollateral(shares, supply);
+            IERC20 usdc = IERC20($.usdc);
+            if (cbShort > 0) {
+                uint256 bal = usdc.balanceOf(address(this));
+                _redeemCoverShortfall($.cbBTC, $.mCbBTC, cbShort, bal > stayersIdle ? bal - stayersIdle : 0);
+            }
+            if (wethShort > 0) {
+                uint256 bal = usdc.balanceOf(address(this));
+                _redeemCoverShortfall($.weth, $.mWeth, wethShort, bal > stayersIdle ? bal - stayersIdle : 0);
+            }
+        }
+
+        // E — sweep residual cbBTC/WETH → USDC, LEAVING the stayers' reserved leg share un-swept
+        // (min-out=0; aggregate guard applies). For a full redeem (f=1) or no rerange remainder,
+        // stayers* == 0 → sweep all (identical to the prior unconditional sweep). In the common
+        // partial case this hands the redeemer exactly f*(idleLeg + LP_leg − debt_leg).
+        _sweepLegToUsdc($.cbBTC, stayersCb, 0);
+        _sweepLegToUsdc($.weth, stayersWeth, 0);
+
+        // assetsOut = total USDC minus the (1-f) idle-USDC portion that stays for stayers (the
+        // stayers' idle-leg share already stayed un-swept above, as legs).
+        uint256 usdcFinal = IERC20($.usdc).balanceOf(address(this));
+        return usdcFinal > stayersIdle ? usdcFinal - stayersIdle : 0;
+    }
+
+    /// @notice Oracle-priced fast-redeem funding (body of the strategy's `redeem`): source `assetsOut`
+    ///         USDC from the redeemer's pro-rata idle share FIRST, then free only the remainder from the
+    ///         Moonwell mUSDC collateral — no LP touch, no debt repay. `idleShare = f×idle` (f =
+    ///         shares/supply, computed by the strategy) caps the idle draw so a partial redeem never
+    ///         dips into a stayer's `(1-f)×idle` (the same reservation `redeemUnwindImpl` makes). The
+    ///         LTV gate is computed BEFORE the withdraw on the same `_readCollateralDebt` basis as
+    ///         `_assertHealthy`, but against the collateral-funded REMAINDER only: a redeem that would
+    ///         push post-withdraw LTV above `maxLtvBps` reverts `FastRedeemExceedsLtv` (a typed,
+    ///         frontend-routable error — send the user to `requestRedeem`), and `_assertHealthy()` runs
+    ///         after as belt. When idle alone covers `assetsOut` (e.g. a flat book), no collateral is
+    ///         touched and the LTV gate is skipped. The strategy pays the redeemer + burns shares; the
+    ///         idle already held plus the freed collateral cover the payout.
+    function fastRedeemImpl(uint256 assetsOut, uint256 idleShare) public {
+        Layout storage $ = _layout();
+        // Idle-first: draw at most the redeemer's `f×idle` share (also clamped to the live balance);
+        // the strategy's payout transfer consumes it implicitly, leaving `(1-f)×idle` for stayers.
+        uint256 idle = IERC20($.usdc).balanceOf(address(this));
+        uint256 fromIdle = assetsOut < idleShare ? assetsOut : idleShare;
+        if (fromIdle > idle) fromIdle = idle;
+        uint256 fromCollateral = assetsOut - fromIdle;
+        if (fromCollateral == 0) return; // idle fully funds the redeem — collateral + LTV gate untouched
+
+        (uint256 collateralUsdc, uint256 debtUsdc) = _readCollateralDebt();
+        uint256 maxLtv = uint256($.maxLtvBps);
+        // Predict the post-withdraw LTV on the pre-withdraw prices (collateral shrinks by the collateral-
+        // funded remainder, debt unchanged). `>= collateralUsdc` would zero/negate the denominator.
+        if (fromCollateral >= collateralUsdc) revert FastRedeemExceedsLtv(type(uint256).max, maxLtv);
+        if (debtUsdc > 0) {
+            uint256 postLtv = (debtUsdc * 10_000) / (collateralUsdc - fromCollateral);
+            if (postLtv > maxLtv) revert FastRedeemExceedsLtv(postLtv, maxLtv);
+        }
+        _redeemUnderlying($.mUsdc, fromCollateral);
+        _assertHealthy(); // authoritative post-op gate (belt over the pre-withdraw prediction)
+    }
+
+    /// @notice Public view wrapper over `_readCollateralDebt` for the strategy's `previewRedeem`
+    ///         (advisory fast-path gate prediction). Delegatecalled under staticcall — the oracle
+    ///         reads inside `_readCollateralDebt` fail-closed (revert) on a down feed, which the
+    ///         strategy's `previewRedeem` catches to return `(0,false)`.
+    function readCollateralDebtImpl() public view returns (uint256 collateralUsdc, uint256 debtUsdc) {
+        return _readCollateralDebt();
+    }
+
+    /// @notice Deploy `amount` of idle strategy USDC into the existing levered position
+    ///         (body of the strategy's `deployIdle`): supply + borrow + increaseLiquidity.
+    function deployIdleImpl(uint256 amount, uint256 minLiquidity) public {
+        Layout storage $ = _layout();
+        if (amount > IERC20($.usdc).balanceOf(address(this))) revert InsufficientIdle();
+        _supplyAmount(amount);
+        (uint256 cbBTCAmt, uint256 wethAmt) = _computeAndBorrow(amount);
+        _wrapAddRestake(cbBTCAmt, wethAmt, minLiquidity);
+        _assertHealthy();
+    }
+
+    /// @notice Compound AERO rewards (body of the strategy's `compound`): claim AERO → swap ALL to
+    ///         USDC via the Aerodrome v2 volatile pool (deepest AERO/USDC on Base, bounded by
+    ///         `minUsdcOut`) → skim up to `skimCap` of the realized USDC for the protocol fee →
+    ///         redeploy the remainder at target leverage via `deployIdleImpl`. No-op when there's no
+    ///         position or no AERO. Fee crystallisation + the external skim transfer live in the
+    ///         strategy entrypoint, NOT here — this only sets aside `pay` so it isn't redeployed.
+    /// @param minUsdcOut   Minimum USDC out of the AERO→USDC swap (slippage guard, on GROSS usdcOut).
+    /// @param minLiquidity Minimum CL liquidity on the redeploy (slippage guard).
+    /// @param skimCap      Max USDC to withhold from redeploy for the protocol fee (owed, or 0).
+    /// @return pay         USDC withheld = `min(skimCap, usdcOut)` (0 when no yield). The strategy
+    ///                     transfers this to the protocol-fee recipient and decrements owed.
+    function compoundImpl(uint256 minUsdcOut, uint256 minLiquidity, uint256 skimCap) public returns (uint256 pay) {
+        Layout storage $ = _layout();
+        uint256 tokenId_ = $.tokenId;
+        if (tokenId_ == 0) return 0; // flat book — nothing staked, nothing to compound
+        if (minUsdcOut == 0) revert ZeroMinOut(); // belt: caller must pass a nonzero floor (see BelowOracleFloor)
+
+        // 1. Claim AERO for the staked NFT. The reward token is read from the gauge
+        //    (definitionally AERO on this pool — fork-confirmed `rewardToken() == AERO`).
+        address gauge_ = $.gauge;
+        address aero = ICLGauge(gauge_).rewardToken();
+        ICLGauge(gauge_).getReward(tokenId_);
+        uint256 aeroBal = IERC20(aero).balanceOf(address(this));
+        if (aeroBal == 0) return 0; // no rewards accrued — clean no-op
+
+        // 2. Derive the on-chain oracle floor from a hardened AERO/USD read (8dp, fail-closed): a
+        //    stale/broken feed reverts the whole compound (defer the harvest, intended posture).
+        //    fair6 = aeroBal(18dp) × price(8dp) / 1e20 → USDC 6dp; floor haircuts by maxSlippageBps.
+        uint256 floor =
+            Math.mulDiv(aeroBal, _readUsd8($.aeroUsdFeed), 1e20) * (10000 - uint256($.maxSlippageBps)) / 10000;
+
+        // 3. Swap ALL claimed AERO → USDC via the Aerodrome v2 volatile pool, passing the caller's
+        //    minUsdcOut to the router. The measured-fill floor below is the robust guard (router-honesty
+        //    independent); the effective bound is max(minUsdcOut, floor), enforced independently.
+        uint256 usdcBefore = IERC20($.usdc).balanceOf(address(this));
+        IERC20(aero).forceApprove(AERO_V2_ROUTER, aeroBal);
+        IAeroRouter.Route[] memory routes = new IAeroRouter.Route[](1);
+        routes[0] = IAeroRouter.Route({from: aero, to: $.usdc, stable: false, factory: AERO_V2_FACTORY});
+        IAeroRouter(AERO_V2_ROUTER)
+            .swapExactTokensForTokens(aeroBal, minUsdcOut, routes, address(this), block.timestamp + 600);
+        uint256 usdcOut = IERC20($.usdc).balanceOf(address(this)) - usdcBefore;
+        if (usdcOut < floor) revert BelowOracleFloor(); // post-check on the measured fill (L9)
+        if (usdcOut == 0) return 0; // unreachable when floor > 0 (aeroBal > 0), kept as defence
+
+        // 4. Withhold up to `skimCap` of the realized yield for the protocol fee (the strategy pays
+        //    it out); redeploy only the remainder.
+        pay = skimCap < usdcOut ? skimCap : usdcOut;
+        uint256 redeploy = usdcOut - pay;
+
+        // 5. Redeploy the net yield into the position at target leverage (supply → borrow →
+        //    increaseLiquidity → restake → _assertHealthy). Any pre-existing idle USDC is left
+        //    untouched — compound deploys the AERO yield, nothing else. Skip if all was skimmed.
+        if (redeploy > 0) deployIdleImpl(redeploy, minLiquidity);
+    }
+
+    /// @notice Recenter the CL position on the current tick WITHOUT swapping (body of the strategy's
+    ///         `rerange`): calm-gate → remove 100% liquidity + collect → new tickSpacing-aligned range
+    ///         → re-add the collected legs → restake → assert health. Debt + collateral untouched.
+    ///
+    ///         No swap → principal conserved; the collected ratio can't match the new range, so a
+    ///         remainder of ONE borrowed leg is left idle (NAV-counted, stays redeployable). A new
+    ///         tokenId is minted (Slipstream ticks are immutable); the old empty NFT is harmless dust.
+    ///         No-op on a flat book.
+    /// @param minLiq0 Minimum token0 (WETH) the re-add must consume (two-sided slippage guard).
+    /// @param minLiq1 Minimum token1 (cbBTC) the re-add must consume (two-sided slippage guard).
+    function rerangeImpl(uint256 minLiq0, uint256 minLiq1) public {
+        Layout storage $ = _layout();
+        if ($.tokenId == 0) return; // flat book — nothing to recenter
+
+        // 1. Calm-gate BEFORE touching the pool — never recenter at a manipulated tick.
+        LeveragedAeroValuation._calmGate(_config());
+
+        // 2. Unstake + remove 100% liquidity + collect (num==den → no restake). The old NFT is
+        //    left empty + unstaked; a recenter needs a fresh range == fresh tokenId.
+        _unwindLiquidity(1, 1);
+
+        // 3. New tickSpacing-aligned range centered on the current (calm) tick.
+        (int24 tickLower, int24 tickUpper) = _computeTickRange();
+
+        // 4. Re-add the collected legs (full balances as desired) into the new range. No swap →
+        //    principal conserved. `_mintPosition` enforces the two-sided `maxSlippageBps` mins
+        //    (the §8 always-on floor) and approves the NPM; the caller's `minLiq0/minLiq1` add an
+        //    explicit two-sided guard on the consumed amounts (proposer-tightenable, like
+        //    compound's `minUsdcOut`).
+        uint256 wethBal = IERC20($.weth).balanceOf(address(this));
+        uint256 cbBal = IERC20($.cbBTC).balanceOf(address(this));
+        (uint256 newTokenId, uint256 used0, uint256 used1) = _mintPosition(wethBal, cbBal, tickLower, tickUpper);
+        if (used0 < minLiq0 || used1 < minLiq1) revert InsufficientLiquidity();
+
+        // 5. Restake the new NFT to resume AERO gauge rewards (mirrors _mintAndStake).
+        _approveAndStake($.gauge, newTokenId);
+
+        // 6. Persist the recentered position (nav()/positions() now read the new NFT).
+        $.tokenId = newTokenId;
+        $.posTickLower = tickLower;
+        $.posTickUpper = tickUpper;
+
+        // 7. Debt + collateral untouched by rerange → health preserved; assert as a belt.
+        _assertHealthy();
+    }
+
+    /// @notice Retarget the position's LTV to `targetLtvBps_` (body of the strategy's `adjustLeverage`;
+    ///         the entrypoint already enforced `targetLtvBps_ ≤ maxLtvBps`). Collateral is untouched,
+    ///         so LTV moves on the debt side: lever UP borrows the cbBTC/WETH delta and adds it
+    ///         (`minLiq`); lever DOWN unwinds the matching CL fraction and repays (per-leg residual
+    ///         rebalanced through USDC, bounded by `minOut`). Ends with `_assertHealthy`.
+    /// @param targetLtvBps_ Target LTV in bps (≤ `maxLtvBps`).
+    /// @param minLiq        Minimum CL liquidity on a lever-UP add (slippage guard).
+    /// @param minOut        Minimum USDC out of a lever-DOWN residual swap (slippage guard).
+    function adjustLeverageImpl(uint16 targetLtvBps_, uint256 minLiq, uint256 minOut) public {
+        (uint256 collateralUsdc, uint256 debtUsdc) = _readCollateralDebt();
+        uint256 targetDebt = (uint256(targetLtvBps_) * collateralUsdc) / 10000;
+        if (targetDebt > debtUsdc) {
+            _leverUp(targetDebt - debtUsdc, minLiq);
+        } else if (debtUsdc > targetDebt) {
+            _leverDown(debtUsdc - targetDebt, debtUsdc, minOut);
+        }
+        _assertHealthy();
+    }
+
+    /// @notice Permissionless safety valve (body of the strategy's `deleverage`): when health falls
+    ///         below `minHealthBps`, anyone may unwind CL liquidity and repay debt to restore the
+    ///         buffer. Health basis mirrors `_assertHealthy` (`collateralUsdc × 1e4 / debtUsdc`, same
+    ///         hardened Chainlink reads); at/above `minHealthBps` or zero debt → `HealthyNoDeleverage`.
+    ///         Repays down to `minHealthBps × (1 + DELEVERAGE_BUFFER_BPS/1e4)` (a recovery op, not the
+    ///         full LTV-≤-max gate): asserts health strictly improved + the shortfall cleared/reduced.
+    ///
+    ///         Oracle-staleness (accepted residual, §13): a stale our-feed reverts (fail-safe —
+    ///         deleveraging at a stale/manipulated price is worse than waiting); Moonwell liquidation
+    ///         uses Moonwell's OWN oracle, so a window where our feed is stale but theirs is fresh is
+    ///         an accepted residual.
+    /// @param minOut Minimum USDC out of any residual rebalancing swap (slippage guard).
+    function deleverageImpl(uint256 minOut) public {
+        Layout storage $ = _layout();
+        (uint256 collateralBefore, uint256 debtBefore) = _readCollateralDebt();
+        if (debtBefore == 0) revert HealthyNoDeleverage(); // no debt ⇒ infinitely healthy
+        uint256 healthBefore = (collateralBefore * 10000) / debtBefore;
+        uint256 minHealth = uint256($.minHealthBps);
+        if (healthBefore >= minHealth) revert HealthyNoDeleverage();
+        (,, uint256 shortfallBefore) = IComptroller($.comptroller).getAccountLiquidity(address(this));
+
+        // Target debt that lands health at minHealthBps + the re-trigger buffer (collateral is
+        // untouched, so health = c / d ⇒ targetDebt = c × 1e4 / targetHealth).
+        uint256 targetHealth = (minHealth * (10000 + uint256(DELEVERAGE_BUFFER_BPS))) / 10000;
+        uint256 targetDebt = (collateralBefore * 10000) / targetHealth;
+        if (debtBefore > targetDebt) _leverDown(debtBefore - targetDebt, debtBefore, minOut);
+
+        // Recovery gate: health strictly improved AND the Moonwell shortfall cleared or reduced.
+        (uint256 collateralAfter, uint256 debtAfter) = _readCollateralDebt();
+        uint256 healthAfter = debtAfter == 0 ? type(uint256).max : (collateralAfter * 10000) / debtAfter;
+        if (healthAfter <= healthBefore) revert UnhealthyPosition(healthAfter, minHealth);
+        (uint256 err,, uint256 shortfallAfter) = IComptroller($.comptroller).getAccountLiquidity(address(this));
+        if (err != 0 || (shortfallAfter != 0 && shortfallAfter >= shortfallBefore)) {
+            revert UnhealthyPosition(healthAfter, minHealth);
+        }
+    }
+
+    // ── Leverage helpers (adjustLeverage / deleverage) ──
+
+    /// @dev Lever UP by `borrowDeltaUsd` (USDC face, 6dp): borrow the cbBTC/WETH delta (50/50) and
+    ///      add it to the existing position. No new collateral — mirrors `deployIdleImpl`'s
+    ///      borrow→wrap→add→restake without the supply step.
+    function _leverUp(uint256 borrowDeltaUsd, uint256 minLiq) private {
+        (uint256 cbBTCAmt, uint256 wethAmt) = _borrowHalfEach(borrowDeltaUsd);
+        _wrapAddRestake(cbBTCAmt, wethAmt, minLiq);
+    }
+
+    /// @dev Lever DOWN by `repayUsd` (USDC face, 6dp) of the current `debtUsd`: unwind the matching
+    ///      fraction `f = repayUsd/debtUsd` of CL liquidity, repay `f` of each debt from the
+    ///      collected legs (oracle-free direct repay), then cover any per-leg IL residual by selling
+    ///      the over-collected sibling leg → USDC (caller `minOut` bounds it) and buying the deficit.
+    ///      Balanced legs (the common case) leave no residual → no swap → `minOut` unused.
+    function _leverDown(uint256 repayUsd, uint256 debtUsd, uint256 minOut) private {
+        Layout storage $ = _layout();
+        _unwindLiquidity(repayUsd, debtUsd);
+        (uint256 cbShort, uint256 wethShort) = _redeemRepayFromCollected(repayUsd, debtUsd, 0, 0);
+        // Two independent `if`s (NOT else-if): a dual-leg IL shortfall covers BOTH legs (L6), mirroring
+        // the redeem path. An `else if` would silently skip the WETH leg when both are short.
+        if (cbShort > 0) {
+            _rebalanceCover($.weth, $.cbBTC, $.mCbBTC, cbShort, minOut);
+        }
+        if (wethShort > 0) {
+            _rebalanceCover($.cbBTC, $.weth, $.mWeth, wethShort, minOut);
+        }
+    }
+
+    /// @dev Cover an IL-driven debt shortfall on `deficitTok` by selling the over-collected
+    ///      `surplusTok` → USDC, then buying exactly the deficit from that USDC and repaying it.
+    ///      Any leftover USDC stays idle (NAV-counted; recoverable via `deployIdle`/`redeem`).
+    ///
+    ///      **Oracle-floor guard** — the minimum USDC out of the surplus-leg sell is enforced as
+    ///      `max(callerMinUsdcOut, oracleFloor)` where
+    ///      `oracleFloor = _tokenToUsdc(surplusBal) × (1 − maxSlippageBps)`.
+    ///      This prevents a griefer from passing `minOut=0` to the permissionless `deleverage()`
+    ///      and sandwiching the IL-residual swap.  If a Chainlink feed is stale the read reverts —
+    ///      fail-safe and consistent with `_assertHealthy`.
+    ///
+    ///      **Redeem path unaffected** — redeem calls `_sweepLegToUsdc` directly with a
+    ///      stayers' `keep > 0`; it never routes through `_rebalanceCover`.
+    function _rebalanceCover(
+        address surplusTok,
+        address deficitTok,
+        address deficitMkt,
+        uint256 shortAmt,
+        uint256 minUsdcOut
+    ) private {
+        Layout storage $ = _layout();
+        uint256 pUsdc = _readUsd8($.usdcFeed); // hoisted: floors the surplus sell AND ceils the deficit buy
+        uint256 surplusBal = IERC20(surplusTok).balanceOf(address(this));
+        if (surplusBal > 0) {
+            bool isCbBTC = surplusTok == $.cbBTC;
+            uint8 dec = isCbBTC ? CBBTC_DECIMALS : WETH_DECIMALS;
+            uint256 pSurplus = _readUsd8(isCbBTC ? $.cbBTCFeed : $.wethFeed);
+            uint256 oracleFloor =
+                _tokenToUsdc(surplusBal, dec, pSurplus, pUsdc) * (10000 - uint256($.maxSlippageBps)) / 10000;
+            if (oracleFloor > minUsdcOut) minUsdcOut = oracleFloor;
+        }
+        _sweepLegToUsdc(surplusTok, 0, minUsdcOut);
+        // Oracle-ceiling the deficit BUY (H1): a sandwiched/manipulated permissionless `deleverage`
+        // can't overpay past the oracle+slippage bound. The redeem path passes max (oracle-free).
+        bool deficitIsCb = deficitTok == $.cbBTC;
+        uint256 pDeficit = _readUsd8(deficitIsCb ? $.cbBTCFeed : $.wethFeed);
+        uint256 buyMax = _tokenToUsdc(shortAmt, deficitIsCb ? CBBTC_DECIMALS : WETH_DECIMALS, pDeficit, pUsdc)
+            * (10000 + uint256($.maxSlippageBps)) / 10000;
+        _redeemCoverShortfall(deficitTok, deficitMkt, shortAmt, buyMax);
+    }
+
+    /// @dev Collateral + debt in USDC face (6dp) on the SAME hardened-Chainlink basis as
+    ///      `_assertHealthy` (the LTV/health basis) — sizes the adjustLeverage / deleverage targets.
+    ///      Returns `debtUsdc == 0` (skipping the price reads) when both borrows are clear.
+    function _readCollateralDebt() private view returns (uint256 collateralUsdc, uint256 debtUsdc) {
+        Layout storage $ = _layout();
+        uint256 cBal = ICToken($.mUsdc).balanceOf(address(this));
+        uint256 rate = ICToken($.mUsdc).exchangeRateStored();
+        collateralUsdc = (cBal * rate) / 1e18;
+        uint256 cbDebt = IMoonwellMarket($.mCbBTC).borrowBalanceStored(address(this));
+        uint256 wethDebt = IMoonwellMarket($.mWeth).borrowBalanceStored(address(this));
+        if (cbDebt == 0 && wethDebt == 0) return (collateralUsdc, 0);
+        (uint256 pBTC, uint256 pETH, uint256 pUsdc) = _readAllPrices();
+        debtUsdc =
+            _tokenToUsdc(cbDebt, CBBTC_DECIMALS, pBTC, pUsdc) + _tokenToUsdc(wethDebt, WETH_DECIMALS, pETH, pUsdc);
+    }
+
+    // ── Moonwell call+check helpers (bytecode offset: 7 repay sites, 3 redeem sites) ──
+
+    /// @dev `market.repayBorrow(amt)` with the uniform error-check. Approve the underlying first.
+    function _repay(address market, uint256 amt) private {
+        uint256 err = IMoonwellMarket(market).repayBorrow(amt);
+        if (err != 0) revert MoonwellRepayFailed(err);
+    }
+
+    /// @dev `mUsdc.redeemUnderlying(amt)` with the uniform error-check.
+    function _redeemUnderlying(address cToken, uint256 amt) private {
+        uint256 err = ICToken(cToken).redeemUnderlying(amt);
+        if (err != 0) revert MoonwellRedeemFailed(err);
+    }
+
+    // ── Execute helpers ──
+
+    /// @dev Supply all strategy USDC to Moonwell and enter the mUSDC market.
+    function _supplyCollateral() private returns (uint256 usdcAmt) {
+        Layout storage $ = _layout();
+        address usdc_ = $.usdc;
+        address mUsdc_ = $.mUsdc;
+        usdcAmt = IERC20(usdc_).balanceOf(address(this));
+        if (usdcAmt == 0) revert ExecuteZeroBalance();
+        IERC20(usdc_).forceApprove(mUsdc_, usdcAmt);
+        uint256 err = ICToken(mUsdc_).mint(usdcAmt);
+        if (err != 0) revert MoonwellMintFailed(err);
+        address[] memory markets = new address[](1);
+        markets[0] = mUsdc_;
+        IComptroller($.comptroller).enterMarkets(markets);
+    }
+
+    /// @dev Borrow against `usdcAmt` of fresh collateral at `targetLtvBps` (execute / deployIdle).
+    ///      The borrow USD = `usdcAmt × targetLtvBps / 1e4`, split 50/50 across cbBTC/WETH.
+    function _computeAndBorrow(uint256 usdcAmt) private returns (uint256 cbBTCAmt, uint256 wethAmt) {
+        return _borrowHalfEach((usdcAmt * uint256(_layout().targetLtvBps)) / 10000);
+    }
+
+    /// @dev Borrow `borrowUsd6` of debt (USDC face, 6dp) split 50/50 by USD across cbBTC + WETH, at
+    ///      hardened-Chainlink prices, and execute both borrows. Used by `_computeAndBorrow` (fresh
+    ///      collateral at target) and by `_leverUp` (a target-LTV debt delta with no new collateral).
+    function _borrowHalfEach(uint256 borrowUsd6) private returns (uint256 cbBTCAmt, uint256 wethAmt) {
+        Layout storage $ = _layout();
+        uint256 pBTC = _readUsd8($.cbBTCFeed);
+        uint256 pETH = _readUsd8($.wethFeed);
+        // halfBorrowUsd8: borrowUsd6 (6dp) → 8dp via ×100, then halve for the per-leg USD value.
+        uint256 halfBorrowUsd8 = (borrowUsd6 * 100) / 2;
+        cbBTCAmt = (halfBorrowUsd8 * 1e8) / pBTC;
+        wethAmt = (halfBorrowUsd8 * 1e18) / pETH;
+        uint256 cbErr = IMoonwellMarket($.mCbBTC).borrow(cbBTCAmt);
+        if (cbErr != 0) revert MoonwellBorrowFailed(cbErr);
+        uint256 wethErr = IMoonwellMarket($.mWeth).borrow(wethAmt);
+        if (wethErr != 0) revert MoonwellBorrowFailed(wethErr);
+    }
+
+    /// @dev Wrap all native ETH held by the strategy into ERC-20 WETH9.
+    function _wrapNativeEth() private {
+        uint256 ethBal = address(this).balance;
+        if (ethBal > 0) {
+            IWETH9(_layout().weth).deposit{value: ethBal}();
+        }
+    }
+
+    /// @dev Compute a tickSpacing-aligned range centred on the current pool tick.
+    function _computeTickRange() private view returns (int24 tickLower, int24 tickUpper) {
+        Layout storage $ = _layout();
+        (, int24 currentTick,,,,) = ICLPool($.pool).slot0();
+        int24 tickSpacing_ = $.tickSpacing;
+        int24 span = int24(uint24(RANGE_TICK_SPACINGS)) * tickSpacing_;
+        tickLower = _alignTick(currentTick - span, tickSpacing_);
+        tickUpper = _alignTick(currentTick + span, tickSpacing_);
+        if (tickUpper <= tickLower) tickUpper = tickLower + tickSpacing_;
+    }
+
+    /// @dev Mint the Slipstream CL position and return its tokenId + the amounts actually
+    ///      consumed. token0 = WETH (18dp), token1 = cbBTC (8dp). Two-sided slippage mins are
+    ///      derived from the expected-actual deposit amounts at the calm-gated sqrtP (the §8
+    ///      always-on floor); `rerange` layers an additional caller-supplied two-sided guard on
+    ///      the returned `used0`/`used1`.
+    function _mintPosition(uint256 wethAmt, uint256 cbBTCAmt, int24 tickLower, int24 tickUpper)
+        private
+        returns (uint256 tokenId_, uint256 used0, uint256 used1)
+    {
+        Layout storage $ = _layout();
+        address npm_ = $.npm;
+        address weth_ = $.weth;
+        address cbBTC_ = $.cbBTC;
+
+        // Compute expected actual deposits at the calm-gated sqrtP.
+        (uint160 sqrtP,,,,,) = ICLPool($.pool).slot0();
+        uint160 sqrtLower = TickMath.getSqrtRatioAtTick(tickLower);
+        uint160 sqrtUpper = TickMath.getSqrtRatioAtTick(tickUpper);
+        uint128 L = LiquidityAmounts.getLiquidityForAmounts(sqrtP, sqrtLower, sqrtUpper, wethAmt, cbBTCAmt);
+        (uint256 exp0, uint256 exp1) = LiquidityAmounts.getAmountsForLiquidity(sqrtP, sqrtLower, sqrtUpper, L);
+        uint256 slip = uint256($.maxSlippageBps);
+        uint256 amt0Min = exp0 * (10000 - slip) / 10000;
+        uint256 amt1Min = exp1 * (10000 - slip) / 10000;
+
+        IERC20(weth_).forceApprove(npm_, wethAmt);
+        IERC20(cbBTC_).forceApprove(npm_, cbBTCAmt);
+        INonfungiblePositionManager.MintParams memory mp = INonfungiblePositionManager.MintParams({
+            token0: weth_,
+            token1: cbBTC_,
+            tickSpacing: $.tickSpacing,
+            tickLower: tickLower,
+            tickUpper: tickUpper,
+            amount0Desired: wethAmt,
+            amount1Desired: cbBTCAmt,
+            amount0Min: amt0Min,
+            amount1Min: amt1Min,
+            recipient: address(this),
+            deadline: block.timestamp + 600,
+            sqrtPriceX96: 0
+        });
+        (tokenId_,, used0, used1) = INonfungiblePositionManager(npm_).mint(mp);
+        if (tokenId_ == 0) revert NpmMintFailed();
+    }
+
+    /// @dev Mint the CL position, stake in gauge, and persist state.
+    function _mintAndStake(uint256 cbBTCAmt, uint256 wethAmt) private {
+        // Calm-gate before reading spot tick / anchoring slippage mins.
+        Layout storage $ = _layout();
+        LeveragedAeroValuation._calmGate(_config());
+        (int24 tickLower, int24 tickUpper) = _computeTickRange();
+        (uint256 tokenId_,,) = _mintPosition(wethAmt, cbBTCAmt, tickLower, tickUpper);
+        _approveAndStake($.gauge, tokenId_);
+        // Persist position state (so nav()/positions() see the live position)
+        $.tokenId = tokenId_;
+        $.posTickLower = tickLower;
+        $.posTickUpper = tickUpper;
+    }
+
+    /// @dev ERC-721 approve `tokenId_` to `gauge_` (low-level `approve(address,uint256)`), then stake
+    ///      it in the gauge. Shared by every mint/restake site (`_mintAndStake`, `rerangeImpl`,
+    ///      `_unwindLiquidity`, `_wrapAddRestake`).
+    function _approveAndStake(address gauge_, uint256 tokenId_) private {
+        (bool ok,) = _layout().npm.call(abi.encodeWithSignature("approve(address,uint256)", gauge_, tokenId_));
+        if (!ok) revert NpmApproveFailed();
+        ICLGauge(gauge_).deposit(tokenId_);
+    }
+
+    /// @dev Align `tick` down to the nearest multiple of `spacing` (handles negatives).
+    function _alignTick(int24 tick, int24 spacing) private pure returns (int24) {
+        int24 rem = tick % spacing;
+        if (rem < 0) rem += spacing;
+        return tick - rem;
+    }
+
+    // ── Settle helpers ──
+
+    /// @dev Unstake NFT, remove num/den fraction of liquidity, collect both tokens.
+    ///      When num==den (full settle), no restake. When num<den (partial redeem),
+    ///      restakes if remaining liq > 0.
+    function _unwindLiquidity(uint256 num, uint256 den) private {
+        Layout storage $ = _layout();
+        uint256 tokenId_ = $.tokenId;
+        if (tokenId_ == 0) return; // flat book — no LP to unwind
+
+        (int24 tickLower, int24 tickUpper, uint128 liq) = _npmPositionData();
+
+        // Unstake so NPM can modify the position
+        address gauge_ = $.gauge;
+        address npm_ = $.npm;
+        ICLGauge(gauge_).withdraw(tokenId_);
+
+        uint128 liqToRemove = (num == den) ? liq : uint128(Math.mulDiv(uint256(liq), num, den));
+
+        if (liqToRemove > 0) {
+            (uint160 sqrtP,,,,,) = ICLPool($.pool).slot0();
+            uint160 sqrtLower = TickMath.getSqrtRatioAtTick(tickLower);
+            uint160 sqrtUpper = TickMath.getSqrtRatioAtTick(tickUpper);
+            (uint256 exp0, uint256 exp1) =
+                LiquidityAmounts.getAmountsForLiquidity(sqrtP, sqrtLower, sqrtUpper, liqToRemove);
+            uint256 slip = uint256($.maxSlippageBps);
+            INonfungiblePositionManager(npm_)
+                .decreaseLiquidity(
+                    INonfungiblePositionManager.DecreaseLiquidityParams({
+                    tokenId: tokenId_,
+                    liquidity: liqToRemove,
+                    amount0Min: exp0 * (10000 - slip) / 10000,
+                    amount1Min: exp1 * (10000 - slip) / 10000,
+                    deadline: block.timestamp + 600
+                })
+                );
+            INonfungiblePositionManager(npm_)
+                .collect(
+                    INonfungiblePositionManager.CollectParams({
+                    tokenId: tokenId_,
+                    recipient: address(this),
+                    amount0Max: type(uint128).max,
+                    amount1Max: type(uint128).max
+                })
+                );
+        }
+
+        // Re-stake only when remaining liquidity is non-zero.
+        (,, uint128 remainingLiq) = _npmPositionData();
+        if (remainingLiq > 0) _approveAndStake(gauge_, tokenId_);
+    }
+
+    /// @dev Repay as much of both Moonwell borrows as current balances allow, then cover
+    ///      any remaining debt via _settleShortfall().
+    function _settleRepayDebts() private {
+        Layout storage $ = _layout();
+        address mCbBTC_ = $.mCbBTC;
+        address mWeth_ = $.mWeth;
+        address cbBTC_ = $.cbBTC;
+        address weth_ = $.weth;
+        uint256 cbDebt = IMoonwellMarket(mCbBTC_).borrowBalanceStored(address(this));
+        uint256 wethDebt = IMoonwellMarket(mWeth_).borrowBalanceStored(address(this));
+        // Repay cbBTC
+        uint256 cbBal = IERC20(cbBTC_).balanceOf(address(this));
+        if (cbBal > 0 && cbDebt > 0) {
+            IERC20(cbBTC_).forceApprove(mCbBTC_, cbBal);
+            _repay(mCbBTC_, cbBal >= cbDebt ? type(uint256).max : cbBal);
+        }
+        // Repay WETH (ERC-20 — no unwrap; mWETH accepts WETH ERC-20 for repay)
+        uint256 wethBal = IERC20(weth_).balanceOf(address(this));
+        if (wethBal > 0 && wethDebt > 0) {
+            IERC20(weth_).forceApprove(mWeth_, wethBal);
+            _repay(mWeth_, wethBal >= wethDebt ? type(uint256).max : wethBal);
+        }
+        // Handle any remaining shortfall (IL or fees ate into LP value)
+        _settleShortfall();
+    }
+
+    /// @dev If any borrow balance remains after the direct repay attempt, redeem USDC from
+    ///      mUSDC collateral and swap to cover it. Chainlink prices + 10% buffer; dust floor.
+    function _settleShortfall() private {
+        Layout storage $ = _layout();
+        uint256 cbDebtRem = IMoonwellMarket($.mCbBTC).borrowBalanceStored(address(this));
+        uint256 wethDebtRem = IMoonwellMarket($.mWeth).borrowBalanceStored(address(this));
+        if (cbDebtRem == 0 && wethDebtRem == 0) return;
+        // Read Chainlink prices (8dp each)
+        (uint256 pBTC, uint256 pETH, uint256 pUsdc) = _readAllPrices();
+        // USDC needed for each shortfall leg (+10% buffer)
+        uint256 cbUsdcNeed = _tokenToUsdc(cbDebtRem, 8, pBTC, pUsdc) * 11000 / 10000;
+        uint256 wethUsdcNeed = _tokenToUsdc(wethDebtRem, 18, pETH, pUsdc) * 11000 / 10000;
+        // Dust floor: nonzero debt but oracle cost rounds to 0 (e.g. 1 wei WETH) → redeem enough
+        // to acquire at least 1 unit of that token.
+        if (cbDebtRem > 0 && cbUsdcNeed == 0) cbUsdcNeed = 1e5;
+        if (wethDebtRem > 0 && wethUsdcNeed == 0) wethUsdcNeed = 1e5;
+        uint256 totalNeed = cbUsdcNeed + wethUsdcNeed;
+        // Redeem USDC collateral to fund the swaps (health elevated after partial repays)
+        if (totalNeed > 0) _redeemUnderlying($.mUsdc, totalNeed);
+        uint256 slip = uint256($.maxSlippageBps);
+        // Cover cbBTC shortfall
+        if (cbDebtRem > 0) {
+            _swapUsdcExactIn($.cbBTC, cbUsdcNeed, cbDebtRem * (10000 - slip) / 10000);
+            uint256 cbBal2 = IERC20($.cbBTC).balanceOf(address(this));
+            if (cbBal2 > 0) {
+                IERC20($.cbBTC).forceApprove($.mCbBTC, cbBal2);
+                _repay($.mCbBTC, type(uint256).max);
+            }
+        }
+        // Cover WETH shortfall (bounded by its own oracle budget, not the full idle balance — M1;
+        // `_swapUsdcExactIn` still caps at the live USDC balance).
+        if (wethDebtRem > 0) {
+            _swapUsdcExactIn($.weth, wethUsdcNeed, wethDebtRem * (10000 - slip) / 10000);
+            uint256 wBal2 = IERC20($.weth).balanceOf(address(this));
+            if (wBal2 > 0) {
+                IERC20($.weth).forceApprove($.mWeth, wBal2);
+                _repay($.mWeth, type(uint256).max);
+            }
+        }
+    }
+
+    /// @dev Swap a fixed USDC amount in for `tokenOut` via Slipstream exactInputSingle.
+    ///      Caps actualIn at the current USDC balance.
+    function _swapUsdcExactIn(address tokenOut, uint256 amountIn, uint256 minAmtOut) private {
+        Layout storage $ = _layout();
+        uint256 usdcBal = IERC20($.usdc).balanceOf(address(this));
+        uint256 actualIn = usdcBal < amountIn ? usdcBal : amountIn;
+        if (actualIn == 0) return;
+        IERC20($.usdc).forceApprove($.swapRouter, actualIn);
+        ICLSwapRouter($.swapRouter)
+            .exactInputSingle(
+                ICLSwapRouter.ExactInputSingleParams({
+                tokenIn: $.usdc,
+                tokenOut: tokenOut,
+                tickSpacing: int24(100),
+                recipient: address(this),
+                deadline: block.timestamp + 600,
+                amountIn: actualIn,
+                amountOutMinimum: minAmtOut,
+                sqrtPriceLimitX96: 0
+            })
+            );
+    }
+
+    /// @dev Sweep the full balance of `tokenIn` to USDC via exactInputSingle (minOut may be 0).
+    function _swapTokenToUsdc(address tokenIn, uint256 minOut) private {
+        _sweepLegToUsdc(tokenIn, 0, minOut);
+    }
+
+    /// @dev Sweep (balance − `keep`) of `tokenIn` → USDC via exactInputSingle. `keep` reserves a
+    ///      stayers' idle-leg share on the redeem path; settle / full-sweep callers pass keep == 0.
+    function _sweepLegToUsdc(address tokenIn, uint256 keep, uint256 minOut) private {
+        Layout storage $ = _layout();
+        uint256 bal = IERC20(tokenIn).balanceOf(address(this));
+        if (bal <= keep) return;
+        uint256 amt = bal - keep;
+        IERC20(tokenIn).forceApprove($.swapRouter, amt);
+        ICLSwapRouter($.swapRouter)
+            .exactInputSingle(
+                ICLSwapRouter.ExactInputSingleParams({
+                tokenIn: tokenIn,
+                tokenOut: $.usdc,
+                tickSpacing: int24(100),
+                recipient: address(this),
+                deadline: block.timestamp + 600,
+                amountIn: amt,
+                amountOutMinimum: minOut,
+                sqrtPriceLimitX96: 0
+            })
+            );
+    }
+
+    /// @dev (1-f) of the strategy's current `token` balance, f = shares/supply. Used by redeem to
+    ///      reserve the stayers' share of a pre-existing idle leg (a rerange remainder) before the
+    ///      residual sweep — keeping the partial-redeem path oracle-free and stayer-fair.
+    function _stayerLeg(address token, uint256 shares, uint256 supply) private view returns (uint256) {
+        uint256 bal = IERC20(token).balanceOf(address(this));
+        return bal - Math.mulDiv(bal, shares, supply);
+    }
+
+    /// @dev Convert `amt` (in `dec`-decimal token units) to USDC (6dp) using Chainlink prices.
+    ///      pToken and pUsdc are both 8dp.
+    function _tokenToUsdc(uint256 amt, uint8 dec, uint256 pToken, uint256 pUsdc) private pure returns (uint256) {
+        return (amt * pToken * 1e6) / ((10 ** uint256(dec)) * pUsdc);
+    }
+
+    /// @dev Hardened USD read that also asserts the feed is 8-decimal (the scaling assumption),
+    ///      mirroring `LeveragedAeroValuation._readUsd8`. The execution-path price reads previously
+    ///      trusted `decimals()` implicitly; consolidating them here closes that gap (L1) — a
+    ///      redeployed feed at a different precision fail-closes instead of mis-scaling the term.
+    function _readUsd8(address feed) private view returns (uint256 price) {
+        Layout storage $ = _layout();
+        (uint256 p, uint8 dec) = ChainlinkReader.readUsd(feed, $.sequencerFeed, $.maxDelay, $.gracePeriod);
+        if (dec != 8) revert FeedDecimalsMismatch();
+        return p;
+    }
+
+    /// @dev The 3-price bundle (cbBTC / WETH / USDC, all 8dp) read on the debt/health/sweep basis.
+    ///      Hoisted so the four debt-sizing sites (settle sweep, _readCollateralDebt, _settleShortfall,
+    ///      _assertHealthy) share one call instead of inlining three `_readUsd8`s each (bytecode offset
+    ///      for the L9 floor).
+    function _readAllPrices() private view returns (uint256 pBTC, uint256 pETH, uint256 pUsdc) {
+        Layout storage $ = _layout();
+        pBTC = _readUsd8($.cbBTCFeed);
+        pETH = _readUsd8($.wethFeed);
+        pUsdc = _readUsd8($.usdcFeed);
+    }
+
+    // ── deployIdle helpers ──
+
+    /// @dev Supply a specific USDC amount to Moonwell mUSDC (no enterMarkets — already entered).
+    function _supplyAmount(uint256 amt) private {
+        Layout storage $ = _layout();
+        IERC20($.usdc).forceApprove($.mUsdc, amt);
+        uint256 err = ICToken($.mUsdc).mint(amt);
+        if (err != 0) revert MoonwellMintFailed(err);
+    }
+
+    /// @dev Add liquidity to the existing tokenId position via NPM.increaseLiquidity.
+    ///      Caller must own the NFT (position unstaked from the gauge).
+    function _addLiquidity(uint256 wethAmt, uint256 cbBTCAmt, uint256 minLiquidity) private {
+        Layout storage $ = _layout();
+        LeveragedAeroValuation._calmGate(_config());
+        uint256 tokenId_ = $.tokenId;
+        address npm_ = $.npm;
+        (uint160 sqrtP,,,,,) = ICLPool($.pool).slot0();
+        uint160 sqrtLower = TickMath.getSqrtRatioAtTick($.posTickLower);
+        uint160 sqrtUpper = TickMath.getSqrtRatioAtTick($.posTickUpper);
+        uint128 L = LiquidityAmounts.getLiquidityForAmounts(sqrtP, sqrtLower, sqrtUpper, wethAmt, cbBTCAmt);
+        (uint256 exp0, uint256 exp1) = LiquidityAmounts.getAmountsForLiquidity(sqrtP, sqrtLower, sqrtUpper, L);
+        uint256 slip = uint256($.maxSlippageBps);
+        IERC20($.weth).forceApprove(npm_, wethAmt);
+        IERC20($.cbBTC).forceApprove(npm_, cbBTCAmt);
+        (uint128 liq,,) = INonfungiblePositionManager(npm_)
+            .increaseLiquidity(
+                INonfungiblePositionManager.IncreaseLiquidityParams({
+                tokenId: tokenId_,
+                amount0Desired: wethAmt,
+                amount1Desired: cbBTCAmt,
+                amount0Min: exp0 * (10000 - slip) / 10000,
+                amount1Min: exp1 * (10000 - slip) / 10000,
+                deadline: block.timestamp + 600
+            })
+            );
+        if (uint256(liq) < minLiquidity) revert InsufficientLiquidity();
+    }
+
+    /// @dev Wrap native ETH from a borrow → WETH, unstake the NFT so the NPM can modify it,
+    ///      `increaseLiquidity` the borrowed legs into the existing position (`minLiquidity`
+    ///      slippage), then restake for AERO rewards. Shared by `deployIdleImpl` and `_leverUp`.
+    function _wrapAddRestake(uint256 cbBTCAmt, uint256 wethAmt, uint256 minLiquidity) private {
+        Layout storage $ = _layout();
+        _wrapNativeEth();
+        uint256 tokenId_ = $.tokenId;
+        address gauge_ = $.gauge;
+        ICLGauge(gauge_).withdraw(tokenId_);
+        _addLiquidity(wethAmt, cbBTCAmt, minLiquidity);
+        _approveAndStake(gauge_, tokenId_);
+    }
+
+    // ── redeem helpers ──
+
+    /// @dev Repay f = shares/supply of each Moonwell borrow from currently-held tokens, capping
+    ///      each leg's repay at the REDEEMER's own budget = `legBal − stayersLeg`. `stayersLeg`
+    ///      is the stayers' reserved `(1-f)` share of a PRE-EXISTING idle leg (a rerange
+    ///      remainder), snapshotted before the unwind. Subtracting it makes the budget exactly
+    ///      `f·idleLeg + collectedLeg` — the redeemer's fair share — so an IL over-repay can never
+    ///      eat the stayers' reserve; the genuine shortfall instead flows to `cbShort`/`wethShort`
+    ///      and is covered from the redeemer's own freed collateral. With `stayersLeg == 0` (full
+    ///      redeem f=1, or no rerange remainder) the cap is the full balance — behaviour unchanged.
+    ///      Returns the shortfall amounts (0 if fully covered).
+    function _redeemRepayFromCollected(uint256 shares, uint256 supply, uint256 stayersCb, uint256 stayersWeth)
+        private
+        returns (uint256 cbShort, uint256 wethShort)
+    {
+        Layout storage $ = _layout();
+        address mCbBTC_ = $.mCbBTC;
+        address mWeth_ = $.mWeth;
+        address cbBTC_ = $.cbBTC;
+        address weth_ = $.weth;
+
+        uint256 cbDebtRepay = Math.mulDiv(IMoonwellMarket(mCbBTC_).borrowBalanceStored(address(this)), shares, supply);
+        uint256 wethDebtRepay = Math.mulDiv(IMoonwellMarket(mWeth_).borrowBalanceStored(address(this)), shares, supply);
+
+        // ── cbBTC leg ── (budget = balance minus the stayers' reserved idle-leg share)
+        if (cbDebtRepay > 0) {
+            uint256 cbBal = IERC20(cbBTC_).balanceOf(address(this));
+            uint256 cbBudget = cbBal > stayersCb ? cbBal - stayersCb : 0;
+            uint256 cbRepay = cbBudget >= cbDebtRepay ? cbDebtRepay : cbBudget;
+            if (cbRepay > 0) {
+                IERC20(cbBTC_).forceApprove(mCbBTC_, cbRepay);
+                _repay(mCbBTC_, cbRepay);
+            }
+            cbShort = cbDebtRepay > cbBudget ? cbDebtRepay - cbBudget : 0;
+        }
+
+        // ── WETH leg ── (budget = balance minus the stayers' reserved idle-leg share)
+        if (wethDebtRepay > 0) {
+            uint256 wethBal = IERC20(weth_).balanceOf(address(this));
+            uint256 wethBudget = wethBal > stayersWeth ? wethBal - stayersWeth : 0;
+            uint256 wethRepay = wethBudget >= wethDebtRepay ? wethDebtRepay : wethBudget;
+            if (wethRepay > 0) {
+                IERC20(weth_).forceApprove(mWeth_, wethRepay);
+                _repay(mWeth_, wethRepay);
+            }
+            wethShort = wethDebtRepay > wethBudget ? wethDebtRepay - wethBudget : 0;
+        }
+    }
+
+    /// @dev Cover a debt shortfall (IL-driven) by swapping idle USDC → `tokenOut` via
+    ///      exactOutputSingle, then repaying the exact remaining amount. `amountInMax` caps the
+    ///      USDC spent: the FULL-redeem path passes `type(uint256).max` (→ bounded only by idle USDC,
+    ///      oracle-free — no stayers exist, Phase 2 `_settleShortfall` handles any residue); the
+    ///      PARTIAL-redeem path passes the redeemer's own budget (`balance − stayersIdle`) so a cover
+    ///      that would dip into stayer idle reverts. The permissionless deleverage path passes an
+    ///      oracle+slippage ceiling so a sandwiched buy reverts instead of overpaying (H1).
+    function _redeemCoverShortfall(address tokenOut, address market, uint256 amountOut, uint256 amountInMax) private {
+        Layout storage $ = _layout();
+        uint256 usdcBal = IERC20($.usdc).balanceOf(address(this));
+        if (usdcBal == 0 || amountOut == 0) return;
+        uint256 maxIn = usdcBal < amountInMax ? usdcBal : amountInMax;
+        IERC20($.usdc).forceApprove($.swapRouter, maxIn);
+        ICLSwapRouter($.swapRouter)
+            .exactOutputSingle(
+                ICLSwapRouter.ExactOutputSingleParams({
+                tokenIn: $.usdc,
+                tokenOut: tokenOut,
+                tickSpacing: int24(100),
+                recipient: address(this),
+                deadline: block.timestamp + 600,
+                amountOut: amountOut,
+                amountInMaximum: maxIn,
+                sqrtPriceLimitX96: 0
+            })
+            );
+        IERC20($.usdc).forceApprove($.swapRouter, 0);
+        uint256 tokenBal = IERC20(tokenOut).balanceOf(address(this));
+        if (tokenBal > 0) {
+            IERC20(tokenOut).forceApprove(market, tokenBal);
+            _repay(market, tokenBal >= amountOut ? amountOut : tokenBal);
+        }
+    }
+
+    /// @dev Redeem f = shares/supply of the mUSDC underlying collateral.
+    function _redeemCollateral(uint256 shares, uint256 supply) private {
+        address mUsdc_ = _layout().mUsdc;
+        uint256 cBal = ICToken(mUsdc_).balanceOf(address(this));
+        if (cBal == 0) return;
+        uint256 rate = ICToken(mUsdc_).exchangeRateStored();
+        uint256 totalUnderlying = (cBal * rate) / 1e18;
+        uint256 toRedeem = Math.mulDiv(totalUnderlying, shares, supply);
+        if (toRedeem == 0) return;
+        _redeemUnderlying(mUsdc_, toRedeem);
+    }
+
+    // ── Shared helpers (health, NPM read, config build) ──
+
+    /// @notice Delegatecall entrypoint that runs `_assertHealthy` in the caller's context.
+    ///         `executeImpl` / `deployIdleImpl` call the private `_assertHealthy` directly;
+    ///         this public wrapper exists so the post-op health invariant can be exercised in
+    ///         isolation (offline `HealthHarness` unit tests).
+    function assertHealthyImpl() public view {
+        _assertHealthy();
+    }
+
+    /// @notice Post-operation LTV + Moonwell-liquidity invariant.
+    ///         Reverts `UnhealthyPosition` if Chainlink-priced LTV exceeds `maxLtvBps` or
+    ///         Moonwell reports a shortfall. Scaling mirrors `LeveragedAeroValuation`.
+    function _assertHealthy() private view {
+        Layout storage $ = _layout();
+        // ── Collateral (USDC face, 6dp) ──
+        address mUsdc_ = $.mUsdc;
+        uint256 cBal = ICToken(mUsdc_).balanceOf(address(this));
+        uint256 rate = ICToken(mUsdc_).exchangeRateStored();
+        uint256 collateralUsd = (cBal * rate) / 1e18;
+
+        // ── Raw borrow balances ──
+        uint256 cbDebt = IMoonwellMarket($.mCbBTC).borrowBalanceStored(address(this));
+        uint256 wethDebt = IMoonwellMarket($.mWeth).borrowBalanceStored(address(this));
+        if (cbDebt == 0 && wethDebt == 0) return; // no debt → trivially healthy (skip oracle)
+
+        // ── Price via hardened Chainlink (same feeds + staleness guards as nav()) ──
+        (uint256 pBTC, uint256 pETH, uint256 pUsdc) = _readAllPrices();
+
+        // ── Debt (USDC face, 6dp) ──
+        uint256 debtUsd =
+            _tokenToUsdc(cbDebt, CBBTC_DECIMALS, pBTC, pUsdc) + _tokenToUsdc(wethDebt, WETH_DECIMALS, pETH, pUsdc);
+        if (debtUsd == 0) return; // dust-level debt rounds to 0 → trivially healthy
+
+        // ── LTV check — binding post-op gate ──
+        uint16 maxLtv = $.maxLtvBps;
+        if (collateralUsd == 0) revert UnhealthyPosition(type(uint256).max, uint256(maxLtv));
+        uint256 ltvBps_ = (debtUsd * 10_000) / collateralUsd;
+        if (ltvBps_ > uint256(maxLtv)) revert UnhealthyPosition(ltvBps_, uint256(maxLtv));
+
+        // ── Moonwell belt: authoritative no-liquidation check ──
+        (uint256 err,, uint256 shortfall) = IComptroller($.comptroller).getAccountLiquidity(address(this));
+        if (err != 0 || shortfall != 0) revert UnhealthyPosition(ltvBps_, uint256(maxLtv));
+    }
+
+    /// @dev Reads only the 3 fields we need from the NPM positions() 12-tuple via a
+    ///      low-level staticcall + assembly (avoids placing all 12 returns on the stack).
+    function _npmPositionData() private view returns (int24 tickLower, int24 tickUpper, uint128 liquidity) {
+        address npm_ = _layout().npm;
+        uint256 tokenId_ = _layout().tokenId;
+        bool ok;
+        bytes memory ret;
+        (ok, ret) = npm_.staticcall(abi.encodeWithSelector(INonfungiblePositionManager.positions.selector, tokenId_));
+        if (!ok) revert InvalidNpmReturn();
+        if (ret.length < 0x120) revert InvalidNpmReturn();
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // ret + 0x20 = start of returndata; field 5 (tickLower) = +0xC0
+            tickLower := mload(add(ret, 0xC0))
+            tickUpper := mload(add(ret, 0xE0))
+            liquidity := mload(add(ret, 0x100))
+        }
+    }
+
+    /// @dev Build the `LeveragedAeroValuation.Config` from stored state (for the calm-gate).
+    function _config() private view returns (LeveragedAeroValuation.Config memory c) {
+        Layout storage $ = _layout();
+        c.usdc = $.usdc;
+        c.vault = address(0); // calm-gate ignores vault; only the strategy's nav() needs the float term
+        c.mUsdc = $.mUsdc;
+        c.cbBTCMarket = $.mCbBTC;
+        c.wethMarket = $.mWeth;
+        c.cbBTC = $.cbBTC;
+        c.weth = $.weth;
+        c.cbBTCDecimals = CBBTC_DECIMALS;
+        c.wethDecimals = WETH_DECIMALS;
+        c.pool = $.pool;
+        c.cbBTCFeed = $.cbBTCFeed;
+        c.wethFeed = $.wethFeed;
+        c.usdcFeed = $.usdcFeed;
+        c.sequencerFeed = $.sequencerFeed;
+        c.maxDelay = $.maxDelay;
+        c.gracePeriod = $.gracePeriod;
+        c.calmDeviationTicks = $.calmDeviationTicks;
+        c.twapWindow = $.twapWindow;
+    }
+}

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -375,8 +375,9 @@ library LeveragedAeroManager {
         IERC20(aero).forceApprove(AERO_V2_ROUTER, aeroBal);
         IAeroRouter.Route[] memory routes = new IAeroRouter.Route[](1);
         routes[0] = IAeroRouter.Route({from: aero, to: $.usdc, stable: false, factory: AERO_V2_FACTORY});
-        IAeroRouter(AERO_V2_ROUTER)
-            .swapExactTokensForTokens(aeroBal, minUsdcOut, routes, address(this), block.timestamp + 600);
+        IAeroRouter(AERO_V2_ROUTER).swapExactTokensForTokens(
+            aeroBal, minUsdcOut, routes, address(this), block.timestamp + 600
+        );
         uint256 usdcOut = IERC20($.usdc).balanceOf(address(this)) - usdcBefore;
         if (usdcOut < floor) revert BelowOracleFloor(); // post-check on the measured fill (L9)
         if (usdcOut == 0) return 0; // unreachable when floor > 0 (aeroBal > 0), kept as defence
@@ -753,25 +754,23 @@ library LeveragedAeroManager {
             (uint256 exp0, uint256 exp1) =
                 LiquidityAmounts.getAmountsForLiquidity(sqrtP, sqrtLower, sqrtUpper, liqToRemove);
             uint256 slip = uint256($.maxSlippageBps);
-            INonfungiblePositionManager(npm_)
-                .decreaseLiquidity(
-                    INonfungiblePositionManager.DecreaseLiquidityParams({
+            INonfungiblePositionManager(npm_).decreaseLiquidity(
+                INonfungiblePositionManager.DecreaseLiquidityParams({
                     tokenId: tokenId_,
                     liquidity: liqToRemove,
                     amount0Min: exp0 * (10000 - slip) / 10000,
                     amount1Min: exp1 * (10000 - slip) / 10000,
                     deadline: block.timestamp + 600
                 })
-                );
-            INonfungiblePositionManager(npm_)
-                .collect(
-                    INonfungiblePositionManager.CollectParams({
+            );
+            INonfungiblePositionManager(npm_).collect(
+                INonfungiblePositionManager.CollectParams({
                     tokenId: tokenId_,
                     recipient: address(this),
                     amount0Max: type(uint128).max,
                     amount1Max: type(uint128).max
                 })
-                );
+            );
         }
 
         // Re-stake only when remaining liquidity is non-zero.
@@ -854,9 +853,8 @@ library LeveragedAeroManager {
         uint256 actualIn = usdcBal < amountIn ? usdcBal : amountIn;
         if (actualIn == 0) return;
         IERC20($.usdc).forceApprove($.swapRouter, actualIn);
-        ICLSwapRouter($.swapRouter)
-            .exactInputSingle(
-                ICLSwapRouter.ExactInputSingleParams({
+        ICLSwapRouter($.swapRouter).exactInputSingle(
+            ICLSwapRouter.ExactInputSingleParams({
                 tokenIn: $.usdc,
                 tokenOut: tokenOut,
                 tickSpacing: int24(100),
@@ -866,7 +864,7 @@ library LeveragedAeroManager {
                 amountOutMinimum: minAmtOut,
                 sqrtPriceLimitX96: 0
             })
-            );
+        );
     }
 
     /// @dev Sweep the full balance of `tokenIn` to USDC via exactInputSingle (minOut may be 0).
@@ -882,9 +880,8 @@ library LeveragedAeroManager {
         if (bal <= keep) return;
         uint256 amt = bal - keep;
         IERC20(tokenIn).forceApprove($.swapRouter, amt);
-        ICLSwapRouter($.swapRouter)
-            .exactInputSingle(
-                ICLSwapRouter.ExactInputSingleParams({
+        ICLSwapRouter($.swapRouter).exactInputSingle(
+            ICLSwapRouter.ExactInputSingleParams({
                 tokenIn: tokenIn,
                 tokenOut: $.usdc,
                 tickSpacing: int24(100),
@@ -894,7 +891,7 @@ library LeveragedAeroManager {
                 amountOutMinimum: minOut,
                 sqrtPriceLimitX96: 0
             })
-            );
+        );
     }
 
     /// @dev (1-f) of the strategy's current `token` balance, f = shares/supply. Used by redeem to
@@ -958,9 +955,8 @@ library LeveragedAeroManager {
         uint256 slip = uint256($.maxSlippageBps);
         IERC20($.weth).forceApprove(npm_, wethAmt);
         IERC20($.cbBTC).forceApprove(npm_, cbBTCAmt);
-        (uint128 liq,,) = INonfungiblePositionManager(npm_)
-            .increaseLiquidity(
-                INonfungiblePositionManager.IncreaseLiquidityParams({
+        (uint128 liq,,) = INonfungiblePositionManager(npm_).increaseLiquidity(
+            INonfungiblePositionManager.IncreaseLiquidityParams({
                 tokenId: tokenId_,
                 amount0Desired: wethAmt,
                 amount1Desired: cbBTCAmt,
@@ -968,7 +964,7 @@ library LeveragedAeroManager {
                 amount1Min: exp1 * (10000 - slip) / 10000,
                 deadline: block.timestamp + 600
             })
-            );
+        );
         if (uint256(liq) < minLiquidity) revert InsufficientLiquidity();
     }
 
@@ -1047,9 +1043,8 @@ library LeveragedAeroManager {
         if (usdcBal == 0 || amountOut == 0) return;
         uint256 maxIn = usdcBal < amountInMax ? usdcBal : amountInMax;
         IERC20($.usdc).forceApprove($.swapRouter, maxIn);
-        ICLSwapRouter($.swapRouter)
-            .exactOutputSingle(
-                ICLSwapRouter.ExactOutputSingleParams({
+        ICLSwapRouter($.swapRouter).exactOutputSingle(
+            ICLSwapRouter.ExactOutputSingleParams({
                 tokenIn: $.usdc,
                 tokenOut: tokenOut,
                 tickSpacing: int24(100),
@@ -1059,7 +1054,7 @@ library LeveragedAeroManager {
                 amountInMaximum: maxIn,
                 sqrtPriceLimitX96: 0
             })
-            );
+        );
         IERC20($.usdc).forceApprove($.swapRouter, 0);
         uint256 tokenBal = IERC20(tokenOut).balanceOf(address(this));
         if (tokenBal > 0) {

--- a/src/leveraged-aero/LeveragedAeroValuation.sol
+++ b/src/leveraged-aero/LeveragedAeroValuation.sol
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import {ICToken} from "./sherwood/interfaces/ICToken.sol";
+import {IMoonwellMarket} from "./sherwood/interfaces/IMoonwellMarket.sol";
+import {ICLPool} from "./sherwood/interfaces/ISlipstream.sol";
+import {ChainlinkReader} from "./sherwood/libraries/ChainlinkReader.sol";
+import {LiquidityAmounts} from "./sherwood/libraries/LiquidityAmounts.sol";
+import {TickMath} from "./sherwood/libraries/TickMath.sol";
+
+/// @title  LeveragedAeroValuation
+/// @notice Net-equity **oracle** NAV for the leveraged Aerodrome CL strategy. This is
+///         the single safety-critical computation — it prices DEPOSITS, so a wrong
+///         sign / decimal / overflow silently mis-mints shares. Everything here is
+///         fail-closed: any oracle staleness, sequencer outage, grace window, or a
+///         spot/TWAP deviation reverts, and a non-positive net equity reverts — a
+///         manipulated price can only *deny* a deposit, never mint cheap shares.
+///
+///         ```
+///         NAV = idleStrategy + collateral + clLegs + idleLegs − debt  (USDC, 6dp)
+///         ```
+///
+///         The strategy prices/redeems against strategy-controlled value only; any vault float
+///         (normally 0 — `execute` sends the vault's USDC to the strategy, so float is reachable
+///         only via a direct donation) is EXCLUDED from NAV and distributed to all shares at
+///         settle. This keeps deposit pricing and redeem consistent: both see the same
+///         strategy-controlled book (M2).
+///
+///         - `idleStrategy`  = `USDC.balanceOf(strategy)`     (face, 6dp)
+///         - `collateral`    = Moonwell USDC supply, `mUSDC.balanceOf(strategy) *
+///                             exchangeRateStored / 1e18`     (face, 6dp; scaling copied
+///                             verbatim from `MoonwellSupplyAdapter`)
+///         - `debt`          = `borrowBalanceStored(cbBTC) * P_cbBTC +
+///                             borrowBalanceStored(WETH) * P_WETH`, each priced via
+///                             Chainlink and converted USD→USDC.
+///         - `clLegs`        = the CL position's token0/token1 amounts at an
+///                             **oracle-implied `sqrtP`** (derived from the two Chainlink
+///                             prices, NOT the manipulable pool tick), each leg priced via
+///                             Chainlink.
+///         - `idleLegs`      = out-of-position cbBTC/WETH held by the strategy (e.g. the
+///                             remainder a no-swap `rerange` recenter leaves), each priced via
+///                             Chainlink on the SAME basis as `debt` — so a borrowed leg is
+///                             never uncounted and a single-position recenter is NAV-neutral.
+///
+///         The CL-leg split uses the oracle sqrtP (the Gamma/Arrakis technique) so the
+///         mint mark cannot be tick-shoved; the same two feeds price the debt, so the
+///         whole net-short book nets on a single Chainlink basis.
+library LeveragedAeroValuation {
+    /// @notice Spot tick deviated from the pool TWAP beyond `calmDeviationTicks`.
+    error CalmGateBreached();
+    /// @notice Net equity is ≤ 0 — minting is fail-closed (no shares at/under water).
+    error NonPositiveEquity();
+    /// @notice The oracle-implied sqrtP fell below the valid pool sqrtP range (`< MIN_SQRT_RATIO`)
+    ///         — fail-closed rather than feed a sub-range price into the leg split. The upper end
+    ///         of the range needs no explicit check: `Math.mulDiv` overflow-reverts before an
+    ///         above-range sqrtP can be produced (see `oracleSqrtPriceX96`).
+    error OracleSqrtPriceOutOfRange();
+    /// @notice A Config value is invalid (e.g. `twapWindow == 0` would divide-by-zero the
+    ///         calm-gate) — fail-closed with a named error instead of an opaque arithmetic panic.
+    error InvalidConfig();
+    /// @notice A Chainlink feed reported decimals != the assumed 8 — fail-closed rather than
+    ///         silently mis-scale the USD→USDC conversion (a redeployed/misconfigured feed).
+    error FeedDecimalsMismatch();
+
+    /// @dev Chainlink USD feeds on Base are 8-decimal; assumed for the USD→USDC scaling.
+    uint256 private constant USD_FEED_DECIMALS = 8;
+
+    /// @notice Everything `netEquityUsdc` needs — no per-call magic numbers. The caller
+    ///         (`strategy.nav()`, a later task) reads `NPM.positions(tokenId)` and passes
+    ///         the ticks + liquidity; this library never touches the NPM.
+    /// @dev `cbBTCFeed`/`wethFeed` are mapped onto the pool's token0/token1 at call time by
+    ///      reading `pool.token0()`/`token1()`, so leg pricing is robust to pool ordering.
+    struct Config {
+        address usdc; // USDC (6dp) — the NAV unit of account
+        address vault; // SyndicateVault (set by the strategy/manager Config builders; NAV excludes vault float — M2)
+        address mUsdc; // Moonwell USDC market (collateral)
+        address cbBTCMarket; // Moonwell cbBTC borrow market
+        address wethMarket; // Moonwell WETH borrow market
+        address cbBTC; // cbBTC underlying token
+        address weth; // WETH underlying token
+        uint8 cbBTCDecimals; // cbBTC decimals (8 on Base)
+        uint8 wethDecimals; // WETH decimals (18)
+        address pool; // Aerodrome Slipstream CL pool (cbBTC/WETH)
+        address cbBTCFeed; // Chainlink BTC/USD feed (8dp)
+        address wethFeed; // Chainlink ETH/USD feed (8dp)
+        address usdcFeed; // Chainlink USDC/USD feed (8dp)
+        address sequencerFeed; // Chainlink L2 sequencer-uptime feed
+        uint256 maxDelay; // per-feed max staleness (seconds)
+        uint256 gracePeriod; // sequencer grace period (seconds)
+        uint16 calmDeviationTicks; // max |spotTick − twapTick| before fail-closed
+        uint32 twapWindow; // calm-gate TWAP lookback (seconds)
+    }
+
+    /// @notice The net-equity oracle NAV of the whole levered book, in USDC (6dp).
+    /// @param c          Valuation config.
+    /// @param strategy   The strategy clone (holds collateral, debt, idle USDC).
+    /// @param tickLower  Lower tick of the CL position (from `NPM.positions`).
+    /// @param tickUpper  Upper tick of the CL position.
+    /// @param liquidity  CL liquidity (from `NPM.positions`); 0 ⇒ no CL legs.
+    /// @return navUsdc   USDC value of `idle + collateral + clLegs + idleLegs − debt` (vault float
+    ///                   excluded — M2 deposit/redeem symmetry; strategy-controlled terms only).
+    /// @dev Fail-closed: reverts on any oracle/calm failure (via `ChainlinkReader` and the
+    ///      calm-gate) and on non-positive equity. Used to price deposits only.
+    function netEquityUsdc(Config memory c, address strategy, int24 tickLower, int24 tickUpper, uint128 liquidity)
+        public
+        view
+        returns (uint256 navUsdc)
+    {
+        // Calm-gate first: if the pool is being shoved, fail closed before pricing anything.
+        _calmGate(c);
+
+        // USDC peg price (8dp) — read once; reused to convert every USD term to USDC face.
+        uint256 pUsdc = _readUsd8(c, c.usdcFeed);
+
+        // --- positive face terms (strategy-controlled only; vault float excluded — M2) ---
+        uint256 assets = IERC20(c.usdc).balanceOf(strategy); // idleStrategy (6dp)
+        assets += _collateralUsdc(c, strategy); // Moonwell USDC collateral (6dp)
+
+        // --- CL legs (oracle-implied sqrtP) ---
+        (uint256 pCbBTC, uint256 pWeth) = _legPrices(c);
+        assets += _clLegsUsdc(c, tickLower, tickUpper, liquidity, pCbBTC, pWeth, pUsdc);
+
+        // --- idle (out-of-position) borrowed legs ---
+        // A no-swap `rerange` recenter leaves a remainder of ONE borrowed leg in the strategy
+        // wallet (the collected token ratio cannot match the new range's required ratio and
+        // swapping is forbidden). Price that remainder on the SAME Chainlink basis as the CL legs
+        // and the debt (fail-closed via `_legPrices`/`_readUsd8`, behind the calm-gate already run
+        // above) so a borrowed token is never uncounted: this makes a single-position recenter
+        // NAV-neutral (the remainder is redeployable and swept on the next exit, not leaked). In
+        // steady state these balances are ~dust (execute/deploy/compound/settle/redeem leave ~0),
+        // and `_usdcValue` returns 0 for a 0 amount, so this is a clean no-op outside a rerange.
+        assets += _usdcValue(IERC20(c.cbBTC).balanceOf(strategy), c.cbBTCDecimals, pCbBTC, pUsdc);
+        assets += _usdcValue(IERC20(c.weth).balanceOf(strategy), c.wethDecimals, pWeth, pUsdc);
+
+        // --- debt (same Chainlink basis) ---
+        uint256 debt = _debtUsdc(c, strategy, pCbBTC, pWeth, pUsdc);
+
+        if (assets <= debt) revert NonPositiveEquity();
+        navUsdc = assets - debt;
+    }
+
+    /// @notice Oracle-implied `sqrtPriceX96` from two USD prices + token decimals — the
+    ///         absolute mark used to split the CL position (NOT the manipulable pool tick).
+    /// @param p0 USD price of token0 (feed answer, any decimals — they cancel against p1).
+    /// @param d0 token0 decimals.
+    /// @param p1 USD price of token1.
+    /// @param d1 token1 decimals.
+    /// @return sqrtPriceX96 `sqrt(rawPrice1per0) * 2^96`, where the raw (smallest-unit) price
+    ///         `token1/token0 = p0 * 10^d1 / (p1 * 10^d0)`.
+    /// @dev Overflow / range (fail-closed): `Math.mulDiv` carries the 512-bit
+    ///      `p0*10^d1 * 2^192` intermediate. Only ONE bound is load-bearing — the LOW one —
+    ///      because the HIGH bound is unreachable by construction (a wrong sqrtP would let
+    ///      `getAmountsForLiquidity`, which is itself unbounded, mis-split the legs — a fail-OPEN
+    ///      mis-mint, so the reachable bound must still fail closed):
+    ///        - HIGH bound is UNREACHABLE, so there is no high-side guard: `Math.mulDiv(num, 2^192,
+    ///          den)` itself reverts (panic 0x11) once `raw = num/den ≳ 2^64`, since `raw * 2^192`
+    ///          then exceeds `type(uint256).max`. The largest representable `ratioX192 ≈ 2^256`
+    ///          therefore yields `s = sqrt(ratioX192) ≤ 2^128`, far below `MAX_SQRT_RATIO (~2^160)`
+    ///          — `s >= MAX_SQRT_RATIO` can never hold, so a high-side check would be dead code.
+    ///        - LOW bound is LOAD-BEARING: a tiny-but-nonzero `raw` yields a small `sqrt(ratioX192)`
+    ///          that is `< MIN_SQRT_RATIO` yet nonzero — `uint160(...)` does NOT truncate it,
+    ///          so without the explicit check below it would slip through as a valid-looking
+    ///          out-of-range price. The bound catches it.
+    ///      For all real cbBTC/WETH 8dp prices the result lands well inside the range; this
+    ///      guard only fires for the degenerate/hostile decimal+price combinations a generic
+    ///      caller could pass.
+    function oracleSqrtPriceX96(uint256 p0, uint8 d0, uint256 p1, uint8 d1)
+        internal
+        pure
+        returns (uint160 sqrtPriceX96)
+    {
+        uint256 num = p0 * (10 ** uint256(d1));
+        uint256 den = p1 * (10 ** uint256(d0));
+        uint256 ratioX192 = Math.mulDiv(num, 1 << 192, den);
+        uint256 s = Math.sqrt(ratioX192);
+        // LOW-bound guard only — the HIGH bound is unreachable (mulDiv overflow-reverts first; see
+        // @dev). Revert rather than pass a nonzero sub-range price that `uint160(...)` won't truncate.
+        if (s < TickMath.MIN_SQRT_RATIO) revert OracleSqrtPriceOutOfRange();
+        sqrtPriceX96 = uint160(s);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Internal terms
+    // ---------------------------------------------------------------------------
+
+    /// @dev Moonwell USDC collateral in USDC face (6dp). Scaling copied verbatim from
+    ///      `MoonwellSupplyAdapter.value`: `underlying = cBal * exchangeRateStored / 1e18`.
+    ///      `exchangeRateStored` (last-accrued, view) is used — never the mutating
+    ///      `balanceOfUnderlying`. USDC is the unit, so the result is already face-valued.
+    function _collateralUsdc(Config memory c, address strategy) private view returns (uint256) {
+        uint256 cBal = ICToken(c.mUsdc).balanceOf(strategy);
+        if (cBal == 0) return 0;
+        uint256 rate = ICToken(c.mUsdc).exchangeRateStored();
+        return (cBal * rate) / 1e18;
+    }
+
+    /// @dev cbBTC + WETH debt at the same Chainlink basis, converted to USDC face.
+    ///      Both this term (`borrowBalanceStored`) and the collateral (`exchangeRateStored`) use
+    ///      Moonwell's LAST-ACCRUED, view-safe values — `nav()` is `view` and cannot
+    ///      `accrueInterest`. The inter-accrual staleness is bounded (bps over hours) and
+    ///      conservative-leaning: if the supply market is more current than the borrow markets,
+    ///      debt is the staler/lower term → NAV slightly OVER-stated → a deposit mints FEWER
+    ///      shares (depositor over-pays), which PROTECTS stayers rather than diluting them. A
+    ///      consumer wanting exactness can `accrueInterest` all three markets before a deposit
+    ///      (off the view path).
+    function _debtUsdc(Config memory c, address strategy, uint256 pCbBTC, uint256 pWeth, uint256 pUsdc)
+        private
+        view
+        returns (uint256 debt)
+    {
+        uint256 cbDebt = IMoonwellMarket(c.cbBTCMarket).borrowBalanceStored(strategy);
+        uint256 wethDebt = IMoonwellMarket(c.wethMarket).borrowBalanceStored(strategy);
+        debt = _usdcValue(cbDebt, c.cbBTCDecimals, pCbBTC, pUsdc);
+        debt += _usdcValue(wethDebt, c.wethDecimals, pWeth, pUsdc);
+    }
+
+    /// @dev Prices the CL position's two legs at the oracle-implied `sqrtP` and converts to
+    ///      USDC face. token0/token1 are mapped to (cbBTC, WETH) prices by reading the pool
+    ///      ordering, so this is robust regardless of which token sorts lower.
+    function _clLegsUsdc(
+        Config memory c,
+        int24 tickLower,
+        int24 tickUpper,
+        uint128 liquidity,
+        uint256 pCbBTC,
+        uint256 pWeth,
+        uint256 pUsdc
+    ) private view returns (uint256 legsUsdc) {
+        if (liquidity == 0) return 0;
+
+        address t0 = ICLPool(c.pool).token0();
+        // Map (price, decimals) to the pool's token0/token1 ordering.
+        (uint256 p0, uint8 d0, uint256 p1, uint8 d1) = (t0 == c.cbBTC)
+            ? (pCbBTC, c.cbBTCDecimals, pWeth, c.wethDecimals)
+            : (pWeth, c.wethDecimals, pCbBTC, c.cbBTCDecimals);
+
+        uint160 sqrtP = oracleSqrtPriceX96(p0, d0, p1, d1);
+        (uint256 amt0, uint256 amt1) = LiquidityAmounts.getAmountsForLiquidity(
+            sqrtP, TickMath.getSqrtRatioAtTick(tickLower), TickMath.getSqrtRatioAtTick(tickUpper), liquidity
+        );
+
+        legsUsdc = _usdcValue(amt0, d0, p0, pUsdc);
+        legsUsdc += _usdcValue(amt1, d1, p1, pUsdc);
+    }
+
+    /// @dev Hardened USD read that also asserts the feed is 8-decimal (the scaling assumption,
+    ///      §5). `readUsd` already fetches `feed.decimals()`, so validating it costs no extra call;
+    ///      a redeployed feed at a different precision fail-closes with `FeedDecimalsMismatch`
+    ///      instead of silently inflating the term by 10^(d-8).
+    function _readUsd8(Config memory c, address feed) private view returns (uint256 price) {
+        uint8 dec;
+        (price, dec) = ChainlinkReader.readUsd(feed, c.sequencerFeed, c.maxDelay, c.gracePeriod);
+        if (dec != USD_FEED_DECIMALS) revert FeedDecimalsMismatch();
+    }
+
+    /// @dev Reads cbBTC + WETH USD prices through the hardened reader (fail-closed).
+    function _legPrices(Config memory c) private view returns (uint256 pCbBTC, uint256 pWeth) {
+        pCbBTC = _readUsd8(c, c.cbBTCFeed);
+        pWeth = _readUsd8(c, c.wethFeed);
+    }
+
+    /// @dev Converts a token `amount` (in `tokenDecimals`) at USD price `pToken` (8dp feed)
+    ///      to USDC face (6dp), honoring the USDC peg via the USDC/USD feed `pUsdc` (8dp).
+    ///
+    ///        usdValue (8dp) = amount * pToken / 10^tokenDecimals
+    ///        usdcFace (6dp) = usdValue * 10^6 / pUsdc          (USD-1e8 / USDC-price-1e8)
+    ///
+    ///      Both feeds are 8-decimal, so the 1e8 scales cancel; `pUsdc ≈ 1e8` for a healthy
+    ///      peg. `Math.mulDiv` carries the intermediate so there is no precision loss / overflow
+    ///      for realistic amounts.
+    function _usdcValue(uint256 amount, uint8 tokenDecimals, uint256 pToken, uint256 pUsdc)
+        private
+        pure
+        returns (uint256)
+    {
+        if (amount == 0) return 0;
+        // usdValue at the feed's 8dp: amount * pToken / 10^tokenDecimals
+        uint256 usdValue = Math.mulDiv(amount, pToken, 10 ** uint256(tokenDecimals));
+        // → USDC face (6dp): divide by the USDC price (8dp) and rescale 1e8 → 1e6.
+        return Math.mulDiv(usdValue, 1e6, pUsdc);
+    }
+
+    /// @dev Spot-vs-TWAP calm-gate (fail-closed). Reverts `CalmGateBreached` when the pool
+    ///      spot tick deviates from the `twapWindow` arithmetic-mean tick beyond
+    ///      `calmDeviationTicks`. Pattern: `AerodromeLPAdapter` deviation gate; mechanism:
+    ///      Mamo `LPAutoBalancerV2.reset()` calm-gate.
+    ///
+    ///      Visibility is `public` so `LeveragedAerodromeCLStrategy` can call it before
+    ///      minting to guard tick-band placement and slippage-min computation (delegatecall
+    ///      via the deployed library).
+    ///      Logic is unchanged — do NOT edit this function without also updating the
+    ///      strategy's `_mintAndStake` caller.
+    function _calmGate(Config memory c) public view {
+        if (c.twapWindow == 0) revert InvalidConfig();
+        (, int24 spotTick,,,,) = ICLPool(c.pool).slot0();
+
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0] = c.twapWindow;
+        secondsAgos[1] = 0;
+        (int56[] memory cum,) = ICLPool(c.pool).observe(secondsAgos);
+
+        int56 delta = cum[1] - cum[0];
+        int24 twapTick = int24(delta / int56(uint56(c.twapWindow)));
+        // Round toward negative infinity (Uniswap convention) when the cumulative delta is
+        // negative and does not divide evenly, so the mean matches the TWAP oracle.
+        if (delta < 0 && (delta % int56(uint56(c.twapWindow)) != 0)) twapTick--;
+
+        int24 diff = spotTick > twapTick ? spotTick - twapTick : twapTick - spotTick;
+        if (uint24(diff) > c.calmDeviationTicks) revert CalmGateBreached();
+    }
+}

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -1,0 +1,1122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+
+import {LeveragedAeroFees} from "./LeveragedAeroFees.sol";
+import {LeveragedAeroManager} from "./LeveragedAeroManager.sol";
+import {LeveragedAeroValuation} from "./LeveragedAeroValuation.sol";
+import {BaseStrategy} from "./sherwood/BaseStrategy.sol";
+import {FeeConstants} from "./sherwood/FeeConstants.sol";
+import {IAggregatorV3} from "./sherwood/interfaces/IAggregatorV3.sol";
+import {Position} from "./sherwood/interfaces/IPriceRouter.sol";
+import {IProtocolConfig} from "./sherwood/interfaces/IProtocolConfig.sol";
+import {ICLGauge, INonfungiblePositionManager} from "./sherwood/interfaces/ISlipstream.sol";
+import {IStrategy} from "./sherwood/interfaces/IStrategy.sol";
+import {ISyndicateFactory} from "./sherwood/interfaces/ISyndicateFactory.sol";
+import {ISyndicateVault} from "./sherwood/interfaces/ISyndicateVault.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+/// @title LeveragedAerodromeCLStrategy
+/// @notice Net-short leveraged Aerodrome CL strategy: USDC collateral → Moonwell (mUSDC)
+///         → borrow cbBTC + WETH → Slipstream CL position → AERO gauge.
+///
+///         ERC-1167 clone, one per proposal (BaseStrategy's constructor locks the template).
+///         NAV is oracle-priced via `LeveragedAeroValuation.netEquityUsdc`, fail-closed.
+///         `ReentrancyGuardTransient` guards every state-changing external op.
+contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient, ERC721Holder {
+    using SafeERC20 for IERC20;
+
+    // ── Errors ──
+    error NotImplemented();
+    error TargetLtvExceedsMax();
+    error MinHealthTooLow(); // minHealthBps < 10500 (1.05x floor)
+    error FeeRecipientRequired();
+    error MaxLtvExceedsCF(); // maxLtvBps >= Moonwell USDC collateral factor
+    error ComptrollerCallFailed();
+    error UnhealthyPosition(uint256 ltvBps, uint256 limitBps);
+    error InvalidNpmReturn();
+    error ExecuteZeroBalance();
+    error MoonwellMintFailed(uint256 errCode);
+    error MoonwellBorrowFailed(uint256 errCode);
+    error NpmMintFailed();
+    error NpmApproveFailed();
+    error MoonwellRepayFailed(uint256 errCode);
+    error MoonwellRedeemFailed(uint256 errCode);
+    error InsufficientShares();
+    error NavUnpriceable(); // deposit while nav()==0 with supply>0 (worthless book, holders present)
+    error InsufficientAssetsOut();
+    error InsufficientLiquidity();
+    error InsufficientIdle();
+    error HealthyNoDeleverage();
+    error CannotRescuePositionToken();
+    error NotProposerOrOwner();
+    error OnlySelf();
+    error PerformanceFeeTooHigh();
+    error ManagementFeeTooHigh();
+    error MinHealthMaxLtvConflict();
+    error AssetMismatch();
+    error UnexpectedAssetDecimals();
+    error UnexpectedFeedDecimals(); // AERO/USD aggregator not 8dp (L9 oracle-floor scaling assumption)
+    error OracleParamOutOfRange();
+    error FastRedeemExceedsLtv(uint256 ltvBps, uint256 maxLtvBps); // fast-path breaches maxLtvBps → use requestRedeem
+    error NotRequestOwner();
+    error RequestSettled();
+    error FulfillWindowOpen(); // emergencyRedeem before FULFILL_WINDOW elapsed
+    error ZeroAssetsOut(); // fast redeem would pay 0 (navNet==0 or dust shares floor to 0) — burn-for-zero
+
+    // ── Constants ──
+    uint8 private constant CBBTC_DECIMALS = 8; // cbBTC is 8dp wrapped Bitcoin
+    uint8 private constant WETH_DECIMALS = 18; // WETH9 on Base is 18dp
+
+    /// @dev Position `kind` tag for the PriceRouter adapter registry.
+    bytes32 public constant POSITION_KIND = keccak256("LEVERAGED_AERO_CL");
+
+    /// @dev ERC-4626 virtual share offset matching the vault's `_decimalsOffset()` (USDC 6dp → 1e6).
+    uint256 private constant SHARES_VIRTUAL_OFFSET = 1e6;
+
+    /// @dev Annual management-fee ceiling (bps); mirrors `SyndicateFactory.MAX_MANAGEMENT_FEE_BPS` (5%/yr).
+    uint16 private constant MAX_MANAGEMENT_FEE_BPS = 500;
+
+    /// @dev Deadman window: after this elapses on an unfulfilled `requestRedeem`, its owner can
+    ///      `emergencyRedeem` trustlessly (oracle-free). The backend fulfills in minutes; 2 days
+    ///      tolerates a weekend outage while keeping the trustless exit reachable.
+    uint256 private constant FULFILL_WINDOW = 2 days;
+
+    // ── Async-redeem queue events ──
+    event RedeemRequested(uint256 indexed id, address indexed owner, uint256 shares);
+    event RedeemFulfilled(uint256 indexed id, address indexed owner, uint256 assetsOut);
+    event RedeemCancelled(uint256 indexed id, address indexed owner, uint256 shares);
+    event RedeemEmergency(uint256 indexed id, address indexed owner, uint256 assetsOut);
+
+    /// @dev A best-effort fee crystallise (deposit / fast redeem / proportional redeem) reverted and was
+    ///      deferred; the op proceeded. Reverts on the fee-MINT (vault paused / feeRecipient
+    ///      de-whitelisted) — or, near-unreachably, on the config read inside the crystallise (see the
+    ///      per-op docstrings). `op` (see `OP_*`) tells a monitor which entrypoint deferred; `navPre` is
+    ///      the NAV at risk (0 on an oracle-out proportional redeem).
+    event FeeCrystallizeDeferred(uint8 op, uint256 navPre);
+
+    // ── `FeeCrystallizeDeferred.op` codes ──
+    uint8 private constant OP_DEPOSIT = 0;
+    uint8 private constant OP_REDEEM = 1; // fast redeem
+    uint8 private constant OP_FULFILL = 2; // proportional redeem (fulfill / emergency)
+
+    // ── Initialisation params (ABI-encoded → BaseStrategy.initialize → _initialize) ──
+
+    struct InitParams {
+        // ── Token addresses ──
+        address usdc; // USDC (6dp) — unit of account + collateral asset
+        address mUsdc; // Moonwell mUSDC market (collateral)
+        address mCbBTC; // Moonwell mcbBTC market (borrow leg)
+        address mWeth; // Moonwell mWETH market (borrow leg)
+        address comptroller; // Moonwell Comptroller (enterMarkets / markets())
+        address cbBTC; // cbBTC underlying (8dp)
+        address weth; // WETH9 underlying (18dp)
+        // ── Venue addresses ──
+        address pool; // Aerodrome Slipstream CL pool (cbBTC/WETH tickSpacing=100)
+        address npm; // Slipstream Non-Fungible Position Manager
+        address gauge; // Gauge for the pool (AERO rewards)
+        address swapRouter; // Slipstream CL Swap Router
+        // ── Chainlink feeds ──
+        address cbBTCFeed; // BTC/USD aggregator (8dp)
+        address wethFeed; // ETH/USD aggregator (8dp)
+        address usdcFeed; // USDC/USD aggregator (8dp)
+        address sequencerFeed; // L2 Sequencer Uptime feed (Base)
+        address aeroUsdFeed; // AERO/USD aggregator (8dp) — floors the compound reward swap (L9)
+        // ── Oracle config ──
+        uint256 maxDelay; // Max feed staleness (seconds)
+        uint256 gracePeriod; // Sequencer grace period after restart (seconds)
+        uint16 calmDeviationTicks; // Max |spotTick − twapTick| before calm-gate fires
+        uint32 twapWindow; // TWAP lookback for the calm-gate (seconds)
+        // ── Pool config ──
+        int24 tickSpacing; // Slipstream pool tickSpacing (100 for primary pool)
+        // ── Risk params ──
+        uint16 targetLtvBps; // Target LTV in bps (e.g. 5000 = 50%)
+        uint16 maxLtvBps; // Maximum LTV cap in bps (e.g. 6500 = 65%)
+        uint16 minHealthBps; // Minimum health ratio in bps (e.g. 12000 = 1.20×)
+        uint16 maxSlippageBps; // Maximum slippage tolerance for swaps in bps
+        // ── Fee params ──
+        uint16 managementFeeBps; // Annual management fee in bps (e.g. 100 = 1%/yr)
+        uint16 performanceFeeBps; // HWM performance fee in bps (e.g. 1000 = 10%)
+        address feeRecipient; // Address that receives fee-shares (must be non-zero if any fee > 0)
+    }
+
+    // ── ERC-7201 namespaced (diamond) storage ──
+    //
+    // All strategy-specific state lives in one `Layout` struct at a fixed ERC-7201 slot, NOT in
+    // sequential storage (which holds only BaseStrategy's state). This lets the venue ops run from
+    // the deployed `LeveragedAeroManager` library via delegatecall.
+    //
+    // CORRUPTION-CRITICAL: `Layout`, `STORAGE_SLOT`, `_layout()`, and `RedeemRequest` are
+    // byte-identical in `LeveragedAeroManager` — they MUST stay in lockstep or a delegatecall
+    // reads/writes the wrong slots. Do not reorder `Layout` fields in one file without the other.
+
+    /// @dev Escrowed async-redeem request (Lane-B-style, but NO price freeze — shares keep bearing
+    ///      PnL until execution, so `cancelRedeem` is not a free look-back option). Byte-identical
+    ///      to the manager's `RedeemRequest`.
+    struct RedeemRequest {
+        address owner; // request creator; the only address that can cancel / emergency-redeem it
+        uint256 shares; // vault shares escrowed in the strategy at request time
+        uint256 minAssetsOut; // slippage floor enforced at fulfill (fresh arg at emergencyRedeem)
+        uint40 requestedAt; // request timestamp; FULFILL_WINDOW deadman clock anchor
+        bool settled; // set once fulfilled / cancelled / emergency-redeemed (double-spend guard)
+    }
+
+    /// @custom:storage-location erc7201:leveraged.aero.cl.storage
+    struct Layout {
+        // valuation config: token / venue / feed addresses
+        address usdc;
+        address mUsdc;
+        address mCbBTC; // LeveragedAeroValuation.Config.cbBTCMarket
+        address mWeth; // LeveragedAeroValuation.Config.wethMarket
+        address cbBTC;
+        address weth;
+        address pool;
+        address cbBTCFeed;
+        address wethFeed;
+        address usdcFeed;
+        address sequencerFeed;
+        uint256 maxDelay;
+        uint256 gracePeriod;
+        uint16 calmDeviationTicks;
+        uint32 twapWindow;
+        // venue / protocol addresses (not in Config)
+        address comptroller;
+        address npm;
+        address gauge;
+        address swapRouter;
+        int24 tickSpacing;
+        // risk params
+        uint16 targetLtvBps;
+        uint16 maxLtvBps;
+        uint16 minHealthBps;
+        uint16 maxSlippageBps;
+        uint16 usdcCollateralFactorBps; // USDC collateral factor from Moonwell at init (8800 = 88%)
+        // position state (all zero pre-deploy / post-settle)
+        uint256 tokenId; // active CL position; 0 == flat book
+        int24 posTickLower;
+        int24 posTickUpper;
+        // fee params + state
+        uint16 managementFeeBps;
+        uint16 performanceFeeBps;
+        address feeRecipient;
+        uint256 hwmPerShare; // HWM nav-per-share (1e18 WAD), 0 until first deposit
+        uint256 lastFeeAccrualTimestamp;
+        uint256 protocolFeeOwed; // accrued protocol-fee USDC liability (6dp); discharged in redeem/compound/settle
+        // ── appended for the L9 compound oracle floor (keep byte-identical in the manager) ──
+        address aeroUsdFeed; // AERO/USD aggregator (8dp) — floors compound()'s AERO→USDC swap
+        // ── LAST fields: appended for the escrowed async-redeem queue (keep byte-identical) ──
+        uint256 nextRedeemRequestId; // monotonic id cursor for `redeemRequests`
+        mapping(uint256 => RedeemRequest) redeemRequests; // id → escrowed async redeem
+    }
+
+    /// @dev keccak256(abi.encode(uint256(keccak256("leveraged.aero.cl.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant STORAGE_SLOT = 0x405ae0b144079093e970849fdffdcb2a514e44968598c6c5c73444496e844900;
+
+    /// @dev ERC-7201 diamond-storage accessor (byte-identical across strategy + manager).
+    function _layout() private pure returns (Layout storage $) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            $.slot := STORAGE_SLOT
+        }
+    }
+
+    /// @dev Memory-returnable mirror of `Layout` minus the trailing `redeemRequests` mapping
+    ///      (a struct with a nested mapping can't be an external return). Field names match
+    ///      `Layout` 1:1 so `layout().field` accessors are unchanged.
+    struct LayoutView {
+        address usdc;
+        address mUsdc;
+        address mCbBTC;
+        address mWeth;
+        address cbBTC;
+        address weth;
+        address pool;
+        address cbBTCFeed;
+        address wethFeed;
+        address usdcFeed;
+        address sequencerFeed;
+        uint256 maxDelay;
+        uint256 gracePeriod;
+        uint16 calmDeviationTicks;
+        uint32 twapWindow;
+        address comptroller;
+        address npm;
+        address gauge;
+        address swapRouter;
+        int24 tickSpacing;
+        uint16 targetLtvBps;
+        uint16 maxLtvBps;
+        uint16 minHealthBps;
+        uint16 maxSlippageBps;
+        uint16 usdcCollateralFactorBps;
+        uint256 tokenId;
+        int24 posTickLower;
+        int24 posTickUpper;
+        uint16 managementFeeBps;
+        uint16 performanceFeeBps;
+        address feeRecipient;
+        uint256 hwmPerShare;
+        uint256 lastFeeAccrualTimestamp;
+        uint256 protocolFeeOwed;
+        address aeroUsdFeed;
+        uint256 nextRedeemRequestId;
+    }
+
+    /// @notice Full strategy storage layout (single accessor for tests / off-chain reads), minus the
+    ///         `redeemRequests` mapping (queried via `redeemRequest(id)`). Field-by-field (not a
+    ///         struct-literal) so the Yul IR emits one sload→mstore per field — avoids the
+    ///         >16-live-variable overflow a struct-literal trips under via_ir.
+    function layout() external view returns (LayoutView memory v) {
+        Layout storage $ = _layout();
+        v.usdc = $.usdc;
+        v.mUsdc = $.mUsdc;
+        v.mCbBTC = $.mCbBTC;
+        v.mWeth = $.mWeth;
+        v.cbBTC = $.cbBTC;
+        v.weth = $.weth;
+        v.pool = $.pool;
+        v.cbBTCFeed = $.cbBTCFeed;
+        v.wethFeed = $.wethFeed;
+        v.usdcFeed = $.usdcFeed;
+        v.sequencerFeed = $.sequencerFeed;
+        v.maxDelay = $.maxDelay;
+        v.gracePeriod = $.gracePeriod;
+        v.calmDeviationTicks = $.calmDeviationTicks;
+        v.twapWindow = $.twapWindow;
+        v.comptroller = $.comptroller;
+        v.npm = $.npm;
+        v.gauge = $.gauge;
+        v.swapRouter = $.swapRouter;
+        v.tickSpacing = $.tickSpacing;
+        v.targetLtvBps = $.targetLtvBps;
+        v.maxLtvBps = $.maxLtvBps;
+        v.minHealthBps = $.minHealthBps;
+        v.maxSlippageBps = $.maxSlippageBps;
+        v.usdcCollateralFactorBps = $.usdcCollateralFactorBps;
+        v.tokenId = $.tokenId;
+        v.posTickLower = $.posTickLower;
+        v.posTickUpper = $.posTickUpper;
+        v.managementFeeBps = $.managementFeeBps;
+        v.performanceFeeBps = $.performanceFeeBps;
+        v.feeRecipient = $.feeRecipient;
+        v.hwmPerShare = $.hwmPerShare;
+        v.lastFeeAccrualTimestamp = $.lastFeeAccrualTimestamp;
+        v.protocolFeeOwed = $.protocolFeeOwed;
+        v.aeroUsdFeed = $.aeroUsdFeed;
+        v.nextRedeemRequestId = $.nextRedeemRequestId;
+    }
+
+    /// @notice A single escrowed async-redeem request by id (queue introspection for tests / UI).
+    function redeemRequest(uint256 id) external view returns (RedeemRequest memory) {
+        return _layout().redeemRequests[id];
+    }
+
+    /// @dev Moonwell's mWETH market delivers native ETH on `borrow()`; the strategy wraps it to
+    ///      WETH9 before use. Without this receiver the borrow's ETH transfer reverts.
+    receive() external payable {}
+
+    /// @inheritdoc IStrategy
+    function name() external pure returns (string memory) {
+        return "Leveraged Aerodrome CL";
+    }
+
+    // ── Initialization ──
+
+    /// @notice Validate `InitParams`, read the USDC collateral factor from Moonwell, and persist
+    ///         everything to diamond storage. Validation order matches the per-field checks below
+    ///         so the same input reverts with the same error.
+    function _initialize(bytes calldata data) internal override {
+        InitParams memory p = abi.decode(data, (InitParams));
+
+        if (p.usdc == address(0)) revert ZeroAddress();
+        if (p.mUsdc == address(0)) revert ZeroAddress();
+        if (p.mCbBTC == address(0)) revert ZeroAddress();
+        if (p.mWeth == address(0)) revert ZeroAddress();
+        if (p.comptroller == address(0)) revert ZeroAddress();
+        if (p.cbBTC == address(0)) revert ZeroAddress();
+        if (p.weth == address(0)) revert ZeroAddress();
+        if (p.pool == address(0)) revert ZeroAddress();
+        if (p.npm == address(0)) revert ZeroAddress();
+        if (p.gauge == address(0)) revert ZeroAddress();
+        if (p.swapRouter == address(0)) revert ZeroAddress();
+        if (p.cbBTCFeed == address(0)) revert ZeroAddress();
+        if (p.wethFeed == address(0)) revert ZeroAddress();
+        if (p.usdcFeed == address(0)) revert ZeroAddress();
+        if (p.sequencerFeed == address(0)) revert ZeroAddress();
+        if (p.aeroUsdFeed == address(0)) revert ZeroAddress();
+        // L9: the AERO/USD floor scales an 8dp price (mulDiv by 1e20); a non-8dp aggregator would
+        // silently mis-scale the floor. Assert it here (the other feeds check dec at read time via
+        // _readUsd8; this one is checked once at init since the manager reads it raw for the floor).
+        if (IAggregatorV3(p.aeroUsdFeed).decimals() != 8) revert UnexpectedFeedDecimals();
+
+        // L7: the strategy's unit of account MUST be the vault's ERC-4626 asset, and the
+        // SHARES_VIRTUAL_OFFSET (1e6) hardcodes a 6-decimal asset — reject any other wiring.
+        if (p.usdc != IERC4626(vault()).asset()) revert AssetMismatch();
+        if (IERC20Metadata(p.usdc).decimals() != 6) revert UnexpectedAssetDecimals();
+
+        uint16 cfBps = _readCollateralFactor(p.comptroller, p.mUsdc);
+        if (p.targetLtvBps > p.maxLtvBps) revert TargetLtvExceedsMax();
+        if (p.minHealthBps < 10500) revert MinHealthTooLow();
+        if (p.maxLtvBps >= cfBps) revert MaxLtvExceedsCF();
+        // L4: permissionless deleverage triggers at LTV = 1e8 / minHealthBps; that trigger LTV MUST
+        // sit strictly above maxLtvBps, else there is an in-band range anyone can grief-deleverage.
+        // Cross-multiplied (overflow-free): require minHealthBps * maxLtvBps < 1e8.
+        if (uint256(p.minHealthBps) * uint256(p.maxLtvBps) >= 1e8) revert MinHealthMaxLtvConflict();
+        // L3 (+L5): bound the oracle / calm-gate params so a misconfig can't silently disable a guard.
+        // Bounds admit the confirmed config yet block degenerate values:
+        //   maxDelay           ∈ (0, 7 days] — a huge value disables staleness detection
+        //   gracePeriod        ∈ [0, 1 days] — sequencer-restart grace
+        //   twapWindow         ∈ (0, 1 days] — 0 disables the TWAP / calm-gate
+        //   calmDeviationTicks ∈ (0, 5000]   — a huge value disables the calm-gate
+        //   maxSlippageBps     ∈ (0, 1000]   — 0 or huge disables swap-slippage protection (10% cap)
+        if (p.maxDelay == 0 || p.maxDelay > 7 days) revert OracleParamOutOfRange();
+        if (p.gracePeriod > 1 days) revert OracleParamOutOfRange();
+        if (p.twapWindow == 0 || p.twapWindow > 1 days) revert OracleParamOutOfRange();
+        if (p.calmDeviationTicks == 0 || p.calmDeviationTicks > 5000) revert OracleParamOutOfRange();
+        if (p.maxSlippageBps == 0 || p.maxSlippageBps > 1000) revert OracleParamOutOfRange();
+        if ((p.managementFeeBps != 0 || p.performanceFeeBps != 0) && p.feeRecipient == address(0)) {
+            revert FeeRecipientRequired();
+        }
+        // M3: hard ceilings on both fee rates (perf mirrors the protocol-wide cap; mgmt the factory's).
+        if (p.performanceFeeBps > FeeConstants.MAX_PERFORMANCE_FEE_BPS) revert PerformanceFeeTooHigh();
+        if (p.managementFeeBps > MAX_MANAGEMENT_FEE_BPS) revert ManagementFeeTooHigh();
+
+        Layout storage $ = _layout();
+        $.usdc = p.usdc;
+        $.mUsdc = p.mUsdc;
+        $.mCbBTC = p.mCbBTC;
+        $.mWeth = p.mWeth;
+        $.comptroller = p.comptroller;
+        $.cbBTC = p.cbBTC;
+        $.weth = p.weth;
+        $.pool = p.pool;
+        $.npm = p.npm;
+        $.gauge = p.gauge;
+        $.swapRouter = p.swapRouter;
+        $.cbBTCFeed = p.cbBTCFeed;
+        $.wethFeed = p.wethFeed;
+        $.usdcFeed = p.usdcFeed;
+        $.sequencerFeed = p.sequencerFeed;
+        $.aeroUsdFeed = p.aeroUsdFeed;
+        $.maxDelay = p.maxDelay;
+        $.gracePeriod = p.gracePeriod;
+        $.calmDeviationTicks = p.calmDeviationTicks;
+        $.twapWindow = p.twapWindow;
+        $.tickSpacing = p.tickSpacing;
+        $.targetLtvBps = p.targetLtvBps;
+        $.maxLtvBps = p.maxLtvBps;
+        $.minHealthBps = p.minHealthBps;
+        $.maxSlippageBps = p.maxSlippageBps;
+        $.usdcCollateralFactorBps = cfBps;
+        $.managementFeeBps = p.managementFeeBps;
+        $.performanceFeeBps = p.performanceFeeBps;
+        $.feeRecipient = p.feeRecipient;
+        $.lastFeeAccrualTimestamp = block.timestamp;
+        // tokenId / posTickLower / posTickUpper / hwmPerShare default to 0 (set in _execute / on first deposit).
+    }
+
+    /// @dev USDC collateral factor (bps) from `Comptroller.markets(mUsdc)`. ABI is
+    ///      `(bool isListed, uint256 collateralFactorMantissa, ...)`; read the 2nd word (1e18-scaled).
+    function _readCollateralFactor(address comptroller_, address mUsdc_) private view returns (uint16 cfBps) {
+        (bool ok, bytes memory ret) = comptroller_.staticcall(abi.encodeWithSignature("markets(address)", mUsdc_));
+        if (!ok || ret.length < 64) revert ComptrollerCallFailed();
+        uint256 cfMantissa;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cfMantissa := mload(add(ret, 0x40))
+        }
+        cfBps = uint16(cfMantissa / 1e14); // 0.88e18 / 1e14 = 8800
+        if (cfBps == 0) revert ComptrollerCallFailed();
+    }
+
+    // ── NAV ──
+
+    /// @notice Oracle NAV of the levered book, in USDC (6dp), NET of the accrued protocol-fee
+    ///         liability (`protocolFeeOwed`). `tokenId == 0` (the flat-book invariant, maintained by
+    ///         `_execute`/`_settle`) → face value of strategy-controlled idle USDC only (vault float
+    ///         excluded — M2 deposit/redeem symmetry), no oracle. Active position →
+    ///         `LeveragedAeroValuation.netEquityUsdc` (oracle-implied sqrtP, fail-closed: reverts on
+    ///         any oracle/calm failure or ≤0 equity). `protocolFeeOwed` is subtracted here (floored at
+    ///         0, never reverts on owed > gross) — this is the fairness mechanism that replaces
+    ///         share-dilution: deposit share-pricing + the next HWM basis both see the net NAV.
+    function nav() public view virtual returns (uint256) {
+        Layout storage $ = _layout();
+        uint256 gross;
+        if ($.tokenId == 0) {
+            // Flat book: strategy-controlled idle USDC only (face, 6dp, no oracle). Vault float is
+            // excluded — `strategy.redeem` never pays it out, so counting it here would re-introduce
+            // the M2 deposit/redeem asymmetry the active-position branch already avoids.
+            gross = IERC20($.usdc).balanceOf(address(this));
+        } else {
+            // Active position: read ticks + liquidity from the NPM and delegate to the valuation lib.
+            (int24 tickLower, int24 tickUpper, uint128 liquidity) = _npmPositionData();
+            gross = LeveragedAeroValuation.netEquityUsdc(_config(), address(this), tickLower, tickUpper, liquidity);
+        }
+        uint256 owed = $.protocolFeeOwed;
+        return gross > owed ? gross - owed : 0;
+    }
+
+    /// @dev Reads only ticks + liquidity (fields 5-7) from the NPM `positions()` 12-tuple via
+    ///      staticcall + assembly — avoids putting all 12 returns on the stack (Yul IR 16-slot limit).
+    ///      Each is a 32-byte word at `ret + 0x20 + N*0x20`: [5] tickLower=0xC0, [6] tickUpper=0xE0,
+    ///      [7] liquidity=0x100.
+    function _npmPositionData() internal view returns (int24 tickLower, int24 tickUpper, uint128 liquidity) {
+        address npm_ = _layout().npm;
+        uint256 tokenId_ = _layout().tokenId;
+        bool ok;
+        bytes memory ret;
+        (ok, ret) = npm_.staticcall(abi.encodeWithSelector(INonfungiblePositionManager.positions.selector, tokenId_));
+        if (!ok) revert InvalidNpmReturn();
+        // Require at least 9 full words of returndata (0x120 bytes) so the mload
+        // at offset 0x100 (field 7, liquidity) cannot read past the allocated buffer.
+        if (ret.length < 0x120) revert InvalidNpmReturn();
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // ret + 0x20 = start of returndata; field 5 = +0x20+5*0x20 = +0xC0
+            tickLower := mload(add(ret, 0xC0))
+            tickUpper := mload(add(ret, 0xE0))
+            liquidity := mload(add(ret, 0x100))
+        }
+    }
+
+    // ── Positions (Lane A reporting for the PriceRouter) ──
+
+    /// @inheritdoc IStrategy
+    /// @notice Reports the single levered-CL position. `ref` encodes the market addresses the
+    ///         `LEVERAGED_AERO_CL` adapter needs to verify the venues.
+    function positions() external view override returns (Position[] memory pos) {
+        Layout storage $ = _layout();
+        pos = new Position[](1);
+        pos[0] = Position({venue: $.pool, kind: POSITION_KIND, ref: abi.encode($.gauge, $.mUsdc, $.mCbBTC, $.mWeth)});
+    }
+
+    /// @inheritdoc IStrategy
+    /// @dev Self-fee'd: this strategy crystallises management + HWM performance fees against its
+    ///      own NAV (custody model: LPs deposit/redeem into the strategy, shares minted/burned on
+    ///      the vault). The governor MUST skip settle-fee distribution — its float-delta PnL would
+    ///      misread net deposits as profit and double-charge fees already taken via crystallize.
+    function selfManagesFees() external pure override returns (bool) {
+        return true;
+    }
+
+    // ── Execute / settle ──
+
+    /// @notice Open the levered cbBTC/WETH CL position: supply USDC → enterMarkets → borrow
+    ///         cbBTC+WETH → wrap ETH → mint Slipstream CL → stake gauge → assert health. The venue
+    ///         sequence lives in `LeveragedAeroManager.executeImpl()` (delegatecalled, so
+    ///         `address(this)` / `_layout()` resolve to this clone).
+    function _execute() internal override {
+        LeveragedAeroManager.executeImpl();
+        // Belt-and-suspenders: keep the fee-accrual clock running even if a clone bypassed
+        // _initialize (guards against a ~54-year dt on the first crystallize).
+        if (_layout().lastFeeAccrualTimestamp == 0) _layout().lastFeeAccrualTimestamp = block.timestamp;
+    }
+
+    /// @notice Full proportional unwind to the vault. The unwind — remove 100% liquidity, repay both
+    ///         Moonwell borrows (self-funding any IL/fee shortfall), redeem collateral, sweep residual
+    ///         cbBTC/WETH → USDC, clear state — lives in `LeveragedAeroManager.settleImpl()`; the
+    ///         realized USDC is pushed to the vault here (the manager never touches `vault()`).
+    function _settle() internal override {
+        LeveragedAeroManager.settleImpl();
+        // Discharge the accrued protocol fee from realized USDC BEFORE pushing the rest to the
+        // vault. Pays `min(owed, balance)` to the live recipient; skips silently when recipient == 0
+        // or owed == 0 (liability persists until a recipient exists — see edge note on `redeem`).
+        Layout storage $ = _layout();
+        uint256 owed = $.protocolFeeOwed;
+        address recipient = _protocolFeeRecipient();
+        if (owed > 0 && recipient != address(0)) {
+            uint256 bal = IERC20($.usdc).balanceOf(address(this));
+            uint256 pay = owed < bal ? owed : bal;
+            if (pay > 0) {
+                $.protocolFeeOwed = owed - pay;
+                IERC20($.usdc).safeTransfer(recipient, pay);
+            }
+        }
+        _pushAllToVault($.usdc);
+    }
+
+    /// @dev Crystallise management + HWM performance fees on the PRE-ACTION vault state. The caller
+    ///      supplies `navPre` (not a self-call to `nav()`) so the caller controls oracle behaviour:
+    ///      deposit passes `nav()` (fail-closed — correct to revert on oracle failure); redeem passes
+    ///      0 when `nav()` is unavailable → `crystallize` still accrues the price-free MANAGEMENT fee
+    ///      for the elapsed `dt` (D6) and defers only the performance fee (HWM unchanged), keeping
+    ///      redeem oracle-free (§7).
+    /// @param navPre Pre-action NAV (USDC 6dp). Pass 0 on oracle outage → performance fee defers, but
+    ///      the price-free management fee still crystallises.
+    function _crystallizeFees(uint256 navPre) private {
+        Layout storage $ = _layout();
+        uint256 supply = IERC20(vault()).totalSupply();
+        if (supply == 0) return;
+        if ($.lastFeeAccrualTimestamp == 0) {
+            $.lastFeeAccrualTimestamp = block.timestamp;
+            return;
+        }
+        // Protocol fee is read LIVE from ProtocolConfig via `factory.protocolConfig()` (a
+        // self-fee'd strategy is skipped by the governor's settle-fee path, so the protocol
+        // leg is collected here instead). Treat a missing factory/config as 0 bps.
+        //
+        // SHARED ARG-LIST CONTRACT: the 8-arg `LeveragedAeroFees.crystallize(...)` call below is the
+        // EXECUTED crystallise; `_simulateCrystallize` (just below `_protocolFeeBps`) re-marshals the
+        // SAME 8 inputs read-only for `previewRedeem`. Any arg change here MUST be mirrored there —
+        // F4 was a desync between the two. This site applies state (mint / owed / hwm / timestamp);
+        // the simulate site only derives `(navNet, supplyPost)`, so they can't collapse into one
+        // helper without either losing these raw returns or breaking the try/catch atomicity.
+        (uint256 feeShares, uint256 newHwm, uint256 newLast, uint256 protocolUsdc) = LeveragedAeroFees.crystallize(
+            navPre,
+            supply,
+            $.hwmPerShare,
+            $.lastFeeAccrualTimestamp,
+            block.timestamp,
+            uint256($.managementFeeBps),
+            uint256($.performanceFeeBps),
+            _protocolFeeBps()
+        );
+        $.hwmPerShare = newHwm;
+        $.lastFeeAccrualTimestamp = newLast;
+        if (protocolUsdc > 0) $.protocolFeeOwed += protocolUsdc;
+        if (feeShares > 0) ISyndicateVault(vault()).strategyMint($.feeRecipient, feeShares);
+    }
+
+    /// @dev READ-ONLY twin of `_crystallizeFees`'s compute: derives the `(navNet, supplyPost)` the
+    ///      EXECUTED crystallise would produce, without applying any state. `previewRedeem` uses it so
+    ///      its quote tracks execution to the wei. Marshals the SAME 8 `LeveragedAeroFees.crystallize`
+    ///      args as `_crystallizeFees` — see the "SHARED ARG-LIST CONTRACT" note there; keep the two
+    ///      lists in lock-step (F4 was a desync). Honours the same `lastFeeAccrualTimestamp == 0`
+    ///      seed-guard early-return (no fee on first accrual). `_protocolFeeBps()` reads ProtocolConfig;
+    ///      the caller wraps this in a try/catch so a reverting config read degrades to `(0, false)`.
+    function _simulateCrystallize(uint256 navPre, uint256 supply)
+        private
+        view
+        returns (uint256 navNet, uint256 supplyPost)
+    {
+        Layout storage $ = _layout();
+        if ($.lastFeeAccrualTimestamp == 0) return (navPre, supply);
+        (uint256 feeShares,,, uint256 freshSlice) = LeveragedAeroFees.crystallize(
+            navPre,
+            supply,
+            $.hwmPerShare,
+            $.lastFeeAccrualTimestamp,
+            block.timestamp,
+            uint256($.managementFeeBps),
+            uint256($.performanceFeeBps),
+            _protocolFeeBps()
+        );
+        navNet = navPre - freshSlice; // freshSlice ≤ navPre (lib caps at navPre) → no underflow
+        supplyPost = supply + feeShares;
+    }
+
+    /// @dev Self-only external view wrapper so `previewRedeem` can `try/catch` `_simulateCrystallize`
+    ///      (its `_protocolFeeBps()` does an external ProtocolConfig staticcall — near-unreachable to revert
+    ///      on a set-once UUPS proxy, but the advisory view must degrade to `(0, false)` symmetrically with
+    ///      its other failure modes rather than revert while executed `redeem` swallows the same).
+    function simulateCrystallizeSelf(uint256 navPre, uint256 supply)
+        external
+        view
+        returns (uint256 navNet, uint256 supplyPost)
+    {
+        if (msg.sender != address(this)) revert OnlySelf();
+        return _simulateCrystallize(navPre, supply);
+    }
+
+    /// @dev The protocol-wide ProtocolConfig, resolved via the vault's factory.
+    ///      Per-vault migration (#421) moved the protocol-fee params off the
+    ///      governor onto this shared config; `address(0)` if the factory is
+    ///      unset (treated as no protocol fee by callers).
+    function _protocolConfig() private view returns (address) {
+        address factory_ = ISyndicateVault(vault()).factory();
+        return factory_ == address(0) ? address(0) : ISyndicateFactory(factory_).protocolConfig();
+    }
+
+    /// @dev Live protocol-fee rate (bps) from ProtocolConfig; 0 if unset.
+    function _protocolFeeBps() private view returns (uint256) {
+        address cfg = _protocolConfig();
+        return cfg == address(0) ? 0 : IProtocolConfig(cfg).protocolFeeBps();
+    }
+
+    /// @dev Live protocol-fee recipient from ProtocolConfig; `address(0)` when unset (skips discharge).
+    function _protocolFeeRecipient() private view returns (address) {
+        address cfg = _protocolConfig();
+        return cfg == address(0) ? address(0) : IProtocolConfig(cfg).protocolFeeRecipient();
+    }
+
+    /// @dev Self-only external wrapper so `redeem` can crystallise fees best-effort via `try/catch`
+    ///      (H3). A fee-mint can revert on the vault's `whenNotPaused` / depositor-whitelist gates;
+    ///      isolating it in an external call lets a failure roll back ONLY the crystallise (HWM +
+    ///      `lastFeeAccrualTimestamp` unchanged → fee defers) while redeem proceeds. Gated to
+    ///      `address(this)`; runs inside redeem's `nonReentrant` scope (not itself guarded), so it
+    ///      adds no reentrancy surface.
+    function crystallizeFeesSelf(uint256 navPre) external {
+        if (msg.sender != address(this)) revert OnlySelf();
+        _crystallizeFees(navPre);
+    }
+
+    /// @dev Best-effort crystallise (H3 pattern), single-site: isolates the fee-MINT / near-unreachable
+    ///      config-read revert inside the external `crystallizeFeesSelf` self-call so a failure rolls back
+    ///      ONLY the crystallise (HWM + `lastFeeAccrualTimestamp` unchanged → fee defers) while the calling
+    ///      op proceeds. `navPre` stays computed by the CALLER so fail-closed pricing (a down oracle) reverts
+    ///      there, outside this try. Not narrowed by selector; the asymmetric un-try'd config reads
+    ///      (compound/settle/skim) hard-revert on the same failure.
+    function _crystallizeBestEffort(uint256 navPre, uint8 op) private {
+        try this.crystallizeFeesSelf(navPre) {}
+        catch {
+            emit FeeCrystallizeDeferred(op, navPre);
+        }
+    }
+
+    /// @dev `_crystallizeBestEffort` + net the FRESH protocol slice the crystallise accrued out of `navPre`
+    ///      (`navNet = navPre − (owedNow − owedBefore)`; prior owed already net inside `nav()`). No underflow
+    ///      — the fees lib caps the slice at navPre. On a caught crystallise owed is unchanged → `navNet ==
+    ///      navPre` (self-consistent). Shared by `deposit` and the fast `redeem` (both price at `f × navNet`
+    ///      against a POST-crystallise `supply` read by the caller).
+    function _crystallizeAndNet(uint256 navPre, uint8 op) private returns (uint256 navNet) {
+        uint256 owedBefore = _layout().protocolFeeOwed;
+        _crystallizeBestEffort(navPre, op);
+        navNet = navPre - (_layout().protocolFeeOwed - owedBefore);
+    }
+
+    /// @notice Oracle-priced deposit: mint vault shares proportional to current NAV. Ordering is
+    ///         load-bearing (phantom-fee fix): crystallise fees on the PRE-deposit NAV (fail-closed on
+    ///         the PRICE) BEFORE pulling USDC, then mint via the ERC-4626 virtual-offset formula.
+    ///         Deposited USDC sits idle until a proposer calls `deployIdle()`.
+    ///
+    ///         The crystallise is best-effort (H3, mirrors `redeem`): `navPre = nav()` stays OUTSIDE
+    ///         the try/catch so a down oracle still reverts the deposit (fail-closed pricing), but a
+    ///         fee-MINT revert (vault paused / feeRecipient de-whitelisted on a whitelist vault) rolls
+    ///         back ONLY the crystallise (fee defers) — deposits must not brick once a fee accrues. The
+    ///         catch ALSO swallows a reverting ProtocolConfig read (`_protocolFeeBps`/`_protocolFeeRecipient`
+    ///         staticcall inside the crystallise) — near-unreachable on a set-once UUPS proxy, so the
+    ///         intended target is the fee-MINT; it is NOT narrowed by selector (fee-mint reverts are
+    ///         hard to enumerate). Note the asymmetry: `compound()` / `_settle()` / `_dischargeRedeemSkim`
+    ///         read ProtocolConfig UN-try'd and hard-revert on the same failure.
+    ///         Pricing mirrors `redeem`: snapshot `owedBefore`, then net the FRESH protocol slice the
+    ///         crystallise accrued out of `navPre` (`navNet = navPre − (owedNow − owedBefore)`); `supply`
+    ///         is read POST-crystallise (includes the perf-fee mint). Without the netting the depositor
+    ///         over-pays / under-mints by their share of the fresh slice. On a caught crystallise owed is
+    ///         unchanged → `navNet == navPre` (self-consistent).
+    /// @param assets    USDC to deposit (6dp).
+    /// @param minShares Minimum vault shares to accept (slippage guard).
+    function deposit(uint256 assets, uint256 minShares) external nonReentrant returns (uint256 shares) {
+        if (_state != State.Executed) revert NotExecuted();
+        // Crystallize on pre-deposit NAV. `nav()` OUTSIDE try/catch → a down oracle reverts the deposit
+        // (fail-closed pricing is load-bearing). Only the fee-MINT failure is swallowed (fee defers).
+        uint256 navPre = nav();
+        uint256 navNet = _crystallizeAndNet(navPre, OP_DEPOSIT);
+        IERC20(_layout().usdc).safeTransferFrom(msg.sender, address(this), assets);
+        address vault_ = vault();
+        uint256 supply = IERC20(vault_).totalSupply(); // POST-crystallize (includes any perf-fee mint)
+        // Guard the navNet==0 share-inflation case: with holders present and a worthless book the
+        // mulDiv denominator collapses to 1, minting ~assets×(supply+offset) shares (dilutes stayers).
+        // First deposit (supply==0) legitimately has navNet==0 (empty book) → must stay allowed.
+        if (navNet == 0 && supply > 0) revert NavUnpriceable();
+        shares = Math.mulDiv(assets, supply + SHARES_VIRTUAL_OFFSET, navNet + 1);
+        if (shares < minShares) revert InsufficientShares();
+        ISyndicateVault(vault_).strategyMint(msg.sender, shares);
+    }
+
+    /// @notice Deploy `amount` of idle strategy USDC into the levered position (supply + borrow +
+    ///         increaseLiquidity + health-assert) via `LeveragedAeroManager.deployIdleImpl()`.
+    /// @param amount       USDC to deploy (6dp); must be ≤ idle USDC held.
+    /// @param minLiquidity Minimum liquidity to accept (slippage guard).
+    function deployIdle(uint256 amount, uint256 minLiquidity) external onlyProposer nonReentrant {
+        if (_state != State.Executed) revert NotExecuted();
+        LeveragedAeroManager.deployIdleImpl(amount, minLiquidity);
+    }
+
+    /// @notice Compound AERO rewards: claim → swap to USDC (Aerodrome v2 volatile pool, the deepest
+    ///         AERO/USDC venue on Base) → redeploy at target leverage, via
+    ///         `LeveragedAeroManager.compoundImpl()`. No-op when no AERO is claimable. The swap fill is
+    ///         floored by `max(minUsdcOut, oracleFloor)`: the manager derives `oracleFloor` from a
+    ///         hardened AERO/USD Chainlink read and post-checks the measured fill (L9), so a thin-pool
+    ///         sandwich or a careless/compromised proposer can't realise emissions below the bound. A
+    ///         stale AERO feed fail-closes → `compound` reverts (defer the harvest, intended posture).
+    ///
+    ///         Fee fairness (§10): crystallise on the PRE-compound NAV first (same fail-closed model
+    ///         as `deposit`) so the realized yield can't escape the performance fee. Crystallisation
+    ///         lives here (it mints fee-shares); unlike the redeem path an oracle read is correct —
+    ///         `compound` is `onlyProposer`, so a stale oracle should defer, not mis-price.
+    /// @param minUsdcOut   Minimum USDC out of the AERO→USDC swap (slippage guard).
+    /// @param minLiquidity Minimum CL liquidity on the redeploy (slippage guard).
+    function compound(uint256 minUsdcOut, uint256 minLiquidity) external onlyProposer nonReentrant {
+        if (_state != State.Executed) revert NotExecuted();
+        // Crystallize on the pre-compound NAV (fail-closed; mirrors deposit's 3.6 fee model).
+        _crystallizeFees(nav());
+        // Discharge the protocol fee from the swapped-out USDC BEFORE it's redeployed. `skimCap`
+        // is 0 when there's no recipient (accrual persists; discharge defers). The manager pays
+        // `min(skimCap, usdcOut)` internally, redeploys the remainder, and returns the amount paid;
+        // the STRATEGY transfers it out + decrements owed (config read + external transfer stay
+        // out of the manager).
+        address recipient = _protocolFeeRecipient();
+        uint256 skimCap = recipient == address(0) ? 0 : _layout().protocolFeeOwed;
+        uint256 pay = LeveragedAeroManager.compoundImpl(minUsdcOut, minLiquidity, skimCap);
+        if (pay > 0) {
+            _layout().protocolFeeOwed -= pay;
+            IERC20(_layout().usdc).safeTransfer(recipient, pay);
+        }
+    }
+
+    /// @notice Recenter the CL position on the current pool tick WITHOUT swapping, via
+    ///         `LeveragedAeroManager.rerangeImpl()`. The calm-gate runs FIRST, so a recenter can never
+    ///         execute at a manipulated tick. No swap → principal conserved (IL is realized only on a
+    ///         true exit); the collected ratio can't match the new range, so a remainder of ONE
+    ///         borrowed leg is left idle — `nav()` prices it, so the recenter is NAV-neutral and the
+    ///         remainder stays redeployable. Debt + collateral are untouched (health preserved); a new
+    ///         tokenId is minted (Slipstream ticks are immutable), the old empty NFT is harmless dust.
+    ///
+    ///         NO fee crystallisation: rerange changes neither supply nor NAV, so the streaming fee is
+    ///         deferred to the next crystallize point (not lost) and the HWM is unaffected.
+    /// @param minLiq0 Minimum token0 (WETH) the re-add must consume (two-sided slippage guard).
+    /// @param minLiq1 Minimum token1 (cbBTC) the re-add must consume (two-sided slippage guard).
+    function rerange(uint256 minLiq0, uint256 minLiq1) external onlyProposer nonReentrant {
+        if (_state != State.Executed) revert NotExecuted();
+        LeveragedAeroManager.rerangeImpl(minLiq0, minLiq1);
+    }
+
+    /// @notice Retarget the position's LTV to `targetLtvBps_` (borrow/repay; no new USDC). Collateral
+    ///         is untouched, so LTV moves on the debt side via `LeveragedAeroManager.adjustLeverageImpl`:
+    ///         lever UP borrows the cbBTC/WETH delta and adds it (`minLiq`); lever DOWN unwinds the
+    ///         matching CL fraction and repays (per-leg residual rebalanced through USDC, bounded by
+    ///         `minOut`). Ends with `_assertHealthy`. `targetLtvBps_ ≤ maxLtvBps` is checked here.
+    ///
+    ///         NO fee crystallisation (like `rerange`): no supply change, no PnL realized; the
+    ///         streaming fee is deferred and the HWM is unaffected.
+    /// @param targetLtvBps_ Target LTV in bps (must be ≤ `maxLtvBps`).
+    /// @param minLiq        Minimum CL liquidity on a lever-UP add (slippage guard).
+    /// @param minOut        Minimum USDC out of a lever-DOWN residual swap (slippage guard).
+    function adjustLeverage(uint16 targetLtvBps_, uint256 minLiq, uint256 minOut) external onlyProposer nonReentrant {
+        if (_state != State.Executed) revert NotExecuted();
+        if (targetLtvBps_ > _layout().maxLtvBps) revert TargetLtvExceedsMax();
+        LeveragedAeroManager.adjustLeverageImpl(targetLtvBps_, minLiq, minOut);
+    }
+
+    /// @notice Permissionless safety valve: when health falls below `minHealthBps`, ANYONE may unwind
+    ///         CL liquidity and repay debt to restore the buffer. Deliberately NOT `onlyProposer` — a
+    ///         public deleverage is the user-safety backstop for the indefinite proposal (§8). Logic in
+    ///         `LeveragedAeroManager.deleverageImpl`: same hardened-Chainlink health basis as
+    ///         `_assertHealthy`, reverts `HealthyNoDeleverage` when safe / no debt, else repays down to
+    ///         a small buffer above the minimum (a recovery op, not the full LTV-≤-max gate).
+    ///
+    ///         A stale our-feed fail-closes the read (deleveraging at a stale/manipulated price is
+    ///         worse than waiting); Moonwell liquidation uses its own oracle, an accepted residual (§13).
+    /// @param minOut Minimum USDC out of any residual rebalancing swap (slippage guard).
+    function deleverage(uint256 minOut) external nonReentrant {
+        if (_state != State.Executed) revert NotExecuted();
+        LeveragedAeroManager.deleverageImpl(minOut);
+    }
+
+    /// @notice Oracle-priced FAST-PATH redeem (the everyday exit): pay `shares × nav() / supply`,
+    ///         funded from the Moonwell USDC collateral ONLY — no LP touch, no debt repay. Caller must
+    ///         `vault.approve(strategy, shares)` first (shares are pulled via `safeTransferFrom`).
+    ///
+    ///         Oracle-dependent by design (fail-closed, exactly like `deposit`): `navPre = nav()`
+    ///         reverts on a down oracle — the caller then routes to `requestRedeem`. **No protocol-fee
+    ///         skim on this path**: `nav()` is ALREADY net of `protocolFeeOwed`, so pricing at
+    ///         `f × navNet` provably preserves stayers' per-share (a skim would double-charge).
+    ///
+    ///         The LTV gate is authoritative in the manager (`fastRedeemImpl` computes the post-withdraw
+    ///         LTV on the pre-withdraw prices and reverts `FastRedeemExceedsLtv` if it breaches
+    ///         `maxLtvBps`, plus a belt `_assertHealthy()`); a breach means the collateral can't fund
+    ///         this size without a deleverage → the frontend routes to `requestRedeem`.
+    /// @param shares       Vault shares to redeem (12dp).
+    /// @param minAssetsOut Minimum USDC out (slippage guard on the payout).
+    function redeem(uint256 shares, uint256 minAssetsOut) external nonReentrant returns (uint256 assetsOut) {
+        if (_state != State.Executed) revert NotExecuted();
+
+        // 1. Crystallise on the pre-redeem NAV (fail-closed: a down oracle reverts — correct, the fast
+        //    path is inherently oracle-dependent). Best-effort (H3, §7): a fee-mint revert (vault paused
+        //    / feeRecipient de-whitelisted) — or a near-unreachable config-read revert inside the
+        //    crystallise — rolls back ONLY the crystallise (owed + supply unchanged, so the netting below
+        //    sees a 0 fresh slice) and the exit still proceeds. Not narrowed by selector; the asymmetric
+        //    un-try'd config reads (compound/settle/skim) hard-revert on that same failure.
+        uint256 navPre = nav();
+        uint256 navNet = _crystallizeAndNet(navPre, OP_REDEEM);
+
+        // 2. Price against the POST-crystallize book, both effects consistently: `supply` is read
+        //    after the crystallize (includes the perf-fee mint dilution) and the FRESH protocol slice
+        //    it just accrued is netted out of navPre inside `_crystallizeAndNet`. Without the netting
+        //    the redeemer would capture f×slice from stayers.
+        address vault_ = vault();
+        uint256 supply = IERC20(vault_).totalSupply();
+        assetsOut = Math.mulDiv(shares, navNet, supply); // rounds down, LP-favourable
+        if (assetsOut < minAssetsOut) revert InsufficientAssetsOut();
+        // Reject a burn-for-zero: at navNet==0 (owed ≥ gross book) or a dust-share redeem that floors to
+        // 0, `assetsOut == 0` with the common `minAssetsOut == 0` would pull + burn shares for no payout.
+        // (The async path guards the same case in `_proportionalRedeem`, after its skim.)
+        if (assetsOut == 0) revert ZeroAssetsOut();
+
+        // 3. Pull shares from caller (requires prior vault.approve(strategy, shares)).
+        IERC20(vault_).safeTransferFrom(msg.sender, address(this), shares);
+
+        // 4. Fund `assetsOut`: idle USDC first (up to the redeemer's pro-rata `f×idle` share, so a
+        //    partial redeem never dips into a stayer's `(1-f)×idle`), remainder from collateral
+        //    (LTV-gated in the manager on that remainder only).
+        uint256 idleShare = Math.mulDiv(IERC20(_layout().usdc).balanceOf(address(this)), shares, supply);
+        LeveragedAeroManager.fastRedeemImpl(assetsOut, idleShare);
+
+        // 5. Pay out + burn.
+        IERC20(_layout().usdc).safeTransfer(msg.sender, assetsOut);
+        ISyndicateVault(vault_).strategyBurn(shares);
+    }
+
+    /// @notice Advisory preview of the fast-path exit — mirrors `redeem` EXACTLY, including the pending
+    ///         fee crystallise. The executed `redeem` crystallises first (perf-fee mint dilutes supply,
+    ///         a fresh protocol slice nets out of `nav()`), so pricing against the LIVE `nav()`/`supply`
+    ///         would over-quote whenever fees are pending (real gain above the HWM, or accrued mgmt `dt`).
+    ///         Here we SIMULATE that crystallise with the current storage — same pure `LeveragedAeroFees`
+    ///         inputs `_crystallizeFees` uses — and price on `navNet = navPre − freshSlice` over the
+    ///         post-mint `supply + feeShares`, so the quote equals the executed payout to the wei *when
+    ///         executed at the same `block.timestamp`*. A frontend passing it as `minAssetsOut` should
+    ///         still apply a small slippage tolerance: the streaming management fee accrues with `dt`, so
+    ///         a redeem landing a few blocks later pays marginally LESS than this quote (and the NAV may
+    ///         drift), which would otherwise bounce an exact-quote `minAssetsOut`.
+    ///
+    ///         Safe-direction edge for the PAYOUT (opposite sign): if the executed crystallise DEFERS
+    ///         (fee-mint reverts on a paused / un-whitelisted vault, H3), the actual pays MORE than this
+    ///         fee-adjusted quote (no dilution, no slice) — that case never bounces a preview-derived
+    ///         `minAssetsOut`. NOTE `fastOk` is the OPPOSITE sign: on a deferred crystallise the executed
+    ///         `assetsOut = shares × navPre / supply` is LARGER than this fee-adjusted quote (`strategyBurn`
+    ///         is not `whenNotPaused`, so redeem proceeds while the crystallise defers), so its larger
+    ///         `fromCollateral` yields a higher `postLtv` — the on-chain `fastRedeemImpl` gate can revert
+    ///         `FastRedeemExceedsLtv` even though this preview optimistically returned `fastOk == true`.
+    ///         `fastOk` is ADVISORY; the manager's LTV gate is authoritative.
+    ///
+    ///         Returns `(0, false)` instead of reverting when the oracle is down (try/catch on the nav +
+    ///         collateral/debt reads), when the fee simulation's config read reverts (try/catch on
+    ///         `simulateCrystallizeSelf` — symmetric with the other degrade-to-`(0,false)` modes rather
+    ///         than reverting while executed `redeem` swallows the same), and when the simulated payout
+    ///         floors to 0 (mirrors `redeem`'s `ZeroAssetsOut` guard) so a preview-`minAssetsOut` never
+    ///         quotes a payout the executed path would revert on. ADVISORY ONLY — the on-chain gate in
+    ///         `fastRedeemImpl` is authoritative; a frontend uses `fastOk` to pre-route to `requestRedeem`.
+    /// @param shares Vault shares to preview (12dp).
+    /// @return assetsOut Predicted USDC out (0 when unpriceable or the payout floors to 0).
+    /// @return fastOk    True iff the fast path would price AND clear the LTV gate (advisory — see above).
+    function previewRedeem(uint256 shares) external view returns (uint256 assetsOut, bool fastOk) {
+        uint256 supply = IERC20(vault()).totalSupply();
+        if (supply == 0) return (0, false);
+        uint256 navPre;
+        try this.nav() returns (uint256 n) {
+            navPre = n;
+        } catch {
+            return (0, false);
+        }
+        // Simulate the pending crystallise the executed `redeem` performs — the SAME arg-marshalling as
+        // `_crystallizeFees` (via `_simulateCrystallize`, F4 dedup). Wrapped in a try/catch so a reverting
+        // ProtocolConfig read inside `_protocolFeeBps()` degrades to `(0, false)` symmetrically with the other
+        // preview failure modes (executed `redeem` swallows the same via its own crystallise try/catch).
+        uint256 navNet;
+        uint256 supplyPost;
+        try this.simulateCrystallizeSelf(navPre, supply) returns (uint256 nn, uint256 sp) {
+            navNet = nn;
+            supplyPost = sp;
+        } catch {
+            return (0, false);
+        }
+        assetsOut = Math.mulDiv(shares, navNet, supplyPost);
+        // Mirror `redeem`'s `ZeroAssetsOut` guard: never quote a payout the executed path would revert on.
+        if (assetsOut == 0) return (0, false);
+        // Idle-first (mirror `fastRedeemImpl`): the redeemer's `f×idle` share funds part of `assetsOut`,
+        // so the LTV gate only sees the collateral-funded remainder.
+        uint256 idleShare = Math.mulDiv(IERC20(_layout().usdc).balanceOf(address(this)), shares, supplyPost);
+        uint256 fromCollateral = assetsOut > idleShare ? assetsOut - idleShare : 0;
+        if (fromCollateral == 0) return (assetsOut, true); // idle alone covers it — no LTV constraint
+        // Predict the LTV gate on the same pre-withdraw basis as `fastRedeemImpl`.
+        try this.previewCollateralDebt() returns (uint256 collateralUsdc, uint256 debtUsdc) {
+            if (fromCollateral >= collateralUsdc) return (assetsOut, false);
+            uint256 maxLtv = uint256(_layout().maxLtvBps);
+            fastOk = debtUsdc == 0 || (debtUsdc * 10_000) / (collateralUsdc - fromCollateral) <= maxLtv;
+        } catch {
+            return (assetsOut, false); // collateral/debt oracle read failed → advise the async path
+        }
+    }
+
+    /// @dev Self-only external view so `previewRedeem` can try/catch the manager's oracle reads
+    ///      (a down feed reverts inside `_readCollateralDebt`). Runs under staticcall; no state change.
+    function previewCollateralDebt() external view returns (uint256 collateralUsdc, uint256 debtUsdc) {
+        if (msg.sender != address(this)) revert OnlySelf();
+        return LeveragedAeroManager.readCollateralDebtImpl();
+    }
+
+    // ── Escrowed async redeem (Lane-B-style, no price freeze) ──
+
+    /// @notice Escrow `shares` for an async proportional redeem — the exit for holders the LTV-gated
+    ///         fast path can't serve (or when the oracle is down). Shares are pulled NOW
+    ///         (`vault.approve(strategy, shares)` required) and held in the strategy; NO price is
+    ///         stamped (shares keep bearing PnL until `fulfillRedeem`), so `cancelRedeem` is not a free
+    ///         look-back option. The backend deleverages (via `adjustLeverage`) then `fulfillRedeem`s.
+    /// @param shares       Vault shares to escrow (12dp).
+    /// @param minAssetsOut Slippage floor enforced (on the net amount) at fulfill.
+    /// @return id          The request id (also emitted).
+    function requestRedeem(uint256 shares, uint256 minAssetsOut) external nonReentrant returns (uint256 id) {
+        if (_state != State.Executed) revert NotExecuted();
+        IERC20(vault()).safeTransferFrom(msg.sender, address(this), shares);
+        Layout storage $ = _layout();
+        id = $.nextRedeemRequestId++;
+        $.redeemRequests[id] = RedeemRequest({
+            owner: msg.sender,
+            shares: shares,
+            minAssetsOut: minAssetsOut,
+            requestedAt: uint40(block.timestamp),
+            settled: false
+        });
+        emit RedeemRequested(id, msg.sender, shares);
+    }
+
+    /// @notice Fulfill an escrowed request via the oracle-free proportional unwind (the demoted
+    ///         everyday path, now reachable ONLY here and via `emergencyRedeem`). `onlyProposer`: the
+    ///         backend deleverages first (`adjustLeverage`) so the unwind's IL self-funds, then fulfills
+    ///         paying `request.owner`. NOT owner-callable — an owner-callable fulfill would resurrect
+    ///         the demoted oracle-free path through the side door.
+    /// @param id Request id to fulfill.
+    function fulfillRedeem(uint256 id) external onlyProposer nonReentrant {
+        if (_state != State.Executed) revert NotExecuted();
+        Layout storage $ = _layout();
+        RedeemRequest storage r = $.redeemRequests[id];
+        if (r.settled) revert RequestSettled();
+        uint256 assetsOut = _proportionalRedeem(r.owner, r.shares, r.minAssetsOut);
+        r.settled = true;
+        emit RedeemFulfilled(id, r.owner, assetsOut);
+    }
+
+    /// @notice Cancel an unsettled request and return the escrowed shares to its owner. Request owner
+    ///         only, callable in ANY strategy state (no `State.Executed` gate): a request outstanding
+    ///         when the proposal settles must stay cancellable so the owner can exit via the vault
+    ///         normally.
+    /// @param id Request id to cancel.
+    function cancelRedeem(uint256 id) external nonReentrant {
+        RedeemRequest storage r = _layout().redeemRequests[id];
+        if (msg.sender != r.owner) revert NotRequestOwner();
+        if (r.settled) revert RequestSettled();
+        r.settled = true;
+        IERC20(vault()).safeTransfer(r.owner, r.shares);
+        emit RedeemCancelled(id, r.owner, r.shares);
+    }
+
+    /// @notice Deadman trustless backstop: after `FULFILL_WINDOW` elapses on an unfulfilled request,
+    ///         its owner may self-fulfill via the same oracle-free proportional unwind. This single
+    ///         gate covers the whole deadman matrix — fulfill is oracle-free, so "oracle down + backend
+    ///         alive" resolves via normal `fulfillRedeem`; the only stuck case (oracle down AND backend
+    ///         dead) self-resolves here. `minAssetsOut` is a FRESH arg (the stored one may be stale
+    ///         after 2 days).
+    /// @param id           Request id (owner-gated).
+    /// @param minAssetsOut Fresh slippage floor on the net payout.
+    function emergencyRedeem(uint256 id, uint256 minAssetsOut) external nonReentrant returns (uint256 assetsOut) {
+        if (_state != State.Executed) revert NotExecuted();
+        RedeemRequest storage r = _layout().redeemRequests[id];
+        if (msg.sender != r.owner) revert NotRequestOwner();
+        if (r.settled) revert RequestSettled();
+        if (block.timestamp <= uint256(r.requestedAt) + FULFILL_WINDOW) revert FulfillWindowOpen();
+        assetsOut = _proportionalRedeem(r.owner, r.shares, minAssetsOut);
+        r.settled = true;
+        emit RedeemEmergency(id, r.owner, assetsOut);
+    }
+
+    /// @dev Shared body of `fulfillRedeem` / `emergencyRedeem`: oracle-free proportional unwind of
+    ///      `shares` for `recipient`, paying net of the Item-3 protocol skim, enforcing `minOut`,
+    ///      burning the escrowed shares. Best-effort crystallise (H3 pattern: navPre=0 on oracle
+    ///      outage → price-free mgmt fee accrues, perf fee defers; a fee-mint revert — or the
+    ///      near-unreachable ProtocolConfig-read revert inside the crystallise — defers the whole crystallise)
+    ///      keeps the exit oracle-free (§7). Not narrowed by selector; note `_dischargeRedeemSkim` below
+    ///      reads ProtocolConfig UN-try'd and hard-reverts on that same failure. `supply` fixed once before burn.
+    function _proportionalRedeem(address recipient, uint256 shares, uint256 minOut)
+        private
+        returns (uint256 assetsOut)
+    {
+        uint256 navPre;
+        try this.nav() returns (uint256 navNow) {
+            navPre = navNow;
+        } catch {
+            navPre = 0;
+        }
+        _crystallizeBestEffort(navPre, OP_FULFILL); // navPre == 0 here on an oracle-out redeem → fee defers
+
+        uint256 supply = IERC20(vault()).totalSupply();
+        assetsOut = LeveragedAeroManager.redeemUnwindImpl(shares, supply);
+        // Item-3 skim: the redeemer bears their pro-rata slice of the accrued protocol liability (the
+        // proportional unwind pays the GROSS book; nav() is net → skim rebalances). Pure arithmetic,
+        // no oracle. Skips silently when recipient == 0 or owed == 0.
+        assetsOut -= _dischargeRedeemSkim(shares, supply, assetsOut);
+        // Reject a burn-for-zero (mirrors the fast path's guard): at navNet==0 (owed ≥ gross book) the
+        // skim nets the payout to exactly 0; with a stored `minOut == 0` the `< minOut` check below
+        // would fall through and burn the escrowed shares for no payout. Reverting keeps the shares
+        // escrowed (no price is stamped at request time → they keep bearing PnL and pay out later) and
+        // `cancelRedeem` (no State/navNet gate) always lets the owner recover them.
+        if (assetsOut == 0) revert ZeroAssetsOut();
+        if (assetsOut < minOut) revert InsufficientAssetsOut();
+        IERC20(_layout().usdc).safeTransfer(recipient, assetsOut);
+        ISyndicateVault(vault()).strategyBurn(shares);
+    }
+
+    /// @dev Skim the redeemer's pro-rata protocol-fee slice from `assetsOut` and pay it to the live
+    ///      recipient. Returns the amount skimmed (0 when recipient unset or nothing owed) so the
+    ///      caller nets it out of the payout. `fee = owed × shares / supply` (rounds down,
+    ///      LP-favourable) capped at `assetsOut`; `owed` decremented by the skim. No oracle.
+    ///      Edge: if the recipient is later zeroed while `owed > 0`, discharge skips here (and in
+    ///      compound/settle) and the liability persists — `nav()` stays net — until a recipient exists.
+    function _dischargeRedeemSkim(uint256 shares, uint256 supply, uint256 assetsOut) private returns (uint256 fee) {
+        Layout storage $ = _layout();
+        uint256 owed = $.protocolFeeOwed;
+        if (owed == 0) return 0;
+        address recipient = _protocolFeeRecipient();
+        if (recipient == address(0)) return 0;
+        fee = Math.mulDiv(owed, shares, supply);
+        if (fee > assetsOut) fee = assetsOut;
+        if (fee == 0) return 0;
+        $.protocolFeeOwed = owed - fee;
+        IERC20($.usdc).safeTransfer(recipient, fee);
+    }
+
+    /// @notice Sweep a STRAY ERC-20 (airdrop / accidental send) back to the vault. Callable by the
+    ///         proposer OR the vault owner (§8): the strategy runs under an indefinite proposal, so
+    ///         `vault.rescueERC20/721/Eth` are dormant (they revert while `redemptionsLocked()`) — this
+    ///         is the only recovery path, and it must survive a dead proposer key. Target is always
+    ///         `vault()`, never caller-supplied, so neither caller can exfil (§13). Reverts
+    ///         `CannotRescuePositionToken` for any position/accounting token — usdc / cbBTC / weth
+    ///         (all NAV-counted) / mUsdc / mCbBTC / mWeth, and AERO (read live from the gauge so a
+    ///         sweep can't bypass `compound()`). The position NFT is never swept (no ERC-721 path).
+    function rescueToVault(address token) external nonReentrant {
+        if (msg.sender != proposer() && msg.sender != Ownable(vault()).owner()) revert NotProposerOrOwner();
+        Layout storage $ = _layout();
+        address aero = ICLGauge($.gauge).rewardToken();
+        if (
+            token == $.usdc || token == $.cbBTC || token == $.weth || token == $.mUsdc || token == $.mCbBTC
+                || token == $.mWeth || token == aero
+        ) revert CannotRescuePositionToken();
+        _pushAllToVault(token);
+    }
+
+    /// @dev No tunable params.
+    function _updateParams(bytes calldata) internal override {}
+
+    // ── Config builder for LeveragedAeroValuation ──
+
+    /// @dev Build the valuation `Config` from stored state (cbBTC 8dp / WETH 18dp are compile-time
+    ///      constants). Field-by-field (not struct-literal) so the Yul IR emits one sload→mstore per
+    ///      field, avoiding the 18-live-variable overflow struct-literals trigger under via_ir.
+    function _config() internal view returns (LeveragedAeroValuation.Config memory c) {
+        Layout storage $ = _layout();
+        c.usdc = $.usdc;
+        c.vault = vault();
+        c.mUsdc = $.mUsdc;
+        c.cbBTCMarket = $.mCbBTC;
+        c.wethMarket = $.mWeth;
+        c.cbBTC = $.cbBTC;
+        c.weth = $.weth;
+        c.cbBTCDecimals = CBBTC_DECIMALS;
+        c.wethDecimals = WETH_DECIMALS;
+        c.pool = $.pool;
+        c.cbBTCFeed = $.cbBTCFeed;
+        c.wethFeed = $.wethFeed;
+        c.usdcFeed = $.usdcFeed;
+        c.sequencerFeed = $.sequencerFeed;
+        c.maxDelay = $.maxDelay;
+        c.gracePeriod = $.gracePeriod;
+        c.calmDeviationTicks = $.calmDeviationTicks;
+        c.twapWindow = $.twapWindow;
+    }
+}

--- a/src/leveraged-aero/sherwood/BaseStrategy.sol
+++ b/src/leveraged-aero/sherwood/BaseStrategy.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Position} from "./interfaces/IPriceRouter.sol";
+import {IStrategy} from "./interfaces/IStrategy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title BaseStrategy
+ * @notice Abstract base for strategy contracts. The vault calls execute() and
+ *         settle() via batch calls — the strategy pulls tokens, deploys them
+ *         into DeFi, and returns them on settlement.
+ *
+ *   Designed for Clones (ERC-1167) — deploy template once, clone per proposal.
+ *
+ *   Typical batch calls from the governor:
+ *     Execute: [approve(strategy, amount), strategy.execute()]
+ *     Settle:  [strategy.settle()]
+ *
+ *   The strategy holds custody of position tokens (e.g., mUSDC) during the
+ *   strategy period. On settlement, underlying returns to the vault.
+ *
+ *   Proposer can update tunable params (slippage, amounts) between execute
+ *   and settle — no new proposal needed.
+ */
+abstract contract BaseStrategy is IStrategy {
+    using SafeERC20 for IERC20;
+
+    // ── Errors ──
+    error AlreadyInitialized();
+    error NotProposer();
+    error NotVault();
+    error NotExecuted();
+    error AlreadyExecuted();
+    error AlreadySettled();
+    error ZeroAddress();
+
+    // ── State ──
+    enum State {
+        Pending,
+        Executed,
+        Settled
+    }
+
+    // slot 0: reserved for HyperCore FirstStorageSlot registration.
+    // HyperliquidGridStrategy._initialize() writes address(this) here so HC
+    // reads slot 0 post-block and confirms it equals the contract address.
+    // Other strategies leave this as address(0) — no functional impact.
+    address internal _hcSelf;
+    address private _vault;
+    address private _proposer;
+    State internal _state;
+    bool private _initialized;
+
+    /**
+     * @notice Disables `initialize` on the template itself so an attacker
+     *         can't front-run a clone deploy with their own init.
+     * @dev Constructors are NOT executed for ERC-1167 minimal proxies, so
+     *      `Clones.clone(template)` produces a clone with `_initialized = false`,
+     *      keeping atomic `cloneAndInit` flows working. Only the template
+     *      contract — deployed via `new` — is permanently locked.
+     */
+    constructor() {
+        _initialized = true;
+    }
+
+    modifier onlyProposer() {
+        if (msg.sender != _proposer) revert NotProposer();
+        _;
+    }
+
+    modifier onlyVault() {
+        if (msg.sender != _vault) revert NotVault();
+        _;
+    }
+
+    /// @inheritdoc IStrategy
+    /// @dev Stamps `_hcSelf = address(this)` at slot 0 BEFORE delegating to
+    ///      `_initialize` so HyperCore's FirstStorageSlot finalize variant
+    ///      always sees the correct value. Foolproof for every strategy that
+    ///      inherits BaseStrategy — strategy-specific `_initialize` overrides
+    ///      cannot forget the stamp. Slot 0 is reserved for this purpose at
+    ///      the storage layout level (see `_hcSelf` declaration above);
+    ///      non-Hyperliquid strategies pay the cost (one SSTORE) but get
+    ///      consistent layout in exchange.
+    function initialize(address vault_, address proposer_, bytes calldata data) external {
+        if (_initialized) revert AlreadyInitialized();
+        if (vault_ == address(0)) revert ZeroAddress();
+        if (proposer_ == address(0)) revert ZeroAddress();
+        _initialized = true;
+        _hcSelf = address(this);
+        _vault = vault_;
+        _proposer = proposer_;
+        _state = State.Pending;
+
+        _initialize(data);
+    }
+
+    /// @notice Slot 0 contents — used by HyperCore FirstStorageSlot variant.
+    ///         Should equal `address(this)` after `initialize`. Diagnostic only.
+    function hcSelf() external view returns (address) {
+        return _hcSelf;
+    }
+
+    /// @inheritdoc IStrategy
+    function execute() external onlyVault {
+        if (_state != State.Pending) revert AlreadyExecuted();
+        _state = State.Executed;
+        _execute();
+    }
+
+    /// @inheritdoc IStrategy
+    function settle() external onlyVault {
+        if (_state != State.Executed) revert NotExecuted();
+        _state = State.Settled;
+        _settle();
+    }
+
+    /// @inheritdoc IStrategy
+    function updateParams(bytes calldata data) external virtual onlyProposer {
+        if (_state != State.Executed) revert NotExecuted();
+        _updateParams(data);
+    }
+
+    /// @inheritdoc IStrategy
+    function vault() public view returns (address) {
+        return _vault;
+    }
+
+    /// @inheritdoc IStrategy
+    function proposer() public view returns (address) {
+        return _proposer;
+    }
+
+    /// @inheritdoc IStrategy
+    function executed() external view returns (bool) {
+        return _state == State.Executed;
+    }
+
+    /// @notice Current lifecycle state
+    function state() external view returns (State) {
+        return _state;
+    }
+
+    /// @inheritdoc IStrategy
+    /// @dev Default: no instant-priceable positions (queue-only / Lane B).
+    ///      Strategies whose positions the PriceRouter can value override this.
+    function positions() external view virtual returns (Position[] memory) {
+        return new Position[](0);
+    }
+
+    /// @inheritdoc IStrategy
+    /// @dev Default: governor distributes settle-fees. Self-fee'd strategies override to `true`.
+    ///      NOTE: `true` makes the governor skip ALL settle-fees (protocol + guardian + agent +
+    ///      management) — a self-fee'd strategy MUST self-collect the protocol fee itself (see
+    ///      LeveragedAerodromeCLStrategy's `protocolFeeOwed` leg) or the protocol earns nothing.
+    function selfManagesFees() external view virtual returns (bool) {
+        return false;
+    }
+
+    // ── Internal helpers ──
+
+    /// @notice Pull tokens from the vault into this strategy
+    function _pullFromVault(address token, uint256 amount) internal {
+        IERC20(token).safeTransferFrom(_vault, address(this), amount);
+    }
+
+    /// @notice Push tokens from this strategy back to the vault
+    function _pushToVault(address token, uint256 amount) internal {
+        IERC20(token).safeTransfer(_vault, amount);
+    }
+
+    /// @notice Push entire balance of a token back to the vault
+    function _pushAllToVault(address token) internal {
+        uint256 bal = IERC20(token).balanceOf(address(this));
+        if (bal > 0) IERC20(token).safeTransfer(_vault, bal);
+    }
+
+    // ── Abstract hooks for concrete strategies ──
+
+    /// @notice Strategy-specific initialization (decode params from data)
+    function _initialize(bytes calldata data) internal virtual;
+
+    /// @notice Execute the strategy — pull tokens, deploy into DeFi
+    function _execute() internal virtual;
+
+    /// @notice Settle the strategy — unwind positions, push tokens back to vault
+    function _settle() internal virtual;
+
+    /// @notice Update tunable parameters (decode from data)
+    function _updateParams(bytes calldata data) internal virtual;
+}

--- a/src/leveraged-aero/sherwood/BatchExecutorLib.sol
+++ b/src/leveraged-aero/sherwood/BatchExecutorLib.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/**
+ * @title BatchExecutorLib
+ * @notice Stateless batch execution logic. Called via delegatecall from vaults.
+ *
+ *   When a vault delegatecalls into this contract:
+ *     - `address(this)` = vault address (positions live on the vault)
+ *     - `msg.sender` = original caller (the agent wallet)
+ *     - All calls to DeFi protocols happen FROM the vault
+ *
+ *   This contract has NO state and NO access control. The calling vault must
+ *   enforce allowlists and caps BEFORE delegatecalling here.
+ *
+ *   Deploy once, share across all syndicate vaults.
+ */
+contract BatchExecutorLib {
+    struct Call {
+        address target;
+        bytes data;
+        uint256 value;
+    }
+
+    struct CallResult {
+        bool success;
+        bytes returnData;
+    }
+
+    /**
+     * @notice Execute a batch of calls atomically.
+     * @dev Called via delegatecall from vault. All calls execute as the vault.
+     *      If any call fails, the entire batch reverts.
+     * @param calls Array of (target, data, value) to execute in order
+     */
+    function executeBatch(Call[] calldata calls) external {
+        for (uint256 i = 0; i < calls.length; i++) {
+            (bool success, bytes memory returnData) = calls[i].target.call{value: calls[i].value}(calls[i].data);
+            if (!success) {
+                assembly {
+                    revert(add(returnData, 32), mload(returnData))
+                }
+            }
+        }
+    }
+
+    /**
+     * @notice Simulate a batch without reverting on failure.
+     * @dev Call via eth_call for dry-run. Returns per-call results.
+     *      State changes from earlier calls ARE visible to later calls,
+     *      matching real execution behavior.
+     * @param calls Array of calls to simulate
+     * @return results Array of (success, returnData) per call
+     */
+    function simulateBatch(Call[] calldata calls) external returns (CallResult[] memory results) {
+        results = new CallResult[](calls.length);
+        for (uint256 i = 0; i < calls.length; i++) {
+            (bool success, bytes memory returnData) = calls[i].target.call{value: calls[i].value}(calls[i].data);
+            results[i] = CallResult({success: success, returnData: returnData});
+        }
+    }
+}

--- a/src/leveraged-aero/sherwood/FeeConstants.sol
+++ b/src/leveraged-aero/sherwood/FeeConstants.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/// @title FeeConstants
+/// @notice Single source of truth for the protocol-wide performance-fee
+///         ceiling. Shared by the governor (the `maxPerformanceFeeBps` hard
+///         cap, `MAX_PERFORMANCE_FEE_CAP`) and the vault (the `agentFeeBps`
+///         hard cap, `MAX_AGENT_FEE_BPS`) so the two can never silently
+///         diverge from a hand-edited literal (L1). Referenced as a
+///         compile-time constant, so it adds no runtime bytecode.
+library FeeConstants {
+    /// @notice Hard ceiling on the agent performance fee, in basis points (15%).
+    uint256 internal constant MAX_PERFORMANCE_FEE_BPS = 1500;
+
+    /// @notice Default agent performance fee a vault charges until its owner
+    ///         sets one, in basis points (5%). Single source of truth for the
+    ///         vault getter's fallback (mirror it in any off-chain default).
+    uint256 internal constant DEFAULT_AGENT_FEE_BPS = 500;
+}

--- a/src/leveraged-aero/sherwood/interfaces/IAggregatorV3.sol
+++ b/src/leveraged-aero/sherwood/interfaces/IAggregatorV3.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+interface IAggregatorV3 {
+    function decimals() external view returns (uint8);
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}

--- a/src/leveraged-aero/sherwood/interfaces/ICToken.sol
+++ b/src/leveraged-aero/sherwood/interfaces/ICToken.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/// @notice Minimal Compound/Moonwell cToken interface
+interface ICToken {
+    function mint(uint256 mintAmount) external returns (uint256);
+    function redeemUnderlying(uint256 redeemAmount) external returns (uint256);
+    function redeem(uint256 redeemTokens) external returns (uint256);
+    function balanceOf(address owner) external view returns (uint256);
+    function balanceOfUnderlying(address owner) external returns (uint256);
+    /// @notice Last-accrued exchange rate between the cToken and underlying.
+    /// @dev    Stored = cheap view (no accrual); Current would re-accrue at call time.
+    ///         The underlying per cToken formula is:
+    ///           underlying = cTokenBalance * exchangeRateStored / 1e18
+    function exchangeRateStored() external view returns (uint256);
+}

--- a/src/leveraged-aero/sherwood/interfaces/IMoonwellMarket.sol
+++ b/src/leveraged-aero/sherwood/interfaces/IMoonwellMarket.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {ICToken} from "./ICToken.sol";
+
+/// @notice Moonwell (Compound-fork) mToken interface — borrow / repay surface.
+/// @dev All functions return a uint256 error code (0 = success), matching the
+///      Compound-fork convention. They do NOT revert on protocol-level errors.
+interface IMoonwellMarket is ICToken {
+    /// @notice Borrows `borrowAmount` of the underlying asset from the market.
+    /// @return 0 on success, otherwise a Compound error code.
+    function borrow(uint256 borrowAmount) external returns (uint256);
+
+    /// @notice Repays `repayAmount` of the outstanding borrow for the caller.
+    /// @dev Pass `type(uint256).max` to repay the entire balance.
+    /// @return 0 on success, otherwise a Compound error code.
+    function repayBorrow(uint256 repayAmount) external returns (uint256);
+
+    /// @notice Returns the borrow balance for `account` using the stored (non-accruing) index.
+    function borrowBalanceStored(address account) external view returns (uint256);
+}
+
+/// @notice Moonwell/Compound Comptroller — market entry.
+/// @dev `enterMarkets` is on the Comptroller, not on individual mTokens.
+interface IComptroller {
+    /// @notice Adds the caller into each listed mToken market.
+    /// @param mTokens Array of mToken addresses to enter.
+    /// @return Array of Compound error codes (0 = success per market).
+    function enterMarkets(address[] calldata mTokens) external returns (uint256[] memory);
+
+    /// @notice Returns the account's excess collateral or shortfall after the virtual borrow.
+    ///         Used by `_assertHealthy` as an authoritative Moonwell liquidation-status check.
+    /// @return err       0 on success; non-zero = Compound error code (treat as unhealthy).
+    /// @return liquidity Excess USDC collateral above requirements (18dp scaled).
+    /// @return shortfall USDC shortfall (18dp scaled); > 0 means the account is liquidatable.
+    function getAccountLiquidity(address account)
+        external
+        view
+        returns (uint256 err, uint256 liquidity, uint256 shortfall);
+}

--- a/src/leveraged-aero/sherwood/interfaces/IPriceRouter.sol
+++ b/src/leveraged-aero/sherwood/interfaces/IPriceRouter.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/// @notice A position the vault holds via a strategy, described in venue-native
+///         terms. The PriceRouter prices it; the strategy is NEVER trusted for
+///         *value* — only for pointing at the venue/position it controls. This
+///         is the "trust inversion" at the heart of the live-NAV redesign:
+///         the strategy reports quantities/locators, the vault prices them.
+struct Position {
+    address venue; // Moonwell mToken / Aerodrome pool / HyperCore precompile
+    bytes32 kind; // keccak256("MOONWELL_SUPPLY") | "AERODROME_LP" | "HL_PERP"
+    bytes ref; // venue-specific locator (empty for single-venue kinds like Moonwell)
+}
+
+/// @notice Per-`kind` pricing adapter. Reads the real quantity from `venue`
+///         (e.g. `mToken.balanceOf(holder)`) and prices it. Returns
+///         `(value, ok)` where `ok == false` means "not safely priceable right
+///         now" — unknown/foreign venue, stale oracle, deviation gate tripped.
+///         The router maps `ok == false` onto instant-ineligible (Lane B).
+interface IPriceAdapter {
+    function value(Position calldata p, address holder) external view returns (uint256 value, bool ok);
+}
+
+/// @notice Governance-owned router. Maps a position `kind` to its adapter,
+///         applies a realizability haircut, and enforces an instant size cap.
+///         `valuePosition` is the only function the vault consumes.
+interface IPriceRouter {
+    /// @param p      the position to price (venue + kind + locator)
+    /// @param holder the address whose position is read at the venue
+    /// @return value     haircut-adjusted value in the position's underlying
+    ///                   units, or 0 when not instantly priceable.
+    /// @return instantOK true only when the position is safely priceable now
+    ///                   AND within the instant cap. When false, `value` is 0
+    ///                   (G2 Option A) and the caller must use the async (Lane
+    ///                   B) settlement path.
+    function valuePosition(Position calldata p, address holder) external view returns (uint256 value, bool instantOK);
+
+    /// @notice Aggregate vault-facing valuation: reads a strategy's on-venue
+    ///         positions and prices them. Instant-eligible (`instantOK == true`)
+    ///         only when every position's kind is Lane-A-enabled and prices OK;
+    ///         otherwise `(0, false)` and the vault uses the async (Lane B) path.
+    function valueStrategy(address strategy) external view returns (uint256 value, bool instantOK);
+
+    /// @notice Register the adapter that prices positions of a given `kind`.
+    function registerAdapter(bytes32 kind, address adapter) external;
+
+    /// @notice Set the realizability haircut (bps) applied to a kind's raw
+    ///         value. Monotone-increasing: lowering requires a contract
+    ///         upgrade (which itself inherits the owner multisig's delay).
+    function setHaircutBps(bytes32 kind, uint16 bps) external;
+
+    /// @notice Set the maximum single-position value eligible for instant
+    ///         pricing. 0 means "no cap" (unlimited).
+    function setInstantCap(bytes32 kind, uint256 cap) external;
+
+    /// @notice Enable / disable the instant (Lane A) lane for a position kind.
+    function setLaneAEnabled(bytes32 kind, bool enabled) external;
+}

--- a/src/leveraged-aero/sherwood/interfaces/IProtocolConfig.sol
+++ b/src/leveraged-aero/sherwood/interfaces/IProtocolConfig.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+interface IProtocolConfig {
+    event ParameterChangeFinalized(bytes32 indexed paramKey, uint256 oldValue, uint256 newValue);
+    event ProtocolFeeRecipientSet(address indexed oldRecipient, address indexed newRecipient);
+    event GuardiansFeeRecipientSet(address indexed oldRecipient, address indexed newRecipient);
+
+    error InvalidProtocolFeeBps();
+    error InvalidGuardianFeeBps();
+    error InvalidProtocolFeeRecipient();
+    error InvalidGuardiansFeeRecipient();
+
+    function protocolFeeBps() external view returns (uint256);
+    function protocolFeeRecipient() external view returns (address);
+    function guardianFeeBps() external view returns (uint256);
+    function guardiansFeeRecipient() external view returns (address);
+}

--- a/src/leveraged-aero/sherwood/interfaces/ISlipstream.sol
+++ b/src/leveraged-aero/sherwood/interfaces/ISlipstream.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.28;
+
+// Source: aerodrome-finance/slipstream @ f8717faaae6e6717db3c8e3850149c01a79c0603 (main)
+//   INonfungiblePositionManager: contracts/periphery/interfaces/INonfungiblePositionManager.sol
+//   ICLPool state/constants:     contracts/core/interfaces/pool/ICLPoolState.sol
+//                                contracts/core/interfaces/pool/ICLPoolConstants.sol
+//                                contracts/core/interfaces/pool/ICLPoolDerivedState.sol
+//   ICLGauge:                    contracts/gauge/interfaces/ICLGauge.sol
+//
+// Key Slipstream deviation from Uniswap V3: pools/positions are keyed by
+// `tickSpacing` (not `fee`). MintParams carries `tickSpacing`; there is no
+// `fee` field in MintParams.
+
+/// @title Slipstream Non-fungible Position Manager
+/// @notice Minimal interface for managing CL positions as NFTs on Aerodrome Slipstream.
+interface INonfungiblePositionManager {
+    // -------------------------------------------------------------------------
+    // Parameter structs (Slipstream-specific — tickSpacing replaces fee)
+    // -------------------------------------------------------------------------
+
+    struct MintParams {
+        address token0;
+        address token1;
+        int24 tickSpacing;
+        int24 tickLower;
+        int24 tickUpper;
+        uint256 amount0Desired;
+        uint256 amount1Desired;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        address recipient;
+        uint256 deadline;
+        uint160 sqrtPriceX96;
+    }
+
+    struct IncreaseLiquidityParams {
+        uint256 tokenId;
+        uint256 amount0Desired;
+        uint256 amount1Desired;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        uint256 deadline;
+    }
+
+    struct DecreaseLiquidityParams {
+        uint256 tokenId;
+        uint128 liquidity;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        uint256 deadline;
+    }
+
+    struct CollectParams {
+        uint256 tokenId;
+        address recipient;
+        uint128 amount0Max;
+        uint128 amount1Max;
+    }
+
+    // -------------------------------------------------------------------------
+    // Position queries
+    // -------------------------------------------------------------------------
+
+    /// @notice Returns the full position state for `tokenId`.
+    /// @dev Return order matches the canonical Slipstream NPM (tickSpacing at index 4,
+    ///      not fee as in vanilla Uniswap V3).
+    function positions(uint256 tokenId)
+        external
+        view
+        returns (
+            uint96 nonce,
+            address operator,
+            address token0,
+            address token1,
+            int24 tickSpacing,
+            int24 tickLower,
+            int24 tickUpper,
+            uint128 liquidity,
+            uint256 feeGrowthInside0LastX128,
+            uint256 feeGrowthInside1LastX128,
+            uint128 tokensOwed0,
+            uint128 tokensOwed1
+        );
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    /// @notice Mints a new NFT position.
+    function mint(MintParams calldata params)
+        external
+        payable
+        returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
+
+    /// @notice Increases liquidity of an existing position.
+    function increaseLiquidity(IncreaseLiquidityParams calldata params)
+        external
+        payable
+        returns (uint128 liquidity, uint256 amount0, uint256 amount1);
+
+    /// @notice Decreases liquidity; tokens are credited to the position (call `collect` to receive them).
+    function decreaseLiquidity(DecreaseLiquidityParams calldata params)
+        external
+        payable
+        returns (uint256 amount0, uint256 amount1);
+
+    /// @notice Collects up to `amount0Max`/`amount1Max` of fees owed to the position.
+    function collect(CollectParams calldata params) external payable returns (uint256 amount0, uint256 amount1);
+
+    /// @notice Burns a fully-withdrawn (liquidity == 0, tokens owed == 0) position NFT.
+    function burn(uint256 tokenId) external payable;
+}
+
+/// @title Aerodrome Slipstream CL Pool
+/// @notice Minimal interface for price/TWAP queries needed by the strategy and valuation contracts.
+interface ICLPool {
+    /// @notice The current price and tick of the pool.
+    /// @return sqrtPriceX96          Current sqrt price as Q64.96.
+    /// @return tick                  Current tick (last crossed).
+    /// @return observationIndex      Index of the last written oracle observation.
+    /// @return observationCardinality Current max number of stored observations.
+    /// @return observationCardinalityNext Next max (pending resize).
+    /// @return unlocked              Reentrancy lock flag.
+    function slot0()
+        external
+        view
+        returns (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint16 observationIndex,
+            uint16 observationCardinality,
+            uint16 observationCardinalityNext,
+            bool unlocked
+        );
+
+    /// @notice Returns cumulative tick and per-liquidity accumulators for each entry in `secondsAgos`.
+    function observe(uint32[] calldata secondsAgos)
+        external
+        view
+        returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s);
+
+    /// @notice The tick spacing of the pool (Slipstream pools are identified by tickSpacing, not fee).
+    function tickSpacing() external view returns (int24);
+
+    /// @notice The swap & flash fee in pips (1e-6).
+    function fee() external view returns (uint24);
+
+    /// @notice The lower-sorted token of the pair.
+    function token0() external view returns (address);
+
+    /// @notice The higher-sorted token of the pair.
+    function token1() external view returns (address);
+
+    /// @notice The gauge address associated with this pool (set by the Voter on first epoch).
+    function gauge() external view returns (address);
+}
+
+/// @title Aerodrome Slipstream CL Gauge
+/// @notice Minimal interface for staking NFT positions and claiming AERO rewards.
+interface ICLGauge {
+    /// @notice Deposits (stakes) a CL position NFT into the gauge to receive emissions.
+    /// @param tokenId The NFT token ID to stake.
+    function deposit(uint256 tokenId) external;
+
+    /// @notice Withdraws (unstakes) a CL position NFT from the gauge.
+    /// @dev Outstanding rewards are collected automatically on withdrawal.
+    /// @param tokenId The NFT token ID to unstake.
+    function withdraw(uint256 tokenId) external;
+
+    /// @notice Claims accumulated rewards for a specific position.
+    /// @param tokenId The NFT token ID to claim rewards for.
+    function getReward(uint256 tokenId) external;
+
+    /// @notice The ERC-20 token distributed as gauge rewards (AERO on Base).
+    function rewardToken() external view returns (address);
+}
+
+/// @title Aerodrome Slipstream CL Swap Router
+/// @notice Minimal swap interface — tickSpacing-keyed (NOT fee-keyed, unlike Uniswap V3).
+interface ICLSwapRouter {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        int24 tickSpacing;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    struct ExactOutputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        int24 tickSpacing;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Swaps `amountIn` of one token for as much as possible of another.
+    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+
+    /// @notice Swaps as little as possible of `tokenIn` for exactly `amountOut` of `tokenOut`.
+    ///         Reverts if more than `amountInMaximum` of `tokenIn` would be required.
+    function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+}

--- a/src/leveraged-aero/sherwood/interfaces/IStrategy.sol
+++ b/src/leveraged-aero/sherwood/interfaces/IStrategy.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Position} from "./IPriceRouter.sol";
+
+/**
+ * @title IStrategy
+ * @notice Interface for strategy contracts called by the vault via batch calls.
+ *
+ *   The vault executes strategy actions as part of its batch:
+ *     Execute batch: [token.approve(strategy, amount), strategy.execute()]
+ *     Settle batch:  [strategy.settle()]
+ *
+ *   The strategy pulls tokens from the vault, deploys into DeFi protocols,
+ *   and returns tokens on settlement. It holds custody of position tokens
+ *   (e.g., mUSDC, LP tokens) during the strategy period.
+ *
+ *   Lifecycle:
+ *     1. Agent deploys strategy (cloned from template) with initial params
+ *     2. Agent includes strategy calls in the proposal batch
+ *     3. Vault calls execute() — strategy pulls tokens and deploys
+ *     4. Proposer can updateParams() to tune slippage/amounts before settlement
+ *     5. Vault calls settle() — strategy unwinds and returns tokens
+ */
+interface IStrategy {
+    /// @notice Initialize the strategy (called once, typically after cloning)
+    /// @param vault The vault this strategy operates on
+    /// @param proposer The agent who created this strategy
+    /// @param data ABI-encoded strategy-specific initialization parameters
+    function initialize(address vault, address proposer, bytes calldata data) external;
+
+    /// @notice Execute the strategy — pull tokens from vault, deploy into DeFi
+    /// @dev Only callable by the vault (via batch call)
+    function execute() external;
+
+    /// @notice Settle the strategy — unwind positions, return tokens to vault
+    /// @dev Only callable by the vault (via batch call)
+    function settle() external;
+
+    /// @notice Update tunable parameters (only proposer, only while executed)
+    /// @param data ABI-encoded parameter updates (strategy-specific)
+    function updateParams(bytes calldata data) external;
+
+    /// @notice The vault this strategy operates on
+    function vault() external view returns (address);
+
+    /// @notice The agent who proposed this strategy
+    function proposer() external view returns (address);
+
+    /// @notice Whether the strategy has been executed
+    function executed() external view returns (bool);
+
+    /// @notice Human-readable name of the strategy template
+    function name() external view returns (string memory);
+
+    /// @notice The strategy's on-venue positions, for vault-side pricing (Lane A).
+    /// @dev    Reports WHERE/WHAT the strategy holds (venue + kind + locator) —
+    ///         never a self-reported value. The vault prices these via the
+    ///         PriceRouter; the strategy is never trusted for value. The default
+    ///         (BaseStrategy) returns an empty array (queue-only / Lane B);
+    ///         strategies with on-chain-priceable positions override it.
+    function positions() external view returns (Position[] memory);
+
+    /// @notice true ⇒ the strategy self-manages fees; the governor skips settle-fee
+    ///         distribution for its proposals.
+    function selfManagesFees() external view returns (bool);
+}

--- a/src/leveraged-aero/sherwood/interfaces/ISyndicateFactory.sol
+++ b/src/leveraged-aero/sherwood/interfaces/ISyndicateFactory.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {ISyndicateGovernor} from "./ISyndicateGovernor.sol";
+
+interface ISyndicateFactory {
+    // ── Events (Task 26) ──
+    event OwnerRotated(address indexed vault, address indexed newOwner);
+    event WithdrawalQueueDeployed(address indexed vault, address indexed queue);
+
+    // ── Errors (Task 26) ──
+    error VaultStillStaked();
+
+    // ── Errors (V-H3) ──
+    error VaultImplMismatch();
+
+    // ── Errors (V-M7) ──
+    error InvalidSyndicateConfig();
+
+    // ── Views ──
+    function governorOf(address vault) external view returns (address);
+    function beacon() external view returns (address);
+    function protocolConfig() external view returns (address);
+    function priceRouter() external view returns (address);
+    function vaultImpl() external view returns (address);
+    function vaultToSyndicate(address vault) external view returns (uint256);
+    function guardianRegistry() external view returns (address);
+
+    // ── Admin ──
+    function rotateOwner(address vault, address newOwner) external;
+    function setParamsOverride(address vault, ISyndicateGovernor.GovernorParams calldata params) external;
+}

--- a/src/leveraged-aero/sherwood/interfaces/ISyndicateGovernor.sol
+++ b/src/leveraged-aero/sherwood/interfaces/ISyndicateGovernor.sol
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {BatchExecutorLib} from "../BatchExecutorLib.sol";
+
+interface ISyndicateGovernor {
+    // ── Enums ──
+
+    enum ProposalState {
+        Draft, // collaborative proposal awaiting co-proposer consent
+        Pending, // voting active
+        GuardianReview, // voting passed, guardian review window active (Task 25)
+        Approved, // review ended without block quorum
+        Rejected, // voting ended, veto threshold reached OR guardians blocked
+        Expired, // execution window passed without execution
+        Executed, // strategy is live
+        Settled, // P&L calculated, fee distributed
+        Cancelled // proposer or owner cancelled
+    }
+
+    enum VoteType {
+        For,
+        Against,
+        Abstain
+    }
+
+    // ── Structs ──
+
+    struct GovernorParams {
+        uint256 votingPeriod;
+        uint256 executionWindow;
+        uint256 vetoThresholdBps;
+        uint256 maxPerformanceFeeBps;
+        uint256 cooldownPeriod;
+        uint256 collaborationWindow;
+        uint256 maxCoProposers;
+        uint256 minStrategyDuration;
+        uint256 maxStrategyDuration;
+    }
+
+    struct StrategyProposal {
+        uint256 id;
+        address proposer;
+        address vault;
+        /// @notice Address of the strategy contract for this proposal. In the V2
+        ///         live-NAV design the vault reads the strategy's on-venue
+        ///         positions and prices them vault-side (via the PriceRouter) —
+        ///         the strategy is never trusted for value. Set at propose time;
+        ///         immutable thereafter. Pass `address(0)` for a queue-only
+        ///         proposal (no instant live-NAV lane).
+        address strategy;
+        string metadataURI;
+        /// @notice Agent performance fee (bps), snapshotted from the vault's
+        ///         `agentFeeBps()` at propose time so it is immutable for this
+        ///         proposal — an owner change after propose cannot alter what
+        ///         voters approved. Clamped to `maxPerformanceFeeBps` at settle.
+        uint256 performanceFeeBps;
+        uint256 strategyDuration;
+        uint256 votesFor;
+        uint256 votesAgainst;
+        uint256 votesAbstain;
+        uint256 snapshotTimestamp;
+        uint256 voteEnd;
+        uint256 reviewEnd; // guardian review window end (Task 25); zero for collaborative drafts
+        uint256 executeBy;
+        uint256 executedAt;
+        ProposalState state;
+        /// @dev G-H6: vetoThresholdBps snapshot taken at Draft -> Pending.
+        ///      Prevents mid-vote timelock finalizes from retroactively
+        ///      moving the rejection threshold.
+        uint256 vetoThresholdBps;
+        // ── Fee snapshot (read from ProtocolConfig at propose time) ──
+        uint256 snapshotProtocolFeeBps;
+        address snapshotProtocolFeeRecipient;
+        uint256 snapshotGuardianFeeBps;
+        address snapshotGuardiansFeeRecipient;
+        /// @notice `IStrategy.selfManagesFees()` snapshotted at propose time (like
+        ///         performanceFeeBps). Read from storage at settle so a non-pure
+        ///         implementation can't flip it between review and settle (TOCTOU),
+        ///         and a broken/EOA strategy can't brick settle via a revert.
+        bool selfManagesFees;
+    }
+
+    struct CoProposer {
+        address agent;
+        uint256 splitBps;
+    }
+
+    // Owner-multisig governs parameter changes via its own delay.
+
+    // ── Errors ──
+
+    error VaultNotRegistered();
+    error VaultAlreadyRegistered();
+    error NotRegisteredAgent();
+    error StrategyDurationTooLong();
+    error StrategyDurationTooShort();
+    error EmptyExecuteCalls();
+    error EmptySettlementCalls();
+    error NotWithinVotingPeriod();
+    error NoVotingPower();
+    error AlreadyVoted();
+    error ProposalNotFound();
+    error ProposalNotApproved();
+    error ExecutionWindowExpired();
+    error StrategyAlreadyActive();
+    error CooldownNotElapsed();
+    error ProposalNotExecuted();
+    error ProposalNotCancellable();
+    error NotProposer();
+    error InvalidVotingPeriod();
+    error InvalidExecutionWindow();
+    error InvalidVetoThresholdBps();
+    error InvalidMaxPerformanceFeeBps();
+    error InvalidStrategyDurationBounds();
+    error InvalidCooldownPeriod();
+    error InvalidVault();
+    error ZeroAddress();
+    error NotVaultOwner();
+    error NotFactory();
+    error StrategyDurationNotElapsed();
+    error InvalidProtocolFeeBps();
+    error InvalidProtocolFeeRecipient();
+    /// @notice G-M1: Revert if a vault already has a non-terminal proposal
+    ///         (Draft / Pending / GuardianReview / Approved / Executed) when
+    ///         a new propose() or approveCollaboration Draft->Pending is
+    ///         attempted. Prevents duplicate lifecycles that would race the
+    ///         same vault state.
+    error VaultHasOpenProposal();
+    /// @notice G-M11: Revert if `metadataURI.length` exceeds
+    ///         MAX_METADATA_URI_LENGTH. Bounds a calldata-unbounded string
+    ///         that would otherwise let a proposer grief gas / event storage.
+    error MetadataURITooLong();
+    /// @notice G-M2/G-M6: Revert if `executeCalls.length` or
+    ///         `settlementCalls.length` exceeds MAX_CALLS_PER_PROPOSAL. Bounds
+    ///         calldata-unbounded arrays that otherwise let a proposer grief
+    ///         gas when the batch is executed.
+    error TooManyCalls();
+
+    // ── Guardian-review emergency settle errors ──
+    error OwnerBondInsufficient();
+    error EmergencySettleBlocked();
+    error EmergencyNotProposed();
+
+    // ── Guardian-review lifecycle errors ──
+    error NotInGuardianReview();
+    error EmergencySettleNotReady();
+    error RegistryNotSet();
+
+    // ── Collaborative proposal errors ──
+    error NotCoProposer();
+    error CollaborationExpired();
+    error AlreadyApproved();
+    error InvalidSplits();
+    error TooManyCoProposers();
+    error SplitTooLow();
+    error LeadSplitTooLow();
+    error DuplicateCoProposer();
+    error NotDraftState();
+    error InvalidCollaborationWindow();
+    error NotAuthorized();
+    error InvalidMaxCoProposers();
+    error Reentrancy();
+    /// @notice Revert if lead tries to cancel a Draft once all-but-one
+    ///         co-proposer has approved (G-H2). Prevents front-running the
+    ///         final approve tx.
+    error CancelNotAllowedNearQuorum();
+    /// @notice Sherlock #9 — `rejectCollaboration` is gated to the lead
+    ///         proposer; a co-proposer who disagrees must withhold approval
+    ///         (Draft lapses naturally at the collaboration window).
+    error NotLeadProposer();
+    /// @notice Revert when `getVoteWeight` is called on a Draft proposal whose
+    ///         snapshotTimestamp hasn't been stamped yet (G-H3). The prior
+    ///         silent zero return confused callers who assumed no power.
+    error ProposalInDraft();
+    /// @notice Revert if an active co-proposer's rounded share is 0 (G-C7).
+    /// @dev Prevents silent routing of zero-rounded shares to the lead.
+    error CoProposerShareUnderflow();
+
+    error InvalidGuardianFeeBps();
+    /// @notice Raised when `guardianFeeBps > 0` would coexist with an unset
+    ///         `guardiansFeeRecipient` — at initialize, on `setGuardianFeeBps`
+    ///         raising the fee, or on `setGuardiansFeeRecipient(address(0))`
+    ///         while the fee is on. Mirrors the protocol-fee recipient coupling.
+    error InvalidGuardiansFeeRecipient();
+    error ParamsFrozenDuringProposal();
+
+    // ── Events ──
+
+    event ProposalCreated(
+        uint256 indexed proposalId,
+        address indexed proposer,
+        address indexed vault,
+        uint256 performanceFeeBps,
+        uint256 strategyDuration,
+        uint256 executeCallCount,
+        uint256 settlementCallCount,
+        string metadataURI
+    );
+
+    /// @notice Emitted whenever the agent performance fee is clamped to
+    ///         `maxPerformanceFeeBps` — at propose (the `agentFeeBps` snapshot
+    ///         exceeds the cap) and again at settle if the cap was lowered
+    ///         in-flight. Surfaces that the realized fee is the clamped value,
+    ///         not the owner's higher intended rate, so voters and indexers can
+    ///         detect the divergence. `snapshotted`/`clamped` are indexed (cheap
+    ///         topics, no memory encoding) so the dual emit stays under budget.
+    event FeeClamped(uint256 indexed proposalId, uint256 indexed snapshotted, uint256 indexed clamped);
+
+    event VoteCast(uint256 indexed proposalId, address indexed voter, VoteType support, uint256 weight);
+
+    event ProposalExecuted(uint256 indexed proposalId, address indexed vault, uint256 capitalSnapshot);
+
+    event ProposalSettled(
+        uint256 indexed proposalId, address indexed vault, int256 pnl, uint256 performanceFee, uint256 duration
+    );
+
+    event ProposalCancelled(uint256 indexed proposalId, address indexed cancelledBy);
+
+    event ProposalVetoed(uint256 indexed proposalId, address indexed vetoedBy);
+
+    event EmergencySettled(uint256 indexed proposalId, address indexed vault, int256 pnl, uint256 customCallCount);
+
+    // PR #351 review #1: GuardianRegistrySet event removed alongside the
+    // `setGuardianRegistry` setter. Repointing mid-proposal silently
+    // auto-Approved blocked reviews — same hazard class as V-H2. The
+    // registry slot is now write-only at `initialize`; migration happens
+    // through a governor UUPS upgrade.
+
+    // ── Fee-distribution resilience events (W-1) ──
+    /// @notice Emitted when a per-recipient fee transfer in `_distributeFees` /
+    ///         `_distributeAgentFee` reverts (e.g., USDC blacklist). The amount
+    ///         is escrowed against `(vault, recipient, token)` in storage (see
+    ///         `unclaimedFees`). `reason` dropped from the event to conserve
+    ///         governor bytecode — the revert data is visible in the tx trace
+    ///         if a debugger needs the underlying cause.
+    event FeeTransferFailed(address indexed recipient, address indexed token, uint256 amount);
+    /// @notice Emitted when a recipient pulls previously escrowed fees via
+    ///         `claimUnclaimedFees`. The originating vault is the caller's
+    ///         argument to `claimUnclaimedFees` (traceable via `tx.input`).
+    event FeeClaimed(address indexed recipient, address indexed token, uint256 amount);
+
+    // ── Guardian-review emergency settle events ──
+    event EmergencySettleProposed(
+        uint256 indexed proposalId, address indexed owner, bytes32 callsHash, uint64 reviewEnd
+    );
+    event EmergencySettleCancelled(uint256 indexed proposalId, address indexed owner);
+    event EmergencySettleFinalized(uint256 indexed proposalId, int256 pnl);
+
+    // ── Guardian-review lifecycle events ──
+    event GuardianReviewResolved(uint256 indexed proposalId, bool blocked);
+
+    event VaultAdded(address indexed vault);
+    event VaultRemoved(address indexed vault);
+    // All parameter updates (votingPeriod / executionWindow / vetoThresholdBps /
+    // maxPerformanceFeeBps / minStrategyDuration / maxStrategyDuration /
+    // cooldownPeriod / collaborationWindow / maxCoProposers / protocolFeeBps /
+    // protocolFeeRecipient / factory) are surfaced via the uniform
+    // `ParameterChangeFinalized(paramKey, oldValue, newValue)` event. Off-chain
+    // consumers filter by `keccak256(name)` rather than per-param topics.
+
+    // ── Collaborative proposal events ──
+    event CollaborativeProposalCreated(
+        uint256 indexed proposalId, address indexed leadProposer, address[] coProposers, uint256[] splitsBps
+    );
+    event CollaborationApproved(uint256 indexed proposalId, address indexed agent);
+    event CollaborationRejected(uint256 indexed proposalId, address indexed agent);
+    event CollaborationTransitionedToPending(uint256 indexed proposalId);
+    event CollaborationDeadlineExpired(uint256 indexed proposalId);
+
+    // ── Parameter change event (owner-instant, no queue/cancel) ──
+    event ParameterChangeFinalized(bytes32 indexed paramKey, uint256 oldValue, uint256 newValue);
+
+    /// @notice Emitted in `_distributeFees` when `guardianFeeBps > 0`.
+    ///         Guardian fee is carved from gross PnL and transferred to
+    ///         `recipient` (the team `guardiansFeeRecipient` multisig). This is
+    ///         the off-chain Merkl bot's sole attribution signal — it swaps the
+    ///         collected asset to WOOD and airdrops to approvers/delegators
+    ///         weekly, reading the per-proposal approver split from
+    ///         `GuardianRegistry.getApproverWeights`.
+    /// @dev `settledAt` is intentionally NOT a field — it equals the emitting
+    ///      block's timestamp, which the off-chain bot reads from the log
+    ///      metadata. Omitted to keep the EIP-170-capped governor under budget.
+    event GuardianFeeAccrued(
+        uint256 indexed proposalId, address indexed asset, address indexed recipient, uint256 amount
+    );
+
+    // ── Functions ──
+
+    /// @notice Submit a strategy proposal for `vault`. The optional `strategy`
+    ///         parameter is the contract that holds the proposal's on-venue
+    ///         positions; the vault prices those positions vault-side (V2
+    ///         live-NAV redesign — the strategy is never trusted for value).
+    ///         Pass `address(0)` for a queue-only proposal (no instant lane).
+    /// @dev    The strategy is set immutably at propose time — voters approve
+    ///         based on this address, and there is no later bind / rebind path.
+    function propose(
+        address vault,
+        address strategy,
+        string calldata metadataURI,
+        uint256 strategyDuration,
+        BatchExecutorLib.Call[] calldata executeCalls,
+        BatchExecutorLib.Call[] calldata settlementCalls,
+        CoProposer[] calldata coProposers
+    ) external returns (uint256 proposalId);
+
+    function vote(uint256 proposalId, VoteType support) external;
+
+    function executeProposal(uint256 proposalId) external;
+
+    function settleProposal(uint256 proposalId) external;
+
+    // ── Guardian-review emergency settle lifecycle ──
+    // Owner-driven paths: `unstick` (pre-committed calls) or
+    // `emergencySettleWithCalls` + `finalizeEmergencySettle` (guardian-gated).
+    function unstick(uint256 proposalId) external;
+    function emergencySettleWithCalls(uint256 proposalId, BatchExecutorLib.Call[] calldata calls) external;
+    function cancelEmergencySettle(uint256 proposalId) external;
+    function finalizeEmergencySettle(uint256 proposalId) external;
+
+    function cancelProposal(uint256 proposalId) external;
+
+    function emergencyCancel(uint256 proposalId) external;
+
+    /// @notice Vault owner vetoes a Pending proposal only, setting it to Rejected.
+    /// @dev Narrowed so guardians own post-review blocks — once a proposal
+    ///      has passed voting and entered `GuardianReview`, the guardian
+    ///      cohort and execution window drive the outcome rather than
+    ///      unilateral owner action. Use `emergencyCancel` for Draft/Pending.
+    function vetoProposal(uint256 proposalId) external;
+
+    // ── Collaborative proposal functions ──
+
+    function approveCollaboration(uint256 proposalId) external;
+    function rejectCollaboration(uint256 proposalId) external;
+
+    // ── Setters (owner-instant; owner is a multisig with external delay) ──
+
+    function setVotingPeriod(uint256 newVotingPeriod) external;
+    function setExecutionWindow(uint256 newExecutionWindow) external;
+    function setVetoThresholdBps(uint256 newVetoThresholdBps) external;
+    function setMaxPerformanceFeeBps(uint256 newMaxPerformanceFeeBps) external;
+    function setMinStrategyDuration(uint256 newMinStrategyDuration) external;
+    function setMaxStrategyDuration(uint256 newMaxStrategyDuration) external;
+    function setCooldownPeriod(uint256 newCooldownPeriod) external;
+    function setCollaborationWindow(uint256 newCollaborationWindow) external;
+    function setMaxCoProposers(uint256 newMaxCoProposers) external;
+    function setProtocolConfig(address newConfig) external;
+
+    // ── Init ──
+    /// @notice Initialize a freshly deployed per-vault governor proxy.
+    ///         Called once by the factory inside the `BeaconProxy` constructor.
+    function initialize(
+        address vault_,
+        address guardianRegistry_,
+        address protocolConfig_,
+        address factory_,
+        GovernorParams calldata params_
+    ) external;
+
+    // ── Factory-only ──
+    function forceSetParams(GovernorParams calldata params) external;
+
+    // ── Views ──
+
+    function getProposal(uint256 proposalId) external view returns (StrategyProposal memory);
+    function getProposalState(uint256 proposalId) external view returns (ProposalState);
+    function getExecuteCalls(uint256 proposalId) external view returns (BatchExecutorLib.Call[] memory);
+    function getSettlementCalls(uint256 proposalId) external view returns (BatchExecutorLib.Call[] memory);
+    function getVoteWeight(uint256 proposalId, address voter) external view returns (uint256);
+    function hasVoted(uint256 proposalId, address voter) external view returns (bool);
+    function proposalCount() external view returns (uint256);
+    function getGovernorParams() external view returns (GovernorParams memory);
+    function getActiveProposal() external view returns (uint256);
+    /// @notice Count of proposals for this vault in any non-terminal state
+    ///         (Pending / GuardianReview / Approved / Executed).
+    /// @dev Incremented on Draft -> Pending, decremented on the terminal edge
+    ///      (Rejected / Expired / Cancelled / Settled). Consumed by
+    ///      `GuardianRegistry.requestUnstakeOwner` alongside `getActiveProposal`
+    ///      to block rage-quit while any proposal binds the vault — the OR
+    ///      check is belt-and-braces so stale-cache transitions can't slip
+    ///      through.
+    function openProposalCount() external view returns (uint256);
+    function getCooldownEnd() external view returns (uint256);
+    function getCapitalSnapshot(uint256 proposalId) external view returns (uint256);
+    function getCoProposers(uint256 proposalId) external view returns (CoProposer[] memory);
+    function vault() external view returns (address);
+    function protocolConfig() external view returns (address);
+
+    /// @notice Address of the guardian registry (zero if not yet wired).
+    function guardianRegistry() external view returns (address);
+
+    // ── Fee-escrow (W-1) ──
+
+    /// @notice Pull previously escrowed fees after the blacklist / revert
+    ///         condition that caused the original settlement transfer has been
+    ///         lifted. Escrow is keyed by origin vault — a recipient can only
+    ///         claim against the specific vault whose fee transfer failed.
+    /// @param vault The vault that originally held the fee asset.
+    /// @param token The ERC-20 address the fee was denominated in.
+    function claimUnclaimedFees(address vault, address token) external;
+
+    /// @notice Amount of fees escrowed against `(vault, recipient)` in `token`
+    ///         awaiting a retryable claim. Zero for `(vault, recipient, token)`
+    ///         tuples that never had a failed transfer.
+    function unclaimedFees(address vault, address recipient, address token) external view returns (uint256);
+}

--- a/src/leveraged-aero/sherwood/interfaces/ISyndicateGovernor.sol
+++ b/src/leveraged-aero/sherwood/interfaces/ISyndicateGovernor.sol
@@ -16,6 +16,7 @@ interface ISyndicateGovernor {
         Executed, // strategy is live
         Settled, // P&L calculated, fee distributed
         Cancelled // proposer or owner cancelled
+
     }
 
     enum VoteType {

--- a/src/leveraged-aero/sherwood/interfaces/ISyndicateVault.sol
+++ b/src/leveraged-aero/sherwood/interfaces/ISyndicateVault.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {BatchExecutorLib} from "../BatchExecutorLib.sol";
+
+interface ISyndicateVault {
+    // ── Errors ──
+    error InvalidOwner();
+    error InvalidExecutorImpl();
+    error NotActiveAgent();
+    error SimulationFailed();
+    error InvalidDepositor();
+    error DepositorAlreadyApproved();
+    error DepositorNotApproved();
+    error NotApprovedDepositor();
+    error AgentAlreadyRegistered();
+    error AgentNotActive();
+    /// @notice PR #324 review R4 — registering this agent would push
+    ///         `_agentSet.length()` past `MAX_AGENTS_PER_VAULT`. Bound for the
+    ///         `rotateOwnership` deactivation loop.
+    error AgentCapExceeded();
+    error InvalidAgentRegistry();
+    error NotAgentOwner();
+    error NotGovernor();
+    error RedemptionsLocked();
+    error DepositsLocked();
+    error InvalidAgentAddress();
+    error TransferFailed();
+    error ZeroAddress();
+    error CannotRescueAsset();
+    error NotFactory();
+    error GovernorNotSet();
+    error ExecutorCodehashMismatch();
+    error InvalidAsset();
+    /// @notice `transferPerformanceFee` was called with an `amount` exceeding
+    ///         the vault's balance of `asset_`.
+    error AmountExceedsBalance();
+    error WithdrawalQueueNotSet();
+    error WithdrawalQueueAlreadySet();
+    error InsufficientShares();
+    error RedemptionsNotLocked();
+    error QueueReserveBreached();
+    error NotQueue();
+    error ZeroAssets();
+    error SharesLocked();
+    error NotActiveStrategy();
+    /// @notice `setAgentFeeBps` was called with `bps > MAX_AGENT_FEE_BPS`.
+    error AgentFeeTooHigh();
+
+    // ── Init Params ──
+    struct InitParams {
+        address asset;
+        string name;
+        string symbol;
+        address owner;
+        address executorImpl;
+        bool openDeposits;
+        address agentRegistry;
+        uint256 managementFeeBps;
+    }
+
+    // ── Per-Agent Config ──
+    struct AgentConfig {
+        uint256 agentId; // ERC-8004 identity token ID
+        address agentAddress; // Agent wallet address
+        bool active;
+    }
+
+    // ── Depositor Whitelist ──
+    function approveDepositor(address depositor) external;
+    function removeDepositor(address depositor) external;
+    function approveDepositors(address[] calldata depositors) external;
+    function isApprovedDepositor(address depositor) external view returns (bool);
+    function approvedDepositorsPaginated(uint256 offset, uint256 limit) external view returns (address[] memory);
+    function setOpenDeposits(bool open) external;
+    function openDeposits() external view returns (bool);
+
+    // ── Views ──
+    // `getAgentConfig` dropped to fit MAX_AGENTS_PER_VAULT cap under
+    // EIP-170. Use `isAgent(addr)` for the auth check.
+    function getAgentCount() external view returns (uint256);
+    function agentsPaginated(uint256 offset, uint256 limit) external view returns (address[] memory);
+    function isAgent(address agentAddress) external view returns (bool);
+
+    // ── Factory ──
+    function factory() external view returns (address);
+
+    // ── Governor ──
+    function executeGovernorBatch(BatchExecutorLib.Call[] calldata calls) external;
+    function owner() external view returns (address);
+    function transferPerformanceFee(address asset, address to, uint256 amount) external;
+    function governor() external view returns (address);
+    function redemptionsLocked() external view returns (bool);
+    function managementFeeBps() external view returns (uint256);
+    /// @notice Vault-owner-set agent performance fee (basis points). Defaults
+    ///         to 5% (500) at vault creation. Snapshotted onto a proposal at
+    ///         propose time and clamped to `maxPerformanceFeeBps` at settlement.
+    function agentFeeBps() external view returns (uint256);
+    /// @notice Set the agent performance fee (owner only). Capped at
+    ///         `MAX_AGENT_FEE_BPS` (15%). Reverts with `AgentFeeTooHigh` above.
+    function setAgentFeeBps(uint256 bps) external;
+    /// @notice Convenience view that resolves the active strategy through the
+    ///         governor (`getProposal(activePid).strategy`). Returns
+    ///         `address(0)` when no proposal is active or when the active
+    ///         proposal opted out of live NAV.
+    function activeStrategyAdapter() external view returns (address);
+
+    // ── Async Withdrawal Queue ──
+    function setWithdrawalQueue(address queue) external; // factory-only, set-once
+    function withdrawalQueue() external view returns (address);
+    function requestRedeem(uint256 shares, address owner_) external returns (uint256 requestId);
+    function requestDeposit(uint256 assets, address receiver) external returns (uint256 requestId);
+    function pendingQueueShares() external view returns (uint256);
+    function reservedQueueAssets() external view returns (uint256);
+    function settleRedeem(uint256 shares, uint256 assets, address to) external; // queue-only
+    function settleDeposit(uint256 shares, address to) external; // queue-only
+    function onProposalSettled(uint256 proposalId) external; // governor-only
+    function strategyMint(address to, uint256 shares) external; // active-strategy-only
+    function strategyBurn(uint256 shares) external; // active-strategy-only
+
+    // ── Rescue ──
+    function rescueEth(address payable to, uint256 amount) external;
+    function rescueERC20(address token, address to, uint256 amount) external;
+    function rescueERC721(address token, uint256 tokenId, address to) external;
+
+    // ── Admin (syndicate creator) ──
+    function registerAgent(uint256 agentId, address agentAddress) external;
+    function removeAgent(address agentAddress) external;
+    function pause() external;
+    function unpause() external;
+
+    // ── Events ──
+    event AgentRegistered(uint256 indexed agentId, address indexed agentAddress);
+    event AgentRemoved(address indexed agentAddress);
+    event DepositorApproved(address indexed depositor);
+    event DepositorRemoved(address indexed depositor);
+    event OpenDepositsUpdated(bool open);
+    /// @notice Emitted when the vault owner updates the agent performance fee.
+    event AgentFeeUpdated(uint256 bps);
+    /// @notice Emitted whenever the governor drives a strategy batch into the
+    ///         vault via `executeGovernorBatch`. `callCount` is the number of
+    ///         sub-calls fanned out by `BatchExecutorLib.executeBatch`.
+    /// @dev V-M9: subgraphs and monitors previously had to observe strategy
+    ///      execution indirectly via downstream protocol events (Moonwell /
+    ///      Aerodrome / Uniswap). Emitting here gives a first-class
+    ///      vault-level execution marker.
+    event GovernorBatchExecuted(address indexed governor, uint256 callCount);
+    event WithdrawalQueueSet(address indexed queue);
+    event RedeemRequested(uint256 indexed requestId, address indexed owner, uint256 shares);
+    event DepositRequested(uint256 indexed requestId, address indexed receiver, uint256 assets);
+}

--- a/src/leveraged-aero/sherwood/libraries/ChainlinkReader.sol
+++ b/src/leveraged-aero/sherwood/libraries/ChainlinkReader.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {IAggregatorV3} from "../interfaces/IAggregatorV3.sol";
+
+/// @notice Fail-closed Chainlink USD reads for Base: staleness + round-completeness
+///         + L2 sequencer-uptime + grace period. (Hardens Mamo SlippagePriceChecker._readFeed,
+///         which checks staleness only.)
+library ChainlinkReader {
+    error StaleOracle();
+    error SequencerDown();
+    error GracePeriodNotOver();
+
+    function readUsd(address feed, address sequencerUptimeFeed, uint256 maxDelay, uint256 gracePeriod)
+        internal
+        view
+        returns (uint256 price, uint8 decimals)
+    {
+        (, int256 up, uint256 seqStartedAt,,) = IAggregatorV3(sequencerUptimeFeed).latestRoundData();
+        if (up != 0) revert SequencerDown();
+        // `seqStartedAt == 0` is an uninitialized / invalid sequencer round — fail closed (mirrors
+        // the price feed's `startedAt == 0` guard below) instead of treating round-0 as a valid
+        // restart time that `block.timestamp - 0 > gracePeriod` would otherwise wave through as a
+        // healthy sequencer. A future seqStartedAt (misconfigured feed / L2 clock skew) means the
+        // sequencer (re)started "in the future" → grace definitely not over. Guard the subtraction
+        // so a caller catching the named error gets GracePeriodNotOver, not an underflow panic.
+        if (seqStartedAt == 0 || seqStartedAt > block.timestamp || block.timestamp - seqStartedAt <= gracePeriod) {
+            revert GracePeriodNotOver();
+        }
+
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            IAggregatorV3(feed).latestRoundData();
+        if (answer <= 0) revert StaleOracle();
+        if (answeredInRound < roundId) revert StaleOracle();
+        if (startedAt == 0) revert StaleOracle();
+        // A future updatedAt (feed clock ahead of a lagging L2 block.timestamp, e.g. a Tenderly
+        // vnet) is the freshest possible answer → age 0; never underflow.
+        uint256 age = block.timestamp > updatedAt ? block.timestamp - updatedAt : 0;
+        if (age > maxDelay) revert StaleOracle();
+
+        price = uint256(answer);
+        decimals = IAggregatorV3(feed).decimals();
+    }
+}

--- a/src/leveraged-aero/sherwood/libraries/LiquidityAmounts.sol
+++ b/src/leveraged-aero/sherwood/libraries/LiquidityAmounts.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.28;
+
+// Vendored from Uniswap/v3-periphery (LiquidityAmounts; math bit-identical to velodrome-finance/slipstream),
+// adapted to 0.8.28. Behavior validated by the ground-truth vectors in test/UniswapMath.t.sol.
+//
+// Dependency substitutions (avoids vendoring extra files):
+//   FullMath.mulDiv(a,b,d)  ->  Math.mulDiv(a,b,d)  (OpenZeppelin; semantically identical 512-bit mul-div)
+//   FixedPoint96.Q96        ->  0x1000000000000000000000000  (2**96 inline constant)
+//   FixedPoint96.RESOLUTION ->  96  (inline constant)
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+/// @title Liquidity amount functions
+/// @notice Provides functions for computing liquidity amounts from token amounts and prices
+library LiquidityAmounts {
+    // 2**96, the Q64.96 fixed-point scaling factor used by Uniswap V3 / Aerodrome Slipstream sqrt prices
+    uint256 private constant Q96 = 0x1000000000000000000000000;
+
+    /// @notice Downcasts uint256 to uint128
+    /// @param x The uint256 to be downcasted
+    /// @return y The passed value, downcasted to uint128
+    function toUint128(uint256 x) private pure returns (uint128 y) {
+        require((y = uint128(x)) == x);
+    }
+
+    /// @notice Computes the amount of liquidity received for a given amount of token0 and price range
+    /// @dev Calculates amount0 * (sqrt(upper) * sqrt(lower)) / (sqrt(upper) - sqrt(lower))
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param amount0 The amount0 being sent in
+    /// @return liquidity The amount of returned liquidity
+    function getLiquidityForAmount0(uint160 sqrtRatioAX96, uint160 sqrtRatioBX96, uint256 amount0)
+        internal
+        pure
+        returns (uint128 liquidity)
+    {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+        uint256 intermediate = Math.mulDiv(sqrtRatioAX96, sqrtRatioBX96, Q96);
+        return toUint128(Math.mulDiv(amount0, intermediate, sqrtRatioBX96 - sqrtRatioAX96));
+    }
+
+    /// @notice Computes the amount of liquidity received for a given amount of token1 and price range
+    /// @dev Calculates amount1 / (sqrt(upper) - sqrt(lower))
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param amount1 The amount1 being sent in
+    /// @return liquidity The amount of returned liquidity
+    function getLiquidityForAmount1(uint160 sqrtRatioAX96, uint160 sqrtRatioBX96, uint256 amount1)
+        internal
+        pure
+        returns (uint128 liquidity)
+    {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+        return toUint128(Math.mulDiv(amount1, Q96, sqrtRatioBX96 - sqrtRatioAX96));
+    }
+
+    /// @notice Computes the maximum amount of liquidity received for a given amount of token0, token1, the current
+    /// pool prices and the prices at the tick boundaries.
+    /// @param sqrtRatioX96 A sqrt price representing the current pool prices
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param amount0 The amount of token0 being sent in
+    /// @param amount1 The amount of token1 being sent in
+    /// @return liquidity The maximum amount of liquidity received
+    function getLiquidityForAmounts(
+        uint160 sqrtRatioX96,
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint256 amount0,
+        uint256 amount1
+    ) internal pure returns (uint128 liquidity) {
+        if (sqrtRatioAX96 > sqrtRatioBX96) {
+            (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+        }
+
+        if (sqrtRatioX96 <= sqrtRatioAX96) {
+            liquidity = getLiquidityForAmount0(sqrtRatioAX96, sqrtRatioBX96, amount0);
+        } else if (sqrtRatioX96 < sqrtRatioBX96) {
+            uint128 liquidity0 = getLiquidityForAmount0(sqrtRatioX96, sqrtRatioBX96, amount0);
+            uint128 liquidity1 = getLiquidityForAmount1(sqrtRatioAX96, sqrtRatioX96, amount1);
+
+            liquidity = liquidity0 < liquidity1 ? liquidity0 : liquidity1;
+        } else {
+            liquidity = getLiquidityForAmount1(sqrtRatioAX96, sqrtRatioBX96, amount1);
+        }
+    }
+
+    /// @notice Computes the amount of token0 for a given amount of liquidity and a price range
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param liquidity The liquidity being valued
+    /// @return amount0 The amount of token0
+    function getAmount0ForLiquidity(uint160 sqrtRatioAX96, uint160 sqrtRatioBX96, uint128 liquidity)
+        internal
+        pure
+        returns (uint256 amount0)
+    {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+        return Math.mulDiv(uint256(liquidity) << 96, sqrtRatioBX96 - sqrtRatioAX96, sqrtRatioBX96) / sqrtRatioAX96;
+    }
+
+    /// @notice Computes the amount of token1 for a given amount of liquidity and a price range
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param liquidity The liquidity being valued
+    /// @return amount1 The amount of token1
+    function getAmount1ForLiquidity(uint160 sqrtRatioAX96, uint160 sqrtRatioBX96, uint128 liquidity)
+        internal
+        pure
+        returns (uint256 amount1)
+    {
+        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+        return Math.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, Q96);
+    }
+
+    /// @notice Computes the token0 and token1 value for a given amount of liquidity, the current
+    /// pool prices and the prices at the tick boundaries.
+    /// @param sqrtRatioX96 A sqrt price representing the current pool prices
+    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+    /// @param liquidity The liquidity being valued
+    /// @return amount0 The amount of token0
+    /// @return amount1 The amount of token1
+    function getAmountsForLiquidity(
+        uint160 sqrtRatioX96,
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity
+    ) internal pure returns (uint256 amount0, uint256 amount1) {
+        if (sqrtRatioAX96 > sqrtRatioBX96) {
+            (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+        }
+
+        if (sqrtRatioX96 <= sqrtRatioAX96) {
+            amount0 = getAmount0ForLiquidity(sqrtRatioAX96, sqrtRatioBX96, liquidity);
+        } else if (sqrtRatioX96 < sqrtRatioBX96) {
+            amount0 = getAmount0ForLiquidity(sqrtRatioX96, sqrtRatioBX96, liquidity);
+            amount1 = getAmount1ForLiquidity(sqrtRatioAX96, sqrtRatioX96, liquidity);
+        } else {
+            amount1 = getAmount1ForLiquidity(sqrtRatioAX96, sqrtRatioBX96, liquidity);
+        }
+    }
+}

--- a/src/leveraged-aero/sherwood/libraries/TickMath.sol
+++ b/src/leveraged-aero/sherwood/libraries/TickMath.sol
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.28;
+
+// Vendored from Uniswap/v3-core@fc2107bd5709cdee6742d5164c1eb998566bcb75 (upstream of velodrome-finance/slipstream;
+// concentrated-liquidity math is bit-identical), adapted to 0.8.28. All magic constants validated byte-exact
+// against that commit; ground-truth vectors in test/UniswapMath.t.sol.
+
+/// @title Math library for computing sqrt prices from ticks and vice versa
+/// @notice Computes sqrt price for ticks of size 1.0001, i.e. sqrt(1.0001^tick) as fixed point Q64.96 numbers.
+/// Supports prices between 2**-128 and 2**128
+library TickMath {
+    /// @dev The minimum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**-128
+    int24 internal constant MIN_TICK = -887272;
+    /// @dev The maximum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**128
+    int24 internal constant MAX_TICK = 887272;
+
+    /// @dev The minimum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MIN_TICK)
+    uint160 internal constant MIN_SQRT_RATIO = 4295128739;
+    /// @dev The maximum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MAX_TICK)
+    uint160 internal constant MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342;
+
+    /// @notice Calculates sqrt(1.0001^tick) * 2^96
+    /// @dev Throws if |tick| > max tick
+    /// @param tick The input tick for the above formula
+    /// @return sqrtPriceX96 A Fixed point Q64.96 number representing the sqrt of the ratio of the two assets
+    /// (token1/token0) at the given tick
+    function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
+        unchecked {
+            uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
+            require(absTick <= uint256(int256(MAX_TICK)), "T");
+
+            uint256 ratio =
+                absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
+            if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;
+            if (absTick & 0x4 != 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
+            if (absTick & 0x8 != 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
+            if (absTick & 0x10 != 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644) >> 128;
+            if (absTick & 0x20 != 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0) >> 128;
+            if (absTick & 0x40 != 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861) >> 128;
+            if (absTick & 0x80 != 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053) >> 128;
+            if (absTick & 0x100 != 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128;
+            if (absTick & 0x200 != 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54) >> 128;
+            if (absTick & 0x400 != 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3) >> 128;
+            if (absTick & 0x800 != 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128;
+            if (absTick & 0x1000 != 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825) >> 128;
+            if (absTick & 0x2000 != 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128;
+            if (absTick & 0x4000 != 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128;
+            if (absTick & 0x8000 != 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6) >> 128;
+            if (absTick & 0x10000 != 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128;
+            if (absTick & 0x20000 != 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604) >> 128;
+            if (absTick & 0x40000 != 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98) >> 128;
+            if (absTick & 0x80000 != 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2) >> 128;
+
+            if (tick > 0) ratio = type(uint256).max / ratio;
+
+            // this divides by 1<<32 rounding up to go from a Q128.128 to a Q128.96.
+            // we then downcast because we know the result always fits within 160 bits due to our tick input constraint
+            // we round up in the division so getTickAtSqrtRatio of the output price is always consistent
+            sqrtPriceX96 = uint160((ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1));
+        }
+    }
+
+    /// @notice Calculates the greatest tick value such that getRatioAtTick(tick) <= ratio
+    /// @dev Throws in case sqrtPriceX96 < MIN_SQRT_RATIO, as MIN_SQRT_RATIO is the minimum value getSqrtRatioAtTick
+    /// may ever return.
+    /// @param sqrtPriceX96 The sqrt ratio for which to compute the tick as a Q64.96
+    /// @return tick The greatest tick for which the ratio is less than or equal to the input ratio
+    function getTickAtSqrtRatio(uint160 sqrtPriceX96) internal pure returns (int24 tick) {
+        unchecked {
+            // second inequality must be < because the price can never reach the price at the max tick
+            require(sqrtPriceX96 >= MIN_SQRT_RATIO && sqrtPriceX96 < MAX_SQRT_RATIO, "R");
+            uint256 ratio = uint256(sqrtPriceX96) << 32;
+
+            uint256 r = ratio;
+            uint256 msb = 0;
+
+            assembly {
+                let f := shl(7, gt(r, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(6, gt(r, 0xFFFFFFFFFFFFFFFF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(5, gt(r, 0xFFFFFFFF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(4, gt(r, 0xFFFF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(3, gt(r, 0xFF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(2, gt(r, 0xF))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := shl(1, gt(r, 0x3))
+                msb := or(msb, f)
+                r := shr(f, r)
+            }
+            assembly {
+                let f := gt(r, 0x1)
+                msb := or(msb, f)
+            }
+
+            if (msb >= 128) r = ratio >> (msb - 127);
+            else r = ratio << (127 - msb);
+
+            int256 log_2 = (int256(msb) - 128) << 64;
+
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(63, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(62, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(61, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(60, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(59, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(58, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(57, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(56, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(55, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(54, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(53, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(52, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(51, f))
+                r := shr(f, r)
+            }
+            assembly {
+                r := shr(127, mul(r, r))
+                let f := shr(128, r)
+                log_2 := or(log_2, shl(50, f))
+            }
+
+            int256 log_sqrt10001 = log_2 * 255738958999603826347141; // 128.128 number
+
+            int24 tickLow = int24((log_sqrt10001 - 3402992956809132418596140100660247210) >> 128);
+            int24 tickHi = int24((log_sqrt10001 + 291339464771989622907027621153398088495) >> 128);
+
+            tick = tickLow == tickHi ? tickLow : getSqrtRatioAtTick(tickHi) <= sqrtPriceX96 ? tickHi : tickLow;
+        }
+    }
+}

--- a/test/leveraged-aero/LayoutParity.t.sol
+++ b/test/leveraged-aero/LayoutParity.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "@forge-std/Test.sol";
+
+/// @title LayoutParity
+/// @notice Guards the CORRUPTION-CRITICAL invariant that `LeveragedAerodromeCLStrategy.sol`
+///         and `LeveragedAeroManager.sol` share an identical diamond-storage triplet:
+///         the `RedeemRequest` struct, the `Layout` struct (field types/order/names),
+///         and the `STORAGE_SLOT` literal `0x405ae0b1...`. The manager is delegatecalled
+///         by the strategy, so any drift silently corrupts storage.
+/// @dev Uses FFI to extract each block from the on-disk sources and diff them. Run with:
+///        forge test --match-path 'test/leveraged-aero/*' --ffi -vv
+///      Line comments are stripped before comparison, so the check tolerates the one
+///      benign self-referential comment in `Layout` while catching every storage-relevant
+///      change. See layout_parity.sh.
+contract LayoutParityTest is Test {
+    string constant SCRIPT = "test/leveraged-aero/layout_parity.sh";
+
+    function _diff(string memory kind) internal returns (string memory) {
+        string[] memory cmd = new string[](3);
+        cmd[0] = "bash";
+        cmd[1] = SCRIPT;
+        cmd[2] = kind;
+        return string(vm.ffi(cmd));
+    }
+
+    function _assertParity(string memory kind, string memory blockName) internal {
+        string memory d = _diff(kind);
+        if (bytes(d).length != 0) {
+            emit log_named_string(string.concat(blockName, " drifted between strategy and manager -- unified diff"), d);
+        }
+        assertEq(
+            bytes(d).length,
+            0,
+            string.concat(
+                blockName,
+                " drifted between LeveragedAerodromeCLStrategy.sol and LeveragedAeroManager.sol. ",
+                "These share a diamond-storage triplet (Layout/RedeemRequest/STORAGE_SLOT) that MUST ",
+                "remain byte-identical -- the manager is delegatecalled by the strategy, so any drift ",
+                "silently corrupts storage. See the CORRUPTION-CRITICAL note above each block; ",
+                "restore identity, do not 'clean up' either copy."
+            )
+        );
+    }
+
+    function test_RedeemRequestStructParity() public {
+        _assertParity("redeemrequest", "RedeemRequest struct");
+    }
+
+    function test_LayoutStructParity() public {
+        _assertParity("layout", "Layout struct");
+    }
+
+    function test_StorageSlotConstantParity() public {
+        _assertParity("storageslot", "STORAGE_SLOT constant");
+    }
+
+    /// @dev Sanity: the extractor must actually find the blocks. A silent empty match
+    ///      (e.g. a renamed struct making both sides empty) would otherwise pass parity.
+    function test_ExtractionIsNonEmpty() public {
+        string[] memory cmd = new string[](3);
+        cmd[0] = "bash";
+        cmd[1] = "-c";
+        cmd[2] = string.concat(
+            "awk '/^    struct Layout \\{/,/^    \\}$/{if (/address usdc;/) print \"FOUND\"}' ",
+            "src/leveraged-aero/LeveragedAerodromeCLStrategy.sol"
+        );
+        string memory out = string(vm.ffi(cmd));
+        // The strategy Layout block must contain the `address usdc;` field line; if the
+        // struct were renamed/emptied, both sides of the parity diff could be empty and
+        // silently "match". This proves the extractor is anchored on real content.
+        assertEq(out, "FOUND", "extractor found no Layout.usdc field -- struct may have been renamed/moved");
+    }
+}

--- a/test/leveraged-aero/layout_parity.sh
+++ b/test/leveraged-aero/layout_parity.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Extracts the CORRUPTION-CRITICAL diamond-storage triplet from the two vendored
+# files that MUST share it byte-for-byte, and prints a unified diff (empty ==
+# parity). Consumed by LayoutParity.t.sol via forge FFI.
+#
+#   kind = redeemrequest | layout | storageslot
+#
+# Normalization strips line comments (`// ...`) and trailing whitespace before
+# comparing, so the meaningful invariant — the Solidity storage declarations
+# (field types + order + names) and the STORAGE_SLOT literal — is what is
+# checked. This intentionally tolerates the one benign self-referential comment
+# inside `Layout` that reads "keep byte-identical in the manager" on the
+# strategy side and "...in the strategy" on the manager side; it catches every
+# storage-relevant drift.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STRAT="$ROOT/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol"
+MGR="$ROOT/src/leveraged-aero/LeveragedAeroManager.sol"
+
+norm() { sed 's#//.*##; s/[[:space:]]*$//' | grep -v '^[[:space:]]*$' || true; }
+
+extract() {
+  local file="$1" kind="$2"
+  case "$kind" in
+    redeemrequest) awk '/^    struct RedeemRequest \{/,/^    \}$/' "$file" ;;
+    layout)        awk '/^    struct Layout \{/,/^    \}$/' "$file" ;;
+    storageslot)   grep -E 'bytes32 private constant STORAGE_SLOT' "$file" ;;
+    *) echo "unknown kind: $kind" >&2; exit 2 ;;
+  esac
+}
+
+kind="${1:?usage: layout_parity.sh <redeemrequest|layout|storageslot>}"
+
+diff <(extract "$STRAT" "$kind" | norm) <(extract "$MGR" "$kind" | norm) || true

--- a/test/leveraged-aero/layout_parity.sh
+++ b/test/leveraged-aero/layout_parity.sh
@@ -24,8 +24,8 @@ norm() { sed 's#//.*##; s/[[:space:]]*$//' | grep -v '^[[:space:]]*$' || true; }
 extract() {
   local file="$1" kind="$2"
   case "$kind" in
-    redeemrequest) awk '/^    struct RedeemRequest \{/,/^    \}$/' "$file" ;;
-    layout)        awk '/^    struct Layout \{/,/^    \}$/' "$file" ;;
+    redeemrequest) awk '/^[[:space:]]*struct RedeemRequest \{/,/^[[:space:]]*\}[[:space:]]*$/' "$file" ;;
+    layout)        awk '/^[[:space:]]*struct Layout \{/,/^[[:space:]]*\}[[:space:]]*$/' "$file" ;;
     storageslot)   grep -E 'bytes32 private constant STORAGE_SLOT' "$file" ;;
     *) echo "unknown kind: $kind" >&2; exit 2 ;;
   esac


### PR DESCRIPTION
## What this is

The strategy contract of the joint Sherwood × Mamo **leveraged Aerodrome LP fund** (net-short leveraged Slipstream CL: supply USDC to Moonwell → borrow cbBTC + WETH → concentrated LP → farm & compound AERO; Mamo backend as operator, Sherwood pooled-vault rails for custody), vendored into this repo as a **self-contained, compiling audit package**.

Start here: **`docs/LEVERAGED_AERO_CL_AUDIT.md`** — provenance pin, scope, trust boundary, audit focus areas, and reproduction instructions.

📄 **Full spec & integration guide:** [`docs/LeveragedAerodromeCLStrategy.md` in sherwoodagent/sherwood-protocol](https://github.com/sherwoodagent/sherwood-protocol/blob/main/docs/LeveragedAerodromeCLStrategy.md) — architecture, storage layout, authorization matrix, valuation & fees, invariants, and integrator flows. Re-verified claim-by-claim against source on 2026-07-13.

## Audit scope — the aero strategy only

**In scope: the four contracts at the top of `src/leveraged-aero/`** (they are one strategy, split across four files for the EIP-170 code cap: entrypoints/NAV, delegatecalled venue manager, valuation, fee math).

**Out of scope: everything under `src/leveraged-aero/sherwood/` and the Sherwood vault.** The vault (`SyndicateVault`, not vendored) is already-audited Sherwood infrastructure. Its relationship to this strategy is the **same trust shape as Mamo's own account-strategy contracts**: users deposit into / withdraw from the strategy contract directly, the strategy custodies the position, the backend operates it through a bounded interface with hard on-chain caps, and the operator can never withdraw user funds to itself. The vault's entire interaction surface with the strategy is two share-ledger hooks (`strategyMint` / `strategyBurn` — supply only, no assets move vault-side), documented with links in the brief.

## Provenance

Vendored from the public repo [`sherwoodagent/sherwood-protocol`](https://github.com/sherwoodagent/sherwood-protocol) @ [`bb10bebf`](https://github.com/sherwoodagent/sherwood-protocol/tree/bb10bebff3cbf554e7538e42f1e876a47b09a6ac): identical modulo import-path rewrites and `forge fmt` under this repo's config + CI toolchain (verified by diffing all 20 files against source with import lines filtered — zero code-body changes).

## Layout

- `src/leveraged-aero/` — the 4 **audit-subject** contracts: strategy (entrypoints/NAV/init/storage), manager (delegatecalled venue logic), valuation (fail-closed oracle NAV), fees (streaming mgmt + HWM perf, pure)
- `src/leveraged-aero/sherwood/` — Sherwood framework files vendored for compilation (BaseStrategy, 10 interfaces, 3 libraries, FeeConstants, BatchExecutorLib) — context, not audit subject
- `test/leveraged-aero/LayoutParity.t.sol` — FFI tripwire for the CORRUPTION-CRITICAL delegatecall storage triplet (`Layout` / `RedeemRequest` / `STORAGE_SLOT`) that must stay identical across strategy and manager
- `docs/LEVERAGED_AERO_CL_AUDIT.md` — the audit brief

## How it was tested

- `forge build` green under the CI toolchain (via_ir / cancun / OZ 5.2.0). Sizes: strategy **19,514** bytes, manager **23,996** bytes (**580 under** EIP-170 under this repo's optimizer profile — margin note in the brief).
- `forge test --match-path 'test/leveraged-aero/*' --ffi` → **4/4 pass** (negative-tested: an injected Layout field fails the tripwire with an actionable diff).
- Upstream behavioral suite re-verified 2026-07-13: **62/62 fork tests green** across 9 suites against a Tenderly Base-fork vnet (full protocol deploy → propose/vote/execute → deposit / deployIdle / compound / rerange / deleverage / redeem → settle), plus the invariant suite. Reproduction command in the brief.

## Notes for reviewers

- No existing mamo file is modified; the package is additive and namespaced (mamo's own `src/BaseStrategy.sol` is untouched — the Sherwood one lives at `src/leveraged-aero/sherwood/BaseStrategy.sol`).
- No solc pin in this repo: pragma `^0.8.28` selects the compiler (Sherwood pins 0.8.28) — flagged in the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)