### PR TITLE
refactor: one GPv2 order-validation module, three adapter paths

### DIFF
--- a/src/LPCompoundModule.sol
+++ b/src/LPCompoundModule.sol
@@ -127,7 +127,7 @@ contract LPCompoundModule is AccessControlEnumerable {
     ///      below (sellToken in {token0, token1}) are structurally disjoint ONLY because the
     ///      balancer refuses AERO as a pair token at registration (_validateAndStore's
     ///      InvalidConfig guard). If that invariant ever broke, an AERO leg would satisfy both
-    ///      classes — see test_classDisjointness_dependsOnBalancerAeroExclusion.
+    ///      classes — see test_documents_classDisjointness_dependsOnBalancerAeroExclusion.
     function isValidSignature(bytes32 orderDigest, bytes calldata encodedOrder) external view returns (bytes4) {
         GPv2Order.Data memory o = abi.decode(encodedOrder, (GPv2Order.Data));
         require(address(o.sellToken) == AERO, "sellToken must be AERO");
@@ -135,7 +135,15 @@ contract LPCompoundModule is AccessControlEnumerable {
         address t1 = ILPAutoBalancerV2(balancer).token1();
         require(address(o.buyToken) == t0 || address(o.buyToken) == t1, "buyToken must be underlying");
         GPv2OrderChecks.validate(
-            o, orderDigest, DOMAIN_SEPARATOR, balancer, compoundAppData, slippagePriceChecker, allowedSlippageInBps
+            o,
+            GPv2OrderChecks.Binding({
+                orderDigest: orderDigest,
+                domainSeparator: DOMAIN_SEPARATOR,
+                expectedAppData: compoundAppData
+            }),
+            balancer,
+            slippagePriceChecker,
+            allowedSlippageInBps
         );
         return MAGIC_VALUE;
     }
@@ -162,7 +170,15 @@ contract LPCompoundModule is AccessControlEnumerable {
             "sellToken must match in-flight approval"
         );
         GPv2OrderChecks.validate(
-            o, orderDigest, DOMAIN_SEPARATOR, balancer, compoundAppData, slippagePriceChecker, rebalanceSlippageBps
+            o,
+            GPv2OrderChecks.Binding({
+                orderDigest: orderDigest,
+                domainSeparator: DOMAIN_SEPARATOR,
+                expectedAppData: compoundAppData
+            }),
+            balancer,
+            slippagePriceChecker,
+            rebalanceSlippageBps
         );
         return MAGIC_VALUE;
     }

--- a/src/LPCompoundModule.sol
+++ b/src/LPCompoundModule.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {ILPAutoBalancerV2} from "@interfaces/ILPAutoBalancerV2.sol";
 import {ISlippagePriceChecker} from "@interfaces/ISlippagePriceChecker.sol";
 import {GPv2Order} from "@libraries/GPv2Order.sol";
+import {GPv2OrderChecks} from "@libraries/GPv2OrderChecks.sol";
 import {AccessControlEnumerable} from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -16,7 +17,6 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 ///         swap proceeds. The balancer's compound() forwards the compound share of AERO here.
 contract LPCompoundModule is AccessControlEnumerable {
     using SafeERC20 for IERC20;
-    using GPv2Order for GPv2Order.Data;
 
     /// @notice CowSwap GPv2Settlement domain separator (Base) — mirrors ERC20MoonwellMorphoStrategy.
     bytes32 public constant DOMAIN_SEPARATOR = 0xd72ffa789b6fae41254d0b5a13e6e1e92ed947ec6a251edf1cf0b6c02c257b4b;
@@ -118,43 +118,24 @@ contract LPCompoundModule is AccessControlEnumerable {
         IERC20(AERO).forceApprove(VAULT_RELAYER, type(uint256).max);
     }
 
-    /// @dev Order-class-agnostic GPv2 checks shared by both validation paths: digest binding, SELL
-    ///      kind, fill-or-kill, ERC20 balance flags, receiver == balancer, zero fee, pinned appData,
-    ///      and the [now+5min, now+maxTimePriceValid(sellToken)] expiry window. The per-path token
-    ///      constraints (compound: AERO->underlying; rebalance: distinct underlyings + in-flight
-    ///      direction pin), the in-flight gate, and the slippage knob stay in the callers — extracting
-    ///      the common block keeps a future hardening from landing in only one of the two stacks (the
-    ///      rebalance class is the permissionlessly-placeable, higher-notional one).
-    function _commonOrderChecks(GPv2Order.Data memory o, bytes32 orderDigest) internal view {
-        require(o.hash(DOMAIN_SEPARATOR) == orderDigest, "bad digest");
-        require(o.kind == GPv2Order.KIND_SELL, "must be sell");
-        require(!o.partiallyFillable, "must be fill-or-kill");
-        require(o.sellTokenBalance == GPv2Order.BALANCE_ERC20, "sell must be erc20");
-        require(o.buyTokenBalance == GPv2Order.BALANCE_ERC20, "buy must be erc20");
-        require(o.receiver == balancer, "receiver must be balancer");
-        require(o.feeAmount == 0, "fee must be zero");
-        require(o.appData == compoundAppData, "bad appData");
-        require(o.validTo >= block.timestamp + 5 minutes, "expires too soon");
-        require(
-            o.validTo <= block.timestamp + slippagePriceChecker.maxTimePriceValid(address(o.sellToken)),
-            "expires too far"
-        );
-    }
-
     /// @notice EIP-1271 validation for CowSwap compound orders (AERO -> token0|token1, reward-only).
     /// @dev Reads token0/token1 live from the balancer so the check survives a setPool re-point.
+    ///      Order-CLASS checks run first (specific error before any checker revert); the shared
+    ///      GPv2 mechanics + price check live in GPv2OrderChecks.validate, one implementation for
+    ///      both of this module's paths and the multi-market strategy's.
+    ///      DISJOINTNESS NOTE: this compound class (sellToken == AERO) and the rebalance class
+    ///      below (sellToken in {token0, token1}) are structurally disjoint ONLY because the
+    ///      balancer refuses AERO as a pair token at registration (_validateAndStore's
+    ///      InvalidConfig guard). If that invariant ever broke, an AERO leg would satisfy both
+    ///      classes — see test_classDisjointness_dependsOnBalancerAeroExclusion.
     function isValidSignature(bytes32 orderDigest, bytes calldata encodedOrder) external view returns (bytes4) {
         GPv2Order.Data memory o = abi.decode(encodedOrder, (GPv2Order.Data));
-        _commonOrderChecks(o, orderDigest);
         require(address(o.sellToken) == AERO, "sellToken must be AERO");
         address t0 = ILPAutoBalancerV2(balancer).token0();
         address t1 = ILPAutoBalancerV2(balancer).token1();
         require(address(o.buyToken) == t0 || address(o.buyToken) == t1, "buyToken must be underlying");
-        require(
-            slippagePriceChecker.checkPrice(
-                o.sellAmount, address(o.sellToken), address(o.buyToken), o.buyAmount, allowedSlippageInBps
-            ),
-            "price check failed"
+        GPv2OrderChecks.validate(
+            o, orderDigest, DOMAIN_SEPARATOR, balancer, compoundAppData, slippagePriceChecker, allowedSlippageInBps
         );
         return MAGIC_VALUE;
     }
@@ -163,10 +144,12 @@ contract LPCompoundModule is AccessControlEnumerable {
     ///         isValidSignature delegates here. Orders validate ONLY while the balancer
     ///         reports rebalanceInFlight, must swap between the two pool underlyings
     ///         (either direction), deliver to the balancer, and pass the price checker.
+    /// @dev Class checks first, shared mechanics in GPv2OrderChecks.validate (see the
+    ///      disjointness note on isValidSignature — this class relies on the balancer never
+    ///      registering AERO as token0/token1).
     function validateRebalanceOrder(bytes32 orderDigest, bytes calldata encodedOrder) external view returns (bytes4) {
         require(ILPAutoBalancerV2(balancer).rebalanceInFlight(), "no rebalance in flight");
         GPv2Order.Data memory o = abi.decode(encodedOrder, (GPv2Order.Data));
-        _commonOrderChecks(o, orderDigest);
         address t0 = ILPAutoBalancerV2(balancer).token0();
         address t1 = ILPAutoBalancerV2(balancer).token1();
         require(
@@ -178,11 +161,8 @@ contract LPCompoundModule is AccessControlEnumerable {
             address(o.sellToken) == ILPAutoBalancerV2(balancer).sellTokenInFlight(),
             "sellToken must match in-flight approval"
         );
-        require(
-            slippagePriceChecker.checkPrice(
-                o.sellAmount, address(o.sellToken), address(o.buyToken), o.buyAmount, rebalanceSlippageBps
-            ),
-            "price check failed"
+        GPv2OrderChecks.validate(
+            o, orderDigest, DOMAIN_SEPARATOR, balancer, compoundAppData, slippagePriceChecker, rebalanceSlippageBps
         );
         return MAGIC_VALUE;
     }

--- a/src/MamoMultiMarketStrategy.sol
+++ b/src/MamoMultiMarketStrategy.sol
@@ -426,10 +426,12 @@ contract MamoMultiMarketStrategy is Initializable, UUPSUpgradeable, BaseStrategy
 
         GPv2OrderChecks.validate(
             _order,
-            orderDigest,
-            DOMAIN_SEPARATOR,
+            GPv2OrderChecks.Binding({
+                orderDigest: orderDigest,
+                domainSeparator: DOMAIN_SEPARATOR,
+                expectedAppData: keccak256(bytes(expectedAppData))
+            }),
             address(this),
-            keccak256(bytes(expectedAppData)),
             slippagePriceChecker,
             allowedSlippageInBps
         );

--- a/src/MamoMultiMarketStrategy.sol
+++ b/src/MamoMultiMarketStrategy.sol
@@ -12,6 +12,7 @@ import {ISlippagePriceChecker} from "@interfaces/ISlippagePriceChecker.sol";
 import {WETH9} from "@interfaces/IWETH.sol";
 
 import {GPv2Order} from "@libraries/GPv2Order.sol";
+import {GPv2OrderChecks} from "@libraries/GPv2OrderChecks.sol";
 import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -36,7 +37,6 @@ interface IMerkleDistributor {
  *      Market definitions are read from MarketRegistry. Per-market splits are stored locally keyed by address.
  */
 contract MamoMultiMarketStrategy is Initializable, UUPSUpgradeable, BaseStrategy {
-    using GPv2Order for GPv2Order.Data;
     using SafeERC20 for IERC20;
 
     // Constants
@@ -393,36 +393,15 @@ contract MamoMultiMarketStrategy is Initializable, UUPSUpgradeable, BaseStrategy
 
     /// @param orderDigest The EIP-712 signing digest derived from the order
     /// @param encodedOrder Bytes-encoded order information
+    /// @dev Order-CLASS checks (reward token in, strategy token out) run first; the shared GPv2
+    ///      sell-order mechanics + price check live in GPv2OrderChecks.validate — one
+    ///      implementation for this path and both of LPCompoundModule's. Revert strings are the
+    ///      repo-canonical short set (see the library).
     function isValidSignature(bytes32 orderDigest, bytes calldata encodedOrder) external view returns (bytes4) {
         GPv2Order.Data memory _order = abi.decode(encodedOrder, (GPv2Order.Data));
 
-        require(_order.hash(DOMAIN_SEPARATOR) == orderDigest, "Order hash does not match the provided digest");
-
-        require(_order.kind == GPv2Order.KIND_SELL, "Order must be a sell order");
-
-        require(
-            _order.validTo >= block.timestamp + 5 minutes,
-            "Order expires too soon - must be valid for at least 5 minutes"
-        );
-
-        require(
-            _order.validTo <= block.timestamp + slippagePriceChecker.maxTimePriceValid(address(_order.sellToken)),
-            "Order expires too far in the future"
-        );
-
-        require(!_order.partiallyFillable, "Order must be fill-or-kill, partial fills not allowed");
-
-        require(_order.sellTokenBalance == GPv2Order.BALANCE_ERC20, "Sell token must be an ERC20 token");
-
-        require(_order.buyTokenBalance == GPv2Order.BALANCE_ERC20, "Buy token must be an ERC20 token");
-
         require(_order.sellToken != token, "Sell token can't be strategy token");
-
         require(_order.buyToken == token, "Buy token must match the strategy token");
-
-        require(_order.feeAmount == 0, "Fee amount must be zero");
-
-        require(_order.receiver == address(this), "Order receiver must be this strategy contract");
 
         uint256 feeAmount = (_order.sellAmount * compoundFee) / SPLIT_TOTAL;
 
@@ -445,19 +424,14 @@ contract MamoMultiMarketStrategy is Initializable, UUPSUpgradeable, BaseStrategy
             )
         );
 
-        bytes32 expectedAppDataBytes = keccak256(bytes(expectedAppData));
-
-        require(_order.appData == expectedAppDataBytes, "Invalid app data");
-
-        require(
-            slippagePriceChecker.checkPrice(
-                _order.sellAmount,
-                address(_order.sellToken),
-                address(_order.buyToken),
-                _order.buyAmount,
-                allowedSlippageInBps
-            ),
-            "Price check failed - output amount too low"
+        GPv2OrderChecks.validate(
+            _order,
+            orderDigest,
+            DOMAIN_SEPARATOR,
+            address(this),
+            keccak256(bytes(expectedAppData)),
+            slippagePriceChecker,
+            allowedSlippageInBps
         );
 
         return MAGIC_VALUE;

--- a/src/libraries/GPv2OrderChecks.sol
+++ b/src/libraries/GPv2OrderChecks.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {ISlippagePriceChecker} from "@interfaces/ISlippagePriceChecker.sol";
+import {GPv2Order} from "@libraries/GPv2Order.sol";
+
+/// @title GPv2OrderChecks
+/// @notice The order-class-agnostic CowSwap/GPv2 sell-order validation skeleton shared by every
+///         EIP-1271 signer in this repo (LPCompoundModule's compound + rebalance paths and
+///         MamoMultiMarketStrategy's reward path). One implementation of the settlement-critical
+///         mechanics; each signer stays an adapter supplying only its order-class constraints.
+///         INTERNAL on purpose: the checks inline into each caller (no linking/deploy surface) —
+///         the point is source-level dedup so a hardening lands in every path by construction,
+///         not bytecode sharing.
+library GPv2OrderChecks {
+    using GPv2Order for GPv2Order.Data;
+
+    /// @notice Shared GPv2 sell-order mechanics: digest binding, SELL kind, fill-or-kill, ERC20
+    ///         balance flags, receiver pin, zero fee, appData pin, the
+    ///         [now+5min, now+maxTimePriceValid(sellToken)] expiry window, and the Chainlink-backed
+    ///         price check at `slippageBps`.
+    /// @dev Order-CLASS constraints (which tokens may be sold/bought, in-flight gates, direction
+    ///      pins) stay in the callers — run them BEFORE this call so a wrong-token order reverts
+    ///      with its specific class error instead of a confusing checker revert from inside
+    ///      checkPrice (an unconfigured pair reverts there).
+    /// @dev Revert strings are the repo-canonical short set; offchain error decoding matches on
+    ///      these exact strings (backend spec §2.4).
+    function validate(
+        GPv2Order.Data memory o,
+        bytes32 orderDigest,
+        bytes32 domainSeparator,
+        address receiver,
+        bytes32 expectedAppData,
+        ISlippagePriceChecker checker,
+        uint256 slippageBps
+    ) internal view {
+        require(o.hash(domainSeparator) == orderDigest, "bad digest");
+        require(o.kind == GPv2Order.KIND_SELL, "must be sell");
+        require(!o.partiallyFillable, "must be fill-or-kill");
+        require(o.sellTokenBalance == GPv2Order.BALANCE_ERC20, "sell must be erc20");
+        require(o.buyTokenBalance == GPv2Order.BALANCE_ERC20, "buy must be erc20");
+        require(o.receiver == receiver, "bad receiver");
+        require(o.feeAmount == 0, "fee must be zero");
+        require(o.appData == expectedAppData, "bad appData");
+        require(o.validTo >= block.timestamp + 5 minutes, "expires too soon");
+        require(o.validTo <= block.timestamp + checker.maxTimePriceValid(address(o.sellToken)), "expires too far");
+        require(
+            checker.checkPrice(o.sellAmount, address(o.sellToken), address(o.buyToken), o.buyAmount, slippageBps),
+            "price check failed"
+        );
+    }
+}

--- a/src/libraries/GPv2OrderChecks.sol
+++ b/src/libraries/GPv2OrderChecks.sol
@@ -41,9 +41,12 @@ library GPv2OrderChecks {
         require(o.buyTokenBalance == GPv2Order.BALANCE_ERC20, "buy must be erc20");
         require(o.receiver == receiver, "bad receiver");
         require(o.feeAmount == 0, "fee must be zero");
-        require(o.appData == expectedAppData, "bad appData");
+        // Expiry window BEFORE the appData pin: appData can be expensive for callers to compute
+        // (the strategy builds a hook JSON), and pre-existing suites construct expiry-violation
+        // orders with placeholder appData — window first keeps each check independently testable.
         require(o.validTo >= block.timestamp + 5 minutes, "expires too soon");
         require(o.validTo <= block.timestamp + checker.maxTimePriceValid(address(o.sellToken)), "expires too far");
+        require(o.appData == expectedAppData, "bad appData");
         require(
             checker.checkPrice(o.sellAmount, address(o.sellToken), address(o.buyToken), o.buyAmount, slippageBps),
             "price check failed"

--- a/src/libraries/GPv2OrderChecks.sol
+++ b/src/libraries/GPv2OrderChecks.sol
@@ -15,6 +15,15 @@ import {GPv2Order} from "@libraries/GPv2Order.sol";
 library GPv2OrderChecks {
     using GPv2Order for GPv2Order.Data;
 
+    /// @notice The three order-binding hashes `validate` pins, grouped so every call site
+    ///         constructs them with named fields — a transposed `bytes32` argument is a compile
+    ///         error, not a silent mis-binding.
+    struct Binding {
+        bytes32 orderDigest; // EIP-712 signing digest the order must hash to
+        bytes32 domainSeparator; // GPv2 settlement domain separator
+        bytes32 expectedAppData; // pinned appData hash
+    }
+
     /// @notice Shared GPv2 sell-order mechanics: digest binding, SELL kind, fill-or-kill, ERC20
     ///         balance flags, receiver pin, zero fee, appData pin, the
     ///         [now+5min, now+maxTimePriceValid(sellToken)] expiry window, and the Chainlink-backed
@@ -23,18 +32,17 @@ library GPv2OrderChecks {
     ///      pins) stay in the callers — run them BEFORE this call so a wrong-token order reverts
     ///      with its specific class error instead of a confusing checker revert from inside
     ///      checkPrice (an unconfigured pair reverts there).
-    /// @dev Revert strings are the repo-canonical short set; offchain error decoding matches on
-    ///      these exact strings (backend spec §2.4).
+    /// @dev Revert strings are the repo-canonical short set, kept stable so the pre-existing
+    ///      suites keep matching. The backend decodes errors by custom-error SELECTOR (its spec
+    ///      §2.4 tables LPAutoBalancerV2 selectors); it does not match on these require-strings.
     function validate(
         GPv2Order.Data memory o,
-        bytes32 orderDigest,
-        bytes32 domainSeparator,
+        Binding memory b,
         address receiver,
-        bytes32 expectedAppData,
         ISlippagePriceChecker checker,
         uint256 slippageBps
     ) internal view {
-        require(o.hash(domainSeparator) == orderDigest, "bad digest");
+        require(o.hash(b.domainSeparator) == b.orderDigest, "bad digest");
         require(o.kind == GPv2Order.KIND_SELL, "must be sell");
         require(!o.partiallyFillable, "must be fill-or-kill");
         require(o.sellTokenBalance == GPv2Order.BALANCE_ERC20, "sell must be erc20");
@@ -46,7 +54,7 @@ library GPv2OrderChecks {
         // orders with placeholder appData — window first keeps each check independently testable.
         require(o.validTo >= block.timestamp + 5 minutes, "expires too soon");
         require(o.validTo <= block.timestamp + checker.maxTimePriceValid(address(o.sellToken)), "expires too far");
-        require(o.appData == expectedAppData, "bad appData");
+        require(o.appData == b.expectedAppData, "bad appData");
         require(
             checker.checkPrice(o.sellAmount, address(o.sellToken), address(o.buyToken), o.buyAmount, slippageBps),
             "price check failed"

--- a/test/LPCompoundModule.unit.t.sol
+++ b/test/LPCompoundModule.unit.t.sol
@@ -177,7 +177,7 @@ contract LPCompoundModuleUnitTest is Test {
     function test_isValidSignature_revertsReceiverNotBalancer() public {
         GPv2Order.Data memory o = _order(aero, token0, address(0xCAFE), uint32(block.timestamp + 10 minutes));
         (bytes32 d, bytes memory e) = _sig(o);
-        vm.expectRevert(bytes("receiver must be balancer"));
+        vm.expectRevert(bytes("bad receiver"));
         module.isValidSignature(d, e);
     }
 
@@ -338,7 +338,7 @@ contract LPCompoundModuleUnitTest is Test {
         spc.setMaxTimePriceValid(token0, 1 hours);
         GPv2Order.Data memory o = _order(token0, token1, makeAddr("attacker"), uint32(block.timestamp + 10 minutes));
         (bytes32 d, bytes memory e) = _sig(o);
-        vm.expectRevert("receiver must be balancer");
+        vm.expectRevert("bad receiver");
         module.validateRebalanceOrder(d, e);
     }
 
@@ -492,6 +492,29 @@ contract LPCompoundModuleUnitTest is Test {
         GPv2Order.Data memory o = _rebalanceOrder(token0, token1);
         (bytes32 d, bytes memory e) = _sig(o);
         assertEq(module.validateRebalanceOrder(d, e), bytes4(0x1626ba7e));
+    }
+
+    // ---------- class disjointness (cross-contract invariant, documented) ----------
+
+    /// @notice The compound class (sellToken == AERO) and the rebalance class (sellToken in
+    ///         {token0, token1}) are structurally disjoint ONLY because LPAutoBalancerV2's
+    ///         _validateAndStore refuses AERO as a pair token at registration. This test documents
+    ///         that dependency: against a hypothetical balancer reporting AERO as token0 — a state
+    ///         the real balancer makes unreachable — ONE order (AERO -> token1) satisfies BOTH
+    ///         classes. The module imports its safety from the balancer's invariant; if that guard
+    ///         is ever weakened, this is the failure shape to expect.
+    function test_classDisjointness_dependsOnBalancerAeroExclusion() public {
+        bal.setTokens(aero, token1); // unreachable on the real balancer (InvalidConfig at registration)
+        bal.setInFlight(true);
+        bal.setSellTokenInFlight(aero);
+        spc.setMaxTimePriceValid(aero, 1 hours);
+        spc.setOracleDiscountBps(-1); // pricing is not the subject here
+
+        GPv2Order.Data memory o = _rebalanceOrder(aero, token1);
+        (bytes32 d, bytes memory e) = _sig(o);
+
+        assertEq(module.validateRebalanceOrder(d, e), MAGIC, "rebalance class accepts the AERO leg");
+        assertEq(module.isValidSignature(d, e), MAGIC, "compound class accepts the SAME order");
     }
 
     // ---------- structural order-shape rejections (both validation paths) ----------

--- a/test/LPCompoundModule.unit.t.sol
+++ b/test/LPCompoundModule.unit.t.sol
@@ -502,8 +502,10 @@ contract LPCompoundModuleUnitTest is Test {
     ///         that dependency: against a hypothetical balancer reporting AERO as token0 — a state
     ///         the real balancer makes unreachable — ONE order (AERO -> token1) satisfies BOTH
     ///         classes. The module imports its safety from the balancer's invariant; if that guard
-    ///         is ever weakened, this is the failure shape to expect.
-    function test_classDisjointness_dependsOnBalancerAeroExclusion() public {
+    ///         is ever weakened, this is the failure shape to expect. DOCUMENTS the dependency —
+    ///         it does not enforce the balancer's AERO-exclusion guard (that stays pinned in the
+    ///         balancer's own suite).
+    function test_documents_classDisjointness_dependsOnBalancerAeroExclusion() public {
         bal.setTokens(aero, token1); // unreachable on the real balancer (InvalidConfig at registration)
         bal.setInFlight(true);
         bal.setSellTokenInFlight(aero);

--- a/test/MoonwellMorphoStrategy.integration.t.sol
+++ b/test/MoonwellMorphoStrategy.integration.t.sol
@@ -1117,7 +1117,7 @@ contract MoonwellMorphoStrategyTest is Test {
         // Create an incorrect digest
         bytes32 incorrectDigest = bytes32(uint256(order.hash(strategy.DOMAIN_SEPARATOR())) + 1);
 
-        vm.expectRevert("Order hash does not match the provided digest");
+        vm.expectRevert("bad digest");
         strategy.isValidSignature(incorrectDigest, encodedOrder);
     }
 
@@ -1149,7 +1149,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes memory encodedOrder = abi.encode(order);
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
-        vm.expectRevert("Order must be a sell order");
+        vm.expectRevert("must be sell");
         strategy.isValidSignature(digest, encodedOrder);
     }
 
@@ -1182,7 +1182,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes memory encodedOrder = abi.encode(order);
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
-        vm.expectRevert("Order expires too soon - must be valid for at least 5 minutes");
+        vm.expectRevert("expires too soon");
         strategy.isValidSignature(digest, encodedOrder);
     }
 
@@ -1214,7 +1214,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes memory encodedOrder = abi.encode(order);
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
-        vm.expectRevert("Order must be fill-or-kill, partial fills not allowed");
+        vm.expectRevert("must be fill-or-kill");
         strategy.isValidSignature(digest, encodedOrder);
     }
 
@@ -1246,7 +1246,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes memory encodedOrder = abi.encode(order);
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
-        vm.expectRevert("Sell token must be an ERC20 token");
+        vm.expectRevert("sell must be erc20");
         strategy.isValidSignature(digest, encodedOrder);
     }
 
@@ -1278,7 +1278,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes memory encodedOrder = abi.encode(order);
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
-        vm.expectRevert("Buy token must be an ERC20 token");
+        vm.expectRevert("buy must be erc20");
         strategy.isValidSignature(digest, encodedOrder);
     }
 
@@ -1348,7 +1348,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes memory encodedOrder = abi.encode(order);
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
-        vm.expectRevert("Order receiver must be this strategy contract");
+        vm.expectRevert("bad receiver");
         strategy.isValidSignature(digest, encodedOrder);
     }
 
@@ -1380,7 +1380,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes memory encodedOrder = abi.encode(order);
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
-        vm.expectRevert("Fee amount must be zero");
+        vm.expectRevert("fee must be zero");
         strategy.isValidSignature(digest, encodedOrder);
     }
 
@@ -1412,7 +1412,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes memory encodedOrder = abi.encode(order);
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
-        vm.expectRevert("Invalid app data");
+        vm.expectRevert("bad appData");
         strategy.isValidSignature(digest, encodedOrder);
     }
 
@@ -1589,7 +1589,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
         // With default slippage, this should revert
-        vm.expectRevert("Price check failed - output amount too low");
+        vm.expectRevert("price check failed");
         strategy.isValidSignature(digest, encodedOrder);
 
         // Now set a higher but still reasonable slippage (10%)
@@ -1602,7 +1602,7 @@ contract MoonwellMorphoStrategyTest is Test {
         );
 
         // With 10% slippage, the extremely low amount should still fail
-        vm.expectRevert("Price check failed - output amount too low");
+        vm.expectRevert("price check failed");
         strategy.isValidSignature(digest, encodedOrder);
 
         // Now create a more reasonable order with a higher buy amount
@@ -1678,7 +1678,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes memory encodedOrder = abi.encode(order);
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
-        vm.expectRevert("Price check failed - output amount too low");
+        vm.expectRevert("price check failed");
         strategy.isValidSignature(digest, encodedOrder);
     }
 
@@ -1756,7 +1756,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes32 orderDigest = order.hash(strategy.DOMAIN_SEPARATOR());
 
         // Call isValidSignature and expect it to revert
-        vm.expectRevert("Order expires too far in the future");
+        vm.expectRevert("expires too far");
         strategy.isValidSignature(orderDigest, encodedOrder);
 
         // Clear the mock
@@ -1874,7 +1874,7 @@ contract MoonwellMorphoStrategyTest is Test {
         bytes memory encodedOrder = abi.encode(order);
         bytes32 digest = order.hash(strategy.DOMAIN_SEPARATOR());
 
-        vm.expectRevert("Order expires too far in the future");
+        vm.expectRevert("expires too far");
         strategy.isValidSignature(digest, encodedOrder);
     }
 


### PR DESCRIPTION
## Summary

Architecture-review candidate 2 (+ candidate 4 folded in), design settled via grill: the CowSwap sell-order validation skeleton was implemented **three times** — `LPCompoundModule.isValidSignature` (compound), `LPCompoundModule.validateRebalanceOrder` (principal), `MamoMultiMarketStrategy.isValidSignature` (reward) — with three divergent revert-string sets and no compiler help against drift. The drift risk is structural: ~11 settlement-critical mechanics (digest binding, order shape, receiver/appData pins, expiry window, price check) maintained by hand in three copies, so any future hardening to one had to be manually replicated into the other two — miss one path and it silently keeps the weaker check. The library makes that class of divergence impossible by construction.

## What changed

- **`src/libraries/GPv2OrderChecks.sol`** (new): one INTERNAL library owning the 11 shared checks — digest binding, SELL kind, fill-or-kill, ERC20 balance flags, receiver pin, zero fee, appData pin, `[now+5min, now+maxTimePriceValid(sellToken)]` window, and the Chainlink `checkPrice` at the caller's `slippageBps`. Internal on purpose: checks inline into each caller (source-level dedup, zero linking/deploy surface).
- **The three order-binding hashes travel in a `Binding` struct** (`orderDigest` / `domainSeparator` / `expectedAppData`), constructed with named fields at every call site — a transposed `bytes32` argument is now a compile error instead of a silent mis-binding.
- **Both signers become adapters.** Order-CLASS constraints stay in the callers and now run FIRST (specific class error instead of a confusing checker revert for wrong-token orders): compound = AERO→underlying; rebalance = in-flight gate + distinct underlyings + `sellTokenInFlight` pin; strategy = reward-in/strategy-token-out + computed hook appData. External selectors unchanged.
- **Revert strings canonicalized** to the short set (`"bad digest"`, `"must be sell"`, …). `"receiver must be balancer"` generalized to `"bad receiver"`. Safe now: the backend decodes errors by custom-error selector (its spec §2.4 tables LPAutoBalancerV2 selectors — it does not match on require-strings), and the multi-market strategy is pre-deploy — after deploy this becomes a breaking change, which is why it lands in this bundle.
- **Candidate 4 folded in**: the compound/rebalance class disjointness depends on the balancer refusing AERO as a pair token (`_validateAndStore`). Now cross-referenced in NatSpec on both module paths and documented by `test_documents_classDisjointness_dependsOnBalancerAeroExclusion`, which proves one AERO order satisfies BOTH classes against a hypothetical balancer without the invariant (documents the dependency; the AERO-exclusion guard itself stays pinned in the balancer's own suite).

## Impact

| Contract | Before | After |
|---|---|---|
| `MamoMultiMarketStrategy` | 20,087 B | 19,861 B (−226) |
| `LPCompoundModule` | 7,546 B | 7,446 B (−100) |
| `LPAutoBalancerV2` | 23,962 B | untouched |

Future hardening to the shared mechanics now lands in all three paths by construction.

## Test plan

- [x] `make test-unit` — 326 pass (incl. 52 module tests, +1 disjointness)
- [x] `make lp-auto-balancer-v2` — 8 fork tests pass
- [x] `forge fmt` run with the CI-pinned nightly (e520767)
- [ ] Strategy fork suites (usdc/weth/cbbtc) — CI only (known local op-revm Isthmus panic on `--fork-url` targets); these assert the canonicalized revert strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
