### PR TITLE
feat: MamoLeveragedAeroStrategy — per-user account wrapper for the Sherwood Aero LP strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,13 @@ lp-auto-balancer-v2:
 lp-v2-setup:
 	forge test --ffi --mc LPAutoBalancerV2SetupTest -vvv
 
+# MamoLeveragedAeroStrategy account unit tests. Mocks only (no fork): the Sherwood strategy/vault are
+# stubbed, so NO --fork-url. Matches test/MamoLeveragedAeroStrategy*.unit.t.sol.
+leveraged-aero-account:
+	forge test --ffi --match-path "test/MamoLeveragedAeroStrategy*.unit.t.sol" -vvv
+
 test-all:
-	$(MAKE) test test-unit usdc-strategy cbbtc-strategy usdc-price-checker cbbtc-price-checker strategy-factory strategy-multicall mamo-staking fee-splitter lp-auto-balancer-v2 lp-v2-setup
+	$(MAKE) test test-unit usdc-strategy cbbtc-strategy usdc-price-checker cbbtc-price-checker strategy-factory strategy-multicall mamo-staking fee-splitter lp-auto-balancer-v2 lp-v2-setup leveraged-aero-account
 
 # Tenderly Virtual TestNet harness: deploy LPAutoBalancerV2 to a Base-fork vnet and drive its real
 # lifecycle as broadcast txs (no-swap reset conservation, single-sided rebuild, fee/AERO skim, role
@@ -77,4 +82,4 @@ tenderly-matrix:
 tenderly-price-checker:
 	./script/tenderly/run-harness.sh price-checker
 
-.PHONY: test test-unit coverage deploy-broadcast usdc-strategy cbbtc-strategy strategy-factory strategy-multicall usdc-price-checker cbbtc-price-checker fee-splitter integration-test mamo-staking lp-auto-balancer-v2 lp-v2-setup test-all tenderly-harness tenderly-matrix tenderly-price-checker
+.PHONY: test test-unit coverage deploy-broadcast usdc-strategy cbbtc-strategy strategy-factory strategy-multicall usdc-price-checker cbbtc-price-checker fee-splitter integration-test mamo-staking lp-auto-balancer-v2 lp-v2-setup leveraged-aero-account test-all tenderly-harness tenderly-matrix tenderly-price-checker

--- a/config/strategies/LeveragedAeroAccountConfig.json
+++ b/config/strategies/LeveragedAeroAccountConfig.json
@@ -1,0 +1,11 @@
+{
+  "symbol": "USDC",
+  "decimals": 6,
+  "token": "USDC",
+  "sherwoodStrategy": "SHERWOOD_LEVERAGED_AERO_STRATEGY",
+  "syndicateVault": "SHERWOOD_SYNDICATE_VAULT",
+  "strategyTypeId": 5,
+  "strategyImplementation": "MAMO_LEVERAGED_AERO_STRATEGY_IMPL",
+  "strategyFactory": "MAMO_LEVERAGED_AERO_STRATEGY_FACTORY",
+  "strategyTypeIdNote": "Next available MamoStrategyRegistry strategy type id. Base mainnet currently has ids 1-4 whitelisted (1=USDC, 2=staking, 3=cbBTC, 4=WETH), so 5 is the first free slot. VERIFY ON-CHAIN before deploy: `cast call $MAMO_STRATEGY_REGISTRY 'latestImplementationById(uint256)(address)' 5 --rpc-url base` MUST return the zero address. NOTE: registry.nextStrategyTypeId() reads 4 (stale) because whitelistImplementation with an explicit non-zero id does NOT advance that counter - the empty-slot check above is the source of truth for availability, not nextStrategyTypeId()."
+}

--- a/config/strategies/LeveragedAeroAccountConfig.json
+++ b/config/strategies/LeveragedAeroAccountConfig.json
@@ -1,11 +1,8 @@
 {
-  "symbol": "USDC",
-  "decimals": 6,
   "token": "USDC",
   "sherwoodStrategy": "SHERWOOD_LEVERAGED_AERO_STRATEGY",
   "syndicateVault": "SHERWOOD_SYNDICATE_VAULT",
   "strategyTypeId": 5,
   "strategyImplementation": "MAMO_LEVERAGED_AERO_STRATEGY_IMPL",
-  "strategyFactory": "MAMO_LEVERAGED_AERO_STRATEGY_FACTORY",
-  "strategyTypeIdNote": "Next available MamoStrategyRegistry strategy type id. Base mainnet currently has ids 1-4 whitelisted (1=USDC, 2=staking, 3=cbBTC, 4=WETH), so 5 is the first free slot. VERIFY ON-CHAIN before deploy: `cast call $MAMO_STRATEGY_REGISTRY 'latestImplementationById(uint256)(address)' 5 --rpc-url base` MUST return the zero address. NOTE: registry.nextStrategyTypeId() reads 4 (stale) because whitelistImplementation with an explicit non-zero id does NOT advance that counter - the empty-slot check above is the source of truth for availability, not nextStrategyTypeId()."
+  "strategyFactory": "MAMO_LEVERAGED_AERO_STRATEGY_FACTORY"
 }

--- a/multisig/mamo-multisig/012_DeployLeveragedAeroAccountSystem.sol
+++ b/multisig/mamo-multisig/012_DeployLeveragedAeroAccountSystem.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {MamoLeveragedAeroStrategyFactory} from "@contracts/MamoLeveragedAeroStrategyFactory.sol";
+import {MamoStrategyRegistry} from "@contracts/MamoStrategyRegistry.sol";
+
+import {Addresses} from "@fps/addresses/Addresses.sol";
+import {MultisigProposal} from "@fps/src/proposals/MultisigProposal.sol";
+
+import {ISyndicateVault} from "@contracts/leveraged-aero/sherwood/interfaces/ISyndicateVault.sol";
+import {DeployLeveragedAeroAccountConfig} from "@script/DeployLeveragedAeroAccountConfig.sol";
+import {LeveragedAeroAccountDeployer} from "@script/LeveragedAeroAccountDeployer.s.sol";
+
+/**
+ * @title DeployLeveragedAeroAccountSystem
+ * @notice Multisig proposal that deploys the MamoLeveragedAeroStrategy account system and wires it into
+ *         the existing MamoStrategyRegistry:
+ *           - deploys the {MamoLeveragedAeroStrategy} implementation + {MamoLeveragedAeroStrategyFactory};
+ *           - whitelists the implementation under a NEW strategy type id (see config);
+ *           - grants the factory BACKEND_ROLE on the registry so it can register user accounts;
+ *           - opens deposits on the SyndicateVault so the accounts can deposit USDC.
+ *
+ * @dev This account has NO Moonwell/Morpho split and NO CowSwap reward path, so there is deliberately
+ *      no SlippagePriceChecker / reward-token configuration here (unlike 010/011).
+ *
+ *      NOT-YET-DEPLOYED DEPENDENCIES: the Sherwood system (SyndicateVault + LeveragedAerodromeCLStrategy)
+ *      is deployed separately — Tenderly vnet Base fork first, Base mainnet after. Until then the address
+ *      book has no `SHERWOOD_LEVERAGED_AERO_STRATEGY` / `SHERWOOD_SYNDICATE_VAULT` entries, so this
+ *      proposal COMPILES but cannot be run end-to-end: any `addresses.getAddress("SHERWOOD_...")` reverts
+ *      until those two keys are added at Sherwood-deploy time. The vault referenced by
+ *      `SHERWOOD_SYNDICATE_VAULT` MUST be owned by MAMO_MULTISIG at execution time for the
+ *      `setOpenDeposits(true)` call in {build} to succeed.
+ */
+contract DeployLeveragedAeroAccountSystem is MultisigProposal {
+    uint256 public immutable strategyTypeId;
+    DeployLeveragedAeroAccountConfig public immutable deployConfig;
+    LeveragedAeroAccountDeployer public immutable accountDeployer;
+
+    string public strategyImplementationKey;
+    string public strategyFactoryKey;
+    string public sherwoodStrategyKey;
+    string public syndicateVaultKey;
+
+    constructor() {
+        deployConfig = new DeployLeveragedAeroAccountConfig("./config/strategies/LeveragedAeroAccountConfig.json");
+        vm.makePersistent(address(deployConfig));
+
+        accountDeployer = new LeveragedAeroAccountDeployer();
+        vm.makePersistent(address(accountDeployer));
+
+        DeployLeveragedAeroAccountConfig.Config memory cfg = deployConfig.getConfig();
+        strategyTypeId = cfg.strategyTypeId;
+        strategyImplementationKey = cfg.strategyImplementation;
+        strategyFactoryKey = cfg.strategyFactory;
+        sherwoodStrategyKey = cfg.sherwoodStrategy;
+        syndicateVaultKey = cfg.syndicateVault;
+    }
+
+    function run() public override {
+        _initializeAddresses();
+
+        if (DO_DEPLOY) {
+            deploy();
+            addresses.printJSONChanges();
+        }
+
+        if (DO_PRE_BUILD_MOCK) preBuildMock();
+        if (DO_BUILD) build();
+        if (DO_SIMULATE) simulate();
+        if (DO_VALIDATE) validate();
+        if (DO_PRINT) print();
+        if (DO_UPDATE_ADDRESS_JSON) addresses.updateJson();
+    }
+
+    function name() public pure override returns (string memory) {
+        return "012_DeployLeveragedAeroAccountSystem";
+    }
+
+    function description() public pure override returns (string memory) {
+        return "Deploy MamoLeveragedAeroStrategy implementation + factory, whitelist the new strategy type, grant the factory BACKEND_ROLE, and open SyndicateVault deposits";
+    }
+
+    function deploy() public override {
+        address deployer = addresses.getAddress("DEPLOYER_EOA");
+        accountDeployer.deployImplementationAndFactory(addresses, deployConfig.getConfig(), deployer);
+    }
+
+    function preBuildMock() public view override {
+        MamoStrategyRegistry registry = MamoStrategyRegistry(addresses.getAddress("MAMO_STRATEGY_REGISTRY"));
+
+        // Availability check (source of truth): the configured type id MUST be an empty slot.
+        // This is the definitive guard against clobbering an existing strategy type.
+        assertEq(
+            registry.latestImplementationById(strategyTypeId),
+            address(0),
+            "Configured strategy type id already has an implementation"
+        );
+
+        // PR #49 (010) pattern verifies `nextStrategyTypeId() == id`. That counter is only advanced when
+        // an implementation is whitelisted with id 0 (auto-assign); whitelisting with an explicit non-zero
+        // id (as 010/011 and this proposal do) leaves it untouched. On Base mainnet it currently reads 4
+        // while ids 1-4 are all filled, i.e. it is a stale lower bound, NOT the next free slot. We assert
+        // the counter has not advanced PAST our chosen slot so the registry's auto-assign path can never
+        // hand out our explicitly-claimed id to another type before this proposal executes.
+        assertLe(registry.nextStrategyTypeId(), strategyTypeId, "nextStrategyTypeId advanced past the configured id");
+    }
+
+    function build() public override buildModifier(addresses.getAddress("MAMO_MULTISIG")) {
+        MamoStrategyRegistry registry = MamoStrategyRegistry(addresses.getAddress("MAMO_STRATEGY_REGISTRY"));
+
+        address implementation = addresses.getAddress(strategyImplementationKey);
+        address factory = addresses.getAddress(strategyFactoryKey);
+
+        // 1. Whitelist the new implementation under the configured (explicit) strategy type id.
+        registry.whitelistImplementation(implementation, strategyTypeId);
+
+        // 2. Grant the factory BACKEND_ROLE so it can register user accounts with the registry.
+        registry.grantRole(registry.BACKEND_ROLE(), factory);
+
+        // 3. Open deposits on the SyndicateVault so the accounts can deposit USDC.
+        //    The vault must be owned by MAMO_MULTISIG at execution time (see contract-level NatSpec).
+        ISyndicateVault(addresses.getAddress(syndicateVaultKey)).setOpenDeposits(true);
+    }
+
+    function simulate() public override {
+        address multisig = addresses.getAddress("MAMO_MULTISIG");
+        _simulateActions(multisig);
+    }
+
+    function validate() public view override {
+        MamoStrategyRegistry registry = MamoStrategyRegistry(addresses.getAddress("MAMO_STRATEGY_REGISTRY"));
+        address implementation = addresses.getAddress(strategyImplementationKey);
+
+        // Implementation is whitelisted and mapped to the configured type id (both directions).
+        assertTrue(registry.whitelistedImplementations(implementation), "Implementation should be whitelisted");
+        assertEq(
+            registry.implementationToId(implementation), strategyTypeId, "Implementation should map to the type id"
+        );
+        assertEq(
+            registry.latestImplementationById(strategyTypeId),
+            implementation,
+            "Latest implementation for the type should be the new implementation"
+        );
+
+        // Factory has BACKEND_ROLE on the registry.
+        address factory = addresses.getAddress(strategyFactoryKey);
+        assertTrue(
+            registry.hasRole(registry.BACKEND_ROLE(), factory), "Factory should have BACKEND_ROLE on the registry"
+        );
+
+        // SyndicateVault deposits are open.
+        assertTrue(
+            ISyndicateVault(addresses.getAddress(syndicateVaultKey)).openDeposits(),
+            "SyndicateVault deposits should be open"
+        );
+
+        // Every factory immutable matches config / address book.
+        _validateFactoryConfig();
+    }
+
+    function _validateFactoryConfig() internal view {
+        MamoLeveragedAeroStrategyFactory factory =
+            MamoLeveragedAeroStrategyFactory(addresses.getAddress(strategyFactoryKey));
+        DeployLeveragedAeroAccountConfig.Config memory cfg = deployConfig.getConfig();
+
+        assertEq(
+            factory.mamoStrategyRegistry(),
+            addresses.getAddress("MAMO_STRATEGY_REGISTRY"),
+            "Factory mamoStrategyRegistry mismatch"
+        );
+        assertEq(
+            factory.strategyImplementation(),
+            addresses.getAddress(strategyImplementationKey),
+            "Factory strategyImplementation mismatch"
+        );
+        assertEq(factory.strategyTypeId(), strategyTypeId, "Factory strategyTypeId mismatch");
+        assertEq(
+            factory.sherwoodStrategy(), addresses.getAddress(cfg.sherwoodStrategy), "Factory sherwoodStrategy mismatch"
+        );
+        assertEq(factory.usdc(), addresses.getAddress(cfg.token), "Factory usdc mismatch");
+
+        // Roles wired at construction: admin = MAMO_MULTISIG, backend = MAMO_BACKEND.
+        assertTrue(
+            factory.hasRole(factory.DEFAULT_ADMIN_ROLE(), addresses.getAddress("MAMO_MULTISIG")),
+            "Factory admin should be MAMO_MULTISIG"
+        );
+        assertTrue(
+            factory.hasRole(factory.BACKEND_ROLE(), addresses.getAddress("MAMO_BACKEND")),
+            "Factory backend should be MAMO_BACKEND"
+        );
+    }
+
+    function _initializeAddresses() internal {
+        string memory addressesFolderPath = "./addresses";
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = block.chainid;
+        addresses = new Addresses(addressesFolderPath, chainIds);
+        vm.makePersistent(address(addresses));
+    }
+}

--- a/script/DeployLeveragedAeroAccountConfig.sol
+++ b/script/DeployLeveragedAeroAccountConfig.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {stdJson} from "forge-std/StdJson.sol";
+import {Test} from "forge-std/Test.sol";
+
+/**
+ * @title DeployLeveragedAeroAccountConfig
+ * @notice Loader for the {MamoLeveragedAeroStrategy} account-system deployment config.
+ * @dev Modeled on {DeployAssetConfig} but deliberately minimal: the leveraged-Aero account has NO
+ *      Moonwell/Morpho market split, NO CowSwap reward path, and therefore NO
+ *      moonwellMarket/metamorphoVault/rewardTokens/priceFeeds. The config carries only what the
+ *      implementation + factory constructors need, plus the strategy type id.
+ *
+ *      Every non-numeric value is an ADDRESS-BOOK KEY (resolved through FPS `Addresses`), not a literal
+ *      address — matching repo convention. Two of those keys ({sherwoodStrategy}, {syndicateVault}) do
+ *      NOT exist in `addresses/8453.json` yet: the Sherwood system (SyndicateVault +
+ *      LeveragedAerodromeCLStrategy) is deployed separately (Tenderly vnet first, Base mainnet after),
+ *      and its addresses are added under those keys at that time.
+ */
+contract DeployLeveragedAeroAccountConfig is Test {
+    using stdJson for string;
+
+    /// @notice Raw JSON contents, kept for ad-hoc getters.
+    string private configData;
+
+    /// @notice Parsed configuration.
+    Config private config;
+
+    struct Config {
+        // Human-readable symbol of the deposit asset (informational).
+        string symbol;
+        // Deposit-asset decimals (USDC = 6).
+        uint8 decimals;
+        // Address-book key of the deposit/payout token (USDC).
+        string token;
+        // Address-book key of the vendored Sherwood leveraged Aerodrome CL strategy.
+        string sherwoodStrategy;
+        // Address-book key of the SyndicateVault whose deposits must be opened.
+        string syndicateVault;
+        // MamoStrategyRegistry strategy type id assigned to this account family.
+        uint256 strategyTypeId;
+        // Address-book key under which the deployed implementation is stored.
+        string strategyImplementation;
+        // Address-book key under which the deployed factory is stored.
+        string strategyFactory;
+    }
+
+    constructor(string memory _configPath) {
+        _loadConfig(_configPath);
+    }
+
+    /// @notice Get the full deployment configuration.
+    function getConfig() public view returns (Config memory) {
+        return config;
+    }
+
+    function _loadConfig(string memory configPath) private {
+        configData = vm.readFile(configPath);
+
+        // Field-by-field decode (avoids whole-struct abi.decode ordering pitfalls).
+        config.symbol = abi.decode(vm.parseJson(configData, ".symbol"), (string));
+        config.decimals = abi.decode(vm.parseJson(configData, ".decimals"), (uint8));
+        config.token = abi.decode(vm.parseJson(configData, ".token"), (string));
+        config.sherwoodStrategy = abi.decode(vm.parseJson(configData, ".sherwoodStrategy"), (string));
+        config.syndicateVault = abi.decode(vm.parseJson(configData, ".syndicateVault"), (string));
+        config.strategyTypeId = abi.decode(vm.parseJson(configData, ".strategyTypeId"), (uint256));
+        config.strategyImplementation = abi.decode(vm.parseJson(configData, ".strategyImplementation"), (string));
+        config.strategyFactory = abi.decode(vm.parseJson(configData, ".strategyFactory"), (string));
+    }
+}

--- a/script/DeployLeveragedAeroAccountConfig.sol
+++ b/script/DeployLeveragedAeroAccountConfig.sol
@@ -28,10 +28,6 @@ contract DeployLeveragedAeroAccountConfig is Test {
     Config private config;
 
     struct Config {
-        // Human-readable symbol of the deposit asset (informational).
-        string symbol;
-        // Deposit-asset decimals (USDC = 6).
-        uint8 decimals;
         // Address-book key of the deposit/payout token (USDC).
         string token;
         // Address-book key of the vendored Sherwood leveraged Aerodrome CL strategy.
@@ -39,6 +35,13 @@ contract DeployLeveragedAeroAccountConfig is Test {
         // Address-book key of the SyndicateVault whose deposits must be opened.
         string syndicateVault;
         // MamoStrategyRegistry strategy type id assigned to this account family.
+        //
+        // Next available MamoStrategyRegistry strategy type id. Base mainnet currently has ids 1-4
+        // whitelisted (1=USDC, 2=staking, 3=cbBTC, 4=WETH), so 5 is the first free slot. VERIFY ON-CHAIN
+        // before deploy: `cast call $MAMO_STRATEGY_REGISTRY 'latestImplementationById(uint256)(address)' 5
+        // --rpc-url base` MUST return the zero address. NOTE: registry.nextStrategyTypeId() reads 4 (stale)
+        // because whitelistImplementation with an explicit non-zero id does NOT advance that counter - the
+        // empty-slot check above is the source of truth for availability, not nextStrategyTypeId().
         uint256 strategyTypeId;
         // Address-book key under which the deployed implementation is stored.
         string strategyImplementation;
@@ -59,8 +62,6 @@ contract DeployLeveragedAeroAccountConfig is Test {
         configData = vm.readFile(configPath);
 
         // Field-by-field decode (avoids whole-struct abi.decode ordering pitfalls).
-        config.symbol = abi.decode(vm.parseJson(configData, ".symbol"), (string));
-        config.decimals = abi.decode(vm.parseJson(configData, ".decimals"), (uint8));
         config.token = abi.decode(vm.parseJson(configData, ".token"), (string));
         config.sherwoodStrategy = abi.decode(vm.parseJson(configData, ".sherwoodStrategy"), (string));
         config.syndicateVault = abi.decode(vm.parseJson(configData, ".syndicateVault"), (string));

--- a/script/LeveragedAeroAccountDeployer.s.sol
+++ b/script/LeveragedAeroAccountDeployer.s.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Script} from "@forge-std/Script.sol";
+import {console} from "@forge-std/console.sol";
+
+import {DeployLeveragedAeroAccountConfig} from "./DeployLeveragedAeroAccountConfig.sol";
+
+import {MamoLeveragedAeroStrategy} from "@contracts/MamoLeveragedAeroStrategy.sol";
+import {MamoLeveragedAeroStrategyFactory} from "@contracts/MamoLeveragedAeroStrategyFactory.sol";
+import {Addresses} from "@fps/addresses/Addresses.sol";
+
+/**
+ * @title LeveragedAeroAccountDeployer
+ * @notice Deploys the {MamoLeveragedAeroStrategy} implementation and its
+ *         {MamoLeveragedAeroStrategyFactory}, resolving all constructor args from FPS `Addresses` and
+ *         the {DeployLeveragedAeroAccountConfig} JSON.
+ * @dev Structured as a reusable helper (mirrors {MultiMarketStrategyFactoryDeployer}) so the
+ *      012 multisig proposal calls into it rather than duplicating deploy logic. Broadcasts under the
+ *      supplied `deployer` EOA and writes both address-book keys.
+ *
+ *      Requires the `SHERWOOD_LEVERAGED_AERO_STRATEGY` and `USDC` keys to resolve at call time; the
+ *      former is added when the Sherwood system is deployed (Tenderly vnet, then Base mainnet).
+ */
+contract LeveragedAeroAccountDeployer is Script {
+    /**
+     * @notice Deploy the implementation (if not already set) and a fresh factory, registering both.
+     * @param addresses The FPS address book.
+     * @param config The loaded leveraged-Aero account config.
+     * @param deployer The EOA to broadcast the deployment transactions from.
+     * @return implementation The MamoLeveragedAeroStrategy implementation address.
+     * @return factory The MamoLeveragedAeroStrategyFactory address.
+     */
+    function deployImplementationAndFactory(
+        Addresses addresses,
+        DeployLeveragedAeroAccountConfig.Config memory config,
+        address deployer
+    ) public returns (address implementation, address factory) {
+        // Resolve constructor dependencies from the address book.
+        address mamoStrategyRegistry = addresses.getAddress("MAMO_STRATEGY_REGISTRY");
+        address admin = addresses.getAddress("MAMO_MULTISIG");
+        address mamoBackend = addresses.getAddress("MAMO_BACKEND");
+        address sherwoodStrategy = addresses.getAddress(config.sherwoodStrategy);
+        address usdc = addresses.getAddress(config.token);
+
+        vm.startBroadcast(deployer);
+
+        // 1. Deploy the UUPS implementation (only once; reuse if already deployed).
+        if (addresses.isAddressSet(config.strategyImplementation)) {
+            implementation = addresses.getAddress(config.strategyImplementation);
+        } else {
+            implementation = address(new MamoLeveragedAeroStrategy());
+        }
+
+        // 2. Deploy the factory wired to the implementation.
+        MamoLeveragedAeroStrategyFactory deployedFactory = new MamoLeveragedAeroStrategyFactory(
+            admin, mamoBackend, mamoStrategyRegistry, implementation, config.strategyTypeId, sherwoodStrategy, usdc
+        );
+        factory = address(deployedFactory);
+
+        vm.stopBroadcast();
+
+        // 3. Register both addresses (create-or-update so re-runs stay idempotent).
+        _setAddress(addresses, config.strategyImplementation, implementation);
+        _setAddress(addresses, config.strategyFactory, factory);
+
+        console.log("MamoLeveragedAeroStrategy implementation:", implementation);
+        console.log("MamoLeveragedAeroStrategyFactory:", factory);
+    }
+
+    function _setAddress(Addresses addresses, string memory key, address value) internal {
+        if (addresses.isAddressSet(key)) {
+            addresses.changeAddress(key, value, true);
+        } else {
+            addresses.addAddress(key, value, true);
+        }
+    }
+}

--- a/src/MamoLeveragedAeroStrategy.sol
+++ b/src/MamoLeveragedAeroStrategy.sol
@@ -29,10 +29,11 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
  *      after the existing ones.
  *
  *      Design notes:
- *      - Terminal/Settled vault-queue exit is deliberately NOT implemented as a bespoke flow. If the
- *        Sherwood strategy settles (or an exit path is otherwise unavailable), the owner's escape hatch
- *        is the inherited `recoverERC20(vaultShares, owner, amount)` to pull the raw shares out and
- *        interact with the vault redemption queue directly.
+ *      - Terminal/Settled vault-queue exit is deliberately NOT implemented as a bespoke flow. The
+ *        inherited `recoverERC20(vaultShares, owner, amount)` is an always-available `onlyOwner` hatch
+ *        (no state gate — it does not go through the withdraw slippage/LTV path, consistent with the
+ *        other Mamo strategies); its intended use here is the Settled terminal state, where the owner
+ *        pulls the raw shares out and interacts with the vault redemption queue directly.
  *      - The fast {withdraw}/{withdrawAll} paths are oracle-dependent and LTV-gated: they revert when the
  *        oracle is down or the LTV gate trips, in which case the owner should route through the async
  *        {requestWithdraw} flow instead.
@@ -130,17 +131,24 @@ contract MamoLeveragedAeroStrategy is Initializable, UUPSUpgradeable, BaseStrate
     }
 
     /**
-     * @notice Deposit this account's entire idle USDC balance into the Sherwood strategy (permissionless).
+     * @notice Deposit this account's entire idle USDC balance into the Sherwood strategy (owner or backend).
      * @dev Users can plain-transfer USDC to their account; the backend then nudges it in via this call
      *      (mirrors `depositIdleTokens` in MamoMultiMarketStrategy). Reverts if there is no idle USDC.
      *
-     *      Note the interaction with {claimWithdrawnUsdc}: idle USDC is ambiguous — it may be pending
-     *      re-deposit OR a fulfilled async withdrawal. The owner claims withdrawals explicitly via
-     *      {claimWithdrawnUsdc}; the backend should only call this when a re-deposit is intended.
+     *      Gated to the owner or the registry backend — the repo's trusted-actor pattern. This closes the
+     *      anonymous-griefer vector: because idle USDC is ambiguous (it may be pending re-deposit OR a
+     *      fulfilled async withdrawal awaiting {claimWithdrawnUsdc}), a permissionless call let any third
+     *      party front-run the owner's {claimWithdrawnUsdc} and force a fulfilled withdrawal back into the
+     *      leveraged position (repeatable re-lock griefing). A residual footgun remains between the two
+     *      trusted actors: the owner claims withdrawals explicitly via {claimWithdrawnUsdc}, so the backend
+     *      must only call this when a re-deposit is intended, and the owner and backend coordinate which
+     *      idle USDC is which.
      * @param minShares Minimum vault shares to accept (slippage guard).
      * @return shares Vault shares minted to this account (12dp).
      */
     function depositIdle(uint256 minShares) external returns (uint256 shares) {
+        require(msg.sender == owner() || msg.sender == mamoStrategyRegistry.getBackendAddress(), "Not owner or backend");
+
         uint256 assets = usdc.balanceOf(address(this));
         require(assets > 0, "No idle USDC to deposit");
 
@@ -223,9 +231,7 @@ contract MamoLeveragedAeroStrategy is Initializable, UUPSUpgradeable, BaseStrate
     function emergencyWithdraw(uint256 id, uint256 minAssetsOut) external onlyOwner returns (uint256 assetsOut) {
         assetsOut = sherwoodStrategy.emergencyRedeem(id, minAssetsOut);
 
-        if (assetsOut > 0) {
-            usdc.safeTransfer(owner(), assetsOut);
-        }
+        _forwardToOwner(assetsOut);
 
         emit WithdrawEmergency(id, assetsOut);
     }
@@ -269,10 +275,10 @@ contract MamoLeveragedAeroStrategy is Initializable, UUPSUpgradeable, BaseStrate
 
     /**
      * @notice The Sherwood strategy's lifecycle state (pass-through).
-     * @return The state as a uint8 (0 = Pending, 1 = Executed, 2 = Settled).
+     * @return The strategy lifecycle state.
      */
-    function strategyState() external view returns (uint8) {
-        return uint8(sherwoodStrategy.state());
+    function strategyState() external view returns (ILeveragedAeroCLStrategy.State) {
+        return sherwoodStrategy.state();
     }
 
     // ==================== INTERNAL ====================
@@ -288,8 +294,16 @@ contract MamoLeveragedAeroStrategy is Initializable, UUPSUpgradeable, BaseStrate
         vaultShares.forceApprove(address(sherwoodStrategy), shares);
         assetsOut = sherwoodStrategy.redeem(shares, minAssetsOut);
 
-        if (assetsOut > 0) {
-            usdc.safeTransfer(owner(), assetsOut);
+        _forwardToOwner(assetsOut);
+    }
+
+    /**
+     * @notice Forward `amount` USDC to the owner, skipping the transfer when there is nothing to send.
+     * @param amount USDC to forward to the owner (6dp).
+     */
+    function _forwardToOwner(uint256 amount) private {
+        if (amount > 0) {
+            usdc.safeTransfer(owner(), amount);
         }
     }
 }

--- a/src/MamoLeveragedAeroStrategy.sol
+++ b/src/MamoLeveragedAeroStrategy.sol
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {BaseStrategy} from "@contracts/BaseStrategy.sol";
+import {ILeveragedAeroCLStrategy} from "@interfaces/ILeveragedAeroCLStrategy.sol";
+
+import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title MamoLeveragedAeroStrategy
+ * @notice A per-user Mamo account contract that wraps the vendored Sherwood leveraged Aerodrome CL
+ *         strategy. It holds SyndicateVault shares on the user's behalf and drives the Sherwood
+ *         strategy externally: USDC (6dp) flows in on deposit, vault shares are custodied here, and
+ *         USDC flows back out to the owner on every withdrawal path.
+ * @dev This contract inherits Mamo's {BaseStrategy} (Initializable + UUPSUpgradeable +
+ *      OwnableUpgradeable). It deliberately does NOT inherit or extend the Sherwood
+ *      `LeveragedAerodromeCLStrategy` — that contract inherits Sherwood's incompatible
+ *      vault/proposer base — and interacts with it only through {ILeveragedAeroCLStrategy}.
+ *
+ *      Deployed behind an {ERC1967Proxy} and used as a UUPS implementation, so all initialization runs
+ *      through {initialize} rather than a constructor.
+ *
+ *      Storage: {BaseStrategy} occupies slots 0-49 (registry, strategyTypeId, and a 48-slot gap), so
+ *      this contract's concrete state starts at slot 50. Matching the repo convention set by
+ *      {MamoStakingStrategy}, no additional trailing storage gap is declared here; future fields append
+ *      after the existing ones.
+ *
+ *      Design notes:
+ *      - Terminal/Settled vault-queue exit is deliberately NOT implemented as a bespoke flow. If the
+ *        Sherwood strategy settles (or an exit path is otherwise unavailable), the owner's escape hatch
+ *        is the inherited `recoverERC20(vaultShares, owner, amount)` to pull the raw shares out and
+ *        interact with the vault redemption queue directly.
+ *      - The fast {withdraw}/{withdrawAll} paths are oracle-dependent and LTV-gated: they revert when the
+ *        oracle is down or the LTV gate trips, in which case the owner should route through the async
+ *        {requestWithdraw} flow instead.
+ *      - Approvals use `forceApprove` for the exact amount immediately before each external call; no
+ *        standing approvals are left outstanding.
+ */
+contract MamoLeveragedAeroStrategy is Initializable, UUPSUpgradeable, BaseStrategy {
+    using SafeERC20 for IERC20;
+
+    /// @notice The vendored Sherwood leveraged Aerodrome CL strategy this account drives.
+    ILeveragedAeroCLStrategy public sherwoodStrategy;
+
+    /// @notice The SyndicateVault share token (12dp) held by this account; also the token approved to
+    ///         the Sherwood strategy for redeem/request flows.
+    IERC20 public vaultShares;
+
+    /// @notice The USDC token (6dp): the deposit asset and the withdrawal payout token.
+    IERC20 public usdc;
+
+    /// @notice Emitted when USDC is deposited and vault shares are minted to this account.
+    event Deposit(address indexed depositor, uint256 assets, uint256 shares);
+
+    /// @notice Emitted on a fast-path withdrawal that pays USDC to the owner.
+    event Withdraw(address indexed owner, uint256 shares, uint256 assetsOut);
+
+    /// @notice Emitted when an async redeem request is created.
+    event WithdrawRequested(uint256 indexed id, uint256 shares, uint256 minAssetsOut);
+
+    /// @notice Emitted when an async redeem request is cancelled and shares are returned to this account.
+    event WithdrawCancelled(uint256 indexed id);
+
+    /// @notice Emitted on a trustless emergency redeem that pays USDC to the owner.
+    event WithdrawEmergency(uint256 indexed id, uint256 assetsOut);
+
+    /// @notice Emitted when idle USDC on this account is swept to the owner.
+    event UsdcClaimed(uint256 amount);
+
+    /// @notice Initialization parameters struct to avoid stack-too-deep and keep the ABI stable.
+    struct InitParams {
+        address mamoStrategyRegistry;
+        uint256 strategyTypeId;
+        address owner;
+        address sherwoodStrategy;
+        address usdc;
+    }
+
+    /**
+     * @notice Constructor disables initializers in the implementation contract.
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initializer that wires the account to the Mamo registry and the Sherwood strategy.
+     * @dev Used instead of a constructor since the contract is deployed behind a proxy. The vault
+     *      share token is derived from `sherwoodStrategy.vault()` (single source of truth) rather than
+     *      passed separately.
+     * @param params The initialization parameters struct.
+     */
+    function initialize(InitParams calldata params) external initializer {
+        require(params.mamoStrategyRegistry != address(0), "Invalid mamoStrategyRegistry address");
+        require(params.strategyTypeId != 0, "Strategy type id not set");
+        require(params.owner != address(0), "Invalid owner address");
+        require(params.sherwoodStrategy != address(0), "Invalid sherwoodStrategy address");
+        require(params.usdc != address(0), "Invalid usdc address");
+
+        __BaseStrategy_init(params.mamoStrategyRegistry, params.strategyTypeId, params.owner);
+
+        sherwoodStrategy = ILeveragedAeroCLStrategy(params.sherwoodStrategy);
+        usdc = IERC20(params.usdc);
+
+        address vault = sherwoodStrategy.vault();
+        require(vault != address(0), "Invalid vault address");
+        vaultShares = IERC20(vault);
+    }
+
+    /**
+     * @notice Deposit USDC into the Sherwood strategy, minting vault shares to this account (permissionless).
+     * @dev Pulls `assets` USDC from the caller, approves the exact amount to the strategy, and deposits.
+     *      Permissionless by design so the backend or any keeper can fund the account; the resulting
+     *      shares are always custodied by this account and remain under owner control.
+     * @param assets USDC to deposit (6dp).
+     * @param minShares Minimum vault shares to accept (slippage guard).
+     * @return shares Vault shares minted to this account (12dp).
+     */
+    function deposit(uint256 assets, uint256 minShares) external returns (uint256 shares) {
+        require(assets > 0, "Amount must be greater than 0");
+
+        usdc.safeTransferFrom(msg.sender, address(this), assets);
+        usdc.forceApprove(address(sherwoodStrategy), assets);
+        shares = sherwoodStrategy.deposit(assets, minShares);
+
+        emit Deposit(msg.sender, assets, shares);
+    }
+
+    /**
+     * @notice Deposit this account's entire idle USDC balance into the Sherwood strategy (permissionless).
+     * @dev Users can plain-transfer USDC to their account; the backend then nudges it in via this call
+     *      (mirrors `depositIdleTokens` in MamoMultiMarketStrategy). Reverts if there is no idle USDC.
+     *
+     *      Note the interaction with {claimWithdrawnUsdc}: idle USDC is ambiguous — it may be pending
+     *      re-deposit OR a fulfilled async withdrawal. The owner claims withdrawals explicitly via
+     *      {claimWithdrawnUsdc}; the backend should only call this when a re-deposit is intended.
+     * @param minShares Minimum vault shares to accept (slippage guard).
+     * @return shares Vault shares minted to this account (12dp).
+     */
+    function depositIdle(uint256 minShares) external returns (uint256 shares) {
+        uint256 assets = usdc.balanceOf(address(this));
+        require(assets > 0, "No idle USDC to deposit");
+
+        usdc.forceApprove(address(sherwoodStrategy), assets);
+        shares = sherwoodStrategy.deposit(assets, minShares);
+
+        emit Deposit(msg.sender, assets, shares);
+    }
+
+    /**
+     * @notice Fast-path withdrawal of `shares`, paying USDC to the owner.
+     * @dev Approves the exact share amount to the strategy, calls its oracle-priced `redeem`, and
+     *      forwards the returned USDC to the owner. The fast path reverts when the oracle is down or the
+     *      LTV gate trips — in that case use {requestWithdraw} instead.
+     * @param shares Vault shares to redeem (12dp).
+     * @param minAssetsOut Minimum USDC out (slippage guard).
+     * @return assetsOut USDC forwarded to the owner (6dp).
+     */
+    function withdraw(uint256 shares, uint256 minAssetsOut) external onlyOwner returns (uint256 assetsOut) {
+        require(shares > 0, "Amount must be greater than 0");
+
+        assetsOut = _redeemAndForward(shares, minAssetsOut);
+
+        emit Withdraw(owner(), shares, assetsOut);
+    }
+
+    /**
+     * @notice Fast-path withdrawal of this account's entire vault-share balance, paying USDC to the owner.
+     * @dev Same oracle/LTV constraints as {withdraw}; route to {requestWithdraw} if the fast path reverts.
+     * @param minAssetsOut Minimum USDC out (slippage guard).
+     * @return assetsOut USDC forwarded to the owner (6dp).
+     */
+    function withdrawAll(uint256 minAssetsOut) external onlyOwner returns (uint256 assetsOut) {
+        uint256 shares = vaultShares.balanceOf(address(this));
+        require(shares > 0, "No shares to withdraw");
+
+        assetsOut = _redeemAndForward(shares, minAssetsOut);
+
+        emit Withdraw(owner(), shares, assetsOut);
+    }
+
+    /**
+     * @notice Create an async redeem request for `shares` (the exit for sizes the fast path can't serve,
+     *         or when the oracle is down).
+     * @dev Approves the exact share amount to the strategy and escrows the shares there. The backend
+     *      later fulfills the request; the resulting USDC lands on this account with no callback and is
+     *      swept to the owner via {claimWithdrawnUsdc}.
+     * @param shares Vault shares to escrow (12dp).
+     * @param minAssetsOut Slippage floor enforced at fulfill.
+     * @return id The request id.
+     */
+    function requestWithdraw(uint256 shares, uint256 minAssetsOut) external onlyOwner returns (uint256 id) {
+        require(shares > 0, "Amount must be greater than 0");
+
+        vaultShares.forceApprove(address(sherwoodStrategy), shares);
+        id = sherwoodStrategy.requestRedeem(shares, minAssetsOut);
+
+        emit WithdrawRequested(id, shares, minAssetsOut);
+    }
+
+    /**
+     * @notice Cancel an outstanding async redeem request, returning the escrowed shares to this account.
+     * @param id Request id to cancel.
+     */
+    function cancelWithdraw(uint256 id) external onlyOwner {
+        sherwoodStrategy.cancelRedeem(id);
+
+        emit WithdrawCancelled(id);
+    }
+
+    /**
+     * @notice Trustless emergency redeem of an unfulfilled request after the strategy's fulfill window,
+     *         paying USDC to the owner.
+     * @dev The strategy pays USDC directly to `msg.sender` (this account); the received amount is then
+     *      forwarded to the owner.
+     * @param id Request id (owner-gated on the strategy side too).
+     * @param minAssetsOut Fresh slippage floor on the net payout.
+     * @return assetsOut USDC forwarded to the owner (6dp).
+     */
+    function emergencyWithdraw(uint256 id, uint256 minAssetsOut) external onlyOwner returns (uint256 assetsOut) {
+        assetsOut = sherwoodStrategy.emergencyRedeem(id, minAssetsOut);
+
+        if (assetsOut > 0) {
+            usdc.safeTransfer(owner(), assetsOut);
+        }
+
+        emit WithdrawEmergency(id, assetsOut);
+    }
+
+    /**
+     * @notice Sweep this account's entire idle USDC balance to the owner.
+     * @dev After the backend fulfills an async request, USDC lands on this account with no callback;
+     *      this is the owner's explicit claim. It sweeps whatever USDC is idle here — which may include
+     *      funds intended for re-deposit (see {depositIdle}); the owner and backend coordinate which is
+     *      which, since idle USDC is inherently ambiguous.
+     * @return amount USDC swept to the owner (6dp).
+     */
+    function claimWithdrawnUsdc() external onlyOwner returns (uint256 amount) {
+        amount = usdc.balanceOf(address(this));
+        require(amount > 0, "No USDC to claim");
+
+        usdc.safeTransfer(owner(), amount);
+
+        emit UsdcClaimed(amount);
+    }
+
+    // ==================== VIEWS ====================
+
+    /**
+     * @notice The vault shares (12dp) currently held by this account.
+     * @return The vault-share balance.
+     */
+    function sharesBalance() external view returns (uint256) {
+        return vaultShares.balanceOf(address(this));
+    }
+
+    /**
+     * @notice Advisory preview of a fast-path withdrawal (pass-through to the strategy).
+     * @param shares Vault shares to preview (12dp).
+     * @return assetsOut Predicted USDC out (0 when unpriceable or the payout floors to 0).
+     * @return fastOk True iff the fast path would price and clear the LTV gate (advisory).
+     */
+    function previewWithdraw(uint256 shares) external view returns (uint256 assetsOut, bool fastOk) {
+        return sherwoodStrategy.previewRedeem(shares);
+    }
+
+    /**
+     * @notice The Sherwood strategy's lifecycle state (pass-through).
+     * @return The state as a uint8 (0 = Pending, 1 = Executed, 2 = Settled).
+     */
+    function strategyState() external view returns (uint8) {
+        return uint8(sherwoodStrategy.state());
+    }
+
+    // ==================== INTERNAL ====================
+
+    /**
+     * @notice Shared body of {withdraw}/{withdrawAll}: approve the exact shares, fast-redeem, and forward
+     *         the returned USDC to the owner.
+     * @param shares Vault shares to redeem (12dp).
+     * @param minAssetsOut Minimum USDC out (slippage guard).
+     * @return assetsOut USDC forwarded to the owner (6dp).
+     */
+    function _redeemAndForward(uint256 shares, uint256 minAssetsOut) internal returns (uint256 assetsOut) {
+        vaultShares.forceApprove(address(sherwoodStrategy), shares);
+        assetsOut = sherwoodStrategy.redeem(shares, minAssetsOut);
+
+        if (assetsOut > 0) {
+            usdc.safeTransfer(owner(), assetsOut);
+        }
+    }
+}

--- a/src/MamoLeveragedAeroStrategyFactory.sol
+++ b/src/MamoLeveragedAeroStrategyFactory.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {ERC1967Proxy} from "./ERC1967Proxy.sol";
+import {MamoLeveragedAeroStrategy} from "./MamoLeveragedAeroStrategy.sol";
+import {IMamoStrategyRegistry} from "./interfaces/IMamoStrategyRegistry.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+
+/**
+ * @title MamoLeveragedAeroStrategyFactory
+ * @notice Factory for creating per-user {MamoLeveragedAeroStrategy} accounts.
+ * @dev Deploys {ERC1967Proxy} instances pointing to a shared {MamoLeveragedAeroStrategy} implementation
+ *      via CREATE2 (deterministic address keyed on the user), initializes them, and registers them with
+ *      the {IMamoStrategyRegistry}. Creation is gated to the backend role or the user themselves.
+ */
+contract MamoLeveragedAeroStrategyFactory is AccessControl {
+    /// @notice Backend role for strategy creation operations.
+    bytes32 public constant BACKEND_ROLE = keccak256("BACKEND_ROLE");
+
+    /// @notice The MamoStrategyRegistry that tracks and owns strategy registration.
+    address public immutable mamoStrategyRegistry;
+
+    /// @notice The {MamoLeveragedAeroStrategy} implementation the proxies delegate to.
+    address public immutable strategyImplementation;
+
+    /// @notice The strategy type ID assigned to accounts created by this factory.
+    uint256 public immutable strategyTypeId;
+
+    /// @notice The vendored Sherwood leveraged Aerodrome CL strategy each account drives.
+    address public immutable sherwoodStrategy;
+
+    /// @notice The USDC token (6dp) used by the accounts.
+    address public immutable usdc;
+
+    /// @notice Typed reference to the MamoStrategyRegistry.
+    IMamoStrategyRegistry public immutable mamoStrategyRegistryInterface;
+
+    /// @notice Emitted when a new account is created for a user.
+    event StrategyCreated(address indexed user, address indexed strategy);
+
+    /**
+     * @notice Constructor that initializes the factory with all required parameters.
+     * @param _admin Address granted the DEFAULT_ADMIN_ROLE.
+     * @param _mamoBackend Address granted the BACKEND_ROLE (the Mamo backend).
+     * @param _mamoStrategyRegistry Address of the MamoStrategyRegistry contract.
+     * @param _strategyImplementation Address of the MamoLeveragedAeroStrategy implementation.
+     * @param _strategyTypeId The strategy type ID (must be non-zero).
+     * @param _sherwoodStrategy Address of the Sherwood leveraged Aerodrome CL strategy.
+     * @param _usdc Address of the USDC token.
+     */
+    constructor(
+        address _admin,
+        address _mamoBackend,
+        address _mamoStrategyRegistry,
+        address _strategyImplementation,
+        uint256 _strategyTypeId,
+        address _sherwoodStrategy,
+        address _usdc
+    ) {
+        require(_admin != address(0), "Invalid admin address");
+        require(_mamoBackend != address(0), "Invalid mamoBackend address");
+        require(_mamoStrategyRegistry != address(0), "Invalid mamoStrategyRegistry address");
+        require(_strategyImplementation != address(0), "Invalid strategyImplementation address");
+        require(_strategyImplementation.code.length > 0, "Implementation must be a contract");
+        require(_strategyTypeId != 0, "Strategy type id not set");
+        require(_sherwoodStrategy != address(0), "Invalid sherwoodStrategy address");
+        require(_usdc != address(0), "Invalid usdc address");
+
+        // Set up roles
+        _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+        _grantRole(BACKEND_ROLE, _mamoBackend);
+
+        mamoStrategyRegistry = _mamoStrategyRegistry;
+        strategyImplementation = _strategyImplementation;
+        strategyTypeId = _strategyTypeId;
+        sherwoodStrategy = _sherwoodStrategy;
+        usdc = _usdc;
+
+        mamoStrategyRegistryInterface = IMamoStrategyRegistry(_mamoStrategyRegistry);
+    }
+
+    /**
+     * @notice Computes the deterministic address for a user's account.
+     * @param user The address of the user.
+     * @return The deterministic address where the account will be deployed.
+     */
+    function computeStrategyAddress(address user) public view returns (address) {
+        bytes32 salt = keccak256(abi.encodePacked(user));
+
+        bytes memory bytecode =
+            abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(strategyImplementation, ""));
+
+        return Create2.computeAddress(salt, keccak256(bytecode));
+    }
+
+    /**
+     * @notice Creates a new {MamoLeveragedAeroStrategy} account for a user.
+     * @dev Callable by an account with the BACKEND_ROLE or by the user themselves. Reverts if the
+     *      account already exists. Deploys the proxy via CREATE2, initializes it, and registers it with
+     *      the MamoStrategyRegistry.
+     * @param user The address of the user to create the account for.
+     * @return strategy The address of the newly created account.
+     */
+    function createStrategyForUser(address user) public returns (address strategy) {
+        require(user != address(0), "Invalid user address");
+        require(hasRole(BACKEND_ROLE, msg.sender) || msg.sender == user, "Only backend or user can create strategy");
+
+        address strategyAddress = computeStrategyAddress(user);
+        // Check if strategy already exists
+        require(strategyAddress.code.length == 0, "Strategy already exists");
+
+        // Generate salt for deterministic deployment (only user address)
+        bytes32 salt = keccak256(abi.encodePacked(user));
+
+        // Deploy the proxy using CREATE2 with deterministic address
+        bytes memory bytecode =
+            abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(strategyImplementation, ""));
+
+        strategy = Create2.deploy(0, salt, bytecode);
+
+        // Initialize the account with the parameters
+        MamoLeveragedAeroStrategy(payable(strategy))
+            .initialize(
+                MamoLeveragedAeroStrategy.InitParams({
+                mamoStrategyRegistry: mamoStrategyRegistry,
+                strategyTypeId: strategyTypeId,
+                owner: user,
+                sherwoodStrategy: sherwoodStrategy,
+                usdc: usdc
+            })
+            );
+
+        // Register the account with the MamoStrategyRegistry
+        mamoStrategyRegistryInterface.addStrategy(user, strategy);
+
+        emit StrategyCreated(user, strategy);
+
+        return strategy;
+    }
+
+    /**
+     * @notice Alias for {createStrategyForUser}.
+     * @param user The address of the user to create the account for.
+     * @return strategy The address of the newly created account.
+     */
+    function createStrategy(address user) external returns (address strategy) {
+        return createStrategyForUser(user);
+    }
+}

--- a/src/MamoLeveragedAeroStrategyFactory.sol
+++ b/src/MamoLeveragedAeroStrategyFactory.sol
@@ -120,16 +120,15 @@ contract MamoLeveragedAeroStrategyFactory is AccessControl {
         strategy = Create2.deploy(0, salt, bytecode);
 
         // Initialize the account with the parameters
-        MamoLeveragedAeroStrategy(payable(strategy))
-            .initialize(
-                MamoLeveragedAeroStrategy.InitParams({
+        MamoLeveragedAeroStrategy(payable(strategy)).initialize(
+            MamoLeveragedAeroStrategy.InitParams({
                 mamoStrategyRegistry: mamoStrategyRegistry,
                 strategyTypeId: strategyTypeId,
                 owner: user,
                 sherwoodStrategy: sherwoodStrategy,
                 usdc: usdc
             })
-            );
+        );
 
         // Register the account with the MamoStrategyRegistry
         mamoStrategyRegistryInterface.addStrategy(user, strategy);

--- a/src/interfaces/ILeveragedAeroCLStrategy.sol
+++ b/src/interfaces/ILeveragedAeroCLStrategy.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+/**
+ * @title ILeveragedAeroCLStrategy
+ * @notice Minimal interface for the vendored Sherwood {LeveragedAerodromeCLStrategy}, exposing
+ *         exactly the entrypoints and views that {MamoLeveragedAeroStrategy} drives externally.
+ * @dev Signatures are verified byte-for-byte against
+ *      `src/leveraged-aero/LeveragedAerodromeCLStrategy.sol` and its base
+ *      `src/leveraged-aero/sherwood/BaseStrategy.sol`. This interface is intentionally NOT the full
+ *      strategy surface: it omits proposer-only ops (deployIdle / compound / rerange / adjustLeverage /
+ *      fulfillRedeem), the settle/execute lifecycle, and the diamond-storage views. Importing the
+ *      concrete contract would drag in the entire vendored dependency tree, so the wrapper depends on
+ *      this narrow interface instead.
+ *
+ *      The vault (share ERC-20) is deliberately not typed here: the wrapper reads/approves shares via
+ *      the OpenZeppelin `IERC20` returned by {vault}, since the vendored `ISyndicateVault` does not
+ *      extend `IERC20`.
+ */
+interface ILeveragedAeroCLStrategy {
+    /// @notice Strategy lifecycle state. Ordering MUST match Sherwood's `BaseStrategy.State`.
+    enum State {
+        Pending, // 0
+        Executed, // 1
+        Settled // 2
+    }
+
+    /**
+     * @notice Oracle-priced deposit: pulls `assets` USDC via `safeTransferFrom(msg.sender)` and mints
+     *         vault shares to `msg.sender`. Requires `state() == State.Executed`.
+     * @param assets USDC to deposit (6dp).
+     * @param minShares Minimum vault shares to accept (slippage guard).
+     * @return shares Vault shares minted to the caller (12dp).
+     */
+    function deposit(uint256 assets, uint256 minShares) external returns (uint256 shares);
+
+    /**
+     * @notice Oracle-priced fast-path redeem. Pulls `shares` from `msg.sender` via `safeTransferFrom`
+     *         (caller must approve the strategy on the VAULT token first) and pays USDC to `msg.sender`.
+     * @dev Can revert on oracle staleness or when the withdraw would breach `maxLtvBps`
+     *      (`FastRedeemExceedsLtv`); callers should fall back to {requestRedeem}.
+     * @param shares Vault shares to redeem (12dp).
+     * @param minAssetsOut Minimum USDC out (slippage guard).
+     * @return assetsOut USDC paid to the caller (6dp).
+     */
+    function redeem(uint256 shares, uint256 minAssetsOut) external returns (uint256 assetsOut);
+
+    /**
+     * @notice Escrows `shares` for an async proportional redeem. Pulls shares via `safeTransferFrom`
+     *         (caller must approve the strategy on the VAULT token first).
+     * @param shares Vault shares to escrow (12dp).
+     * @param minAssetsOut Slippage floor enforced at fulfill.
+     * @return id The request id.
+     */
+    function requestRedeem(uint256 shares, uint256 minAssetsOut) external returns (uint256 id);
+
+    /**
+     * @notice Cancels an unsettled request and returns the escrowed shares to its owner.
+     * @dev Request owner only; callable in ANY strategy state.
+     * @param id Request id to cancel.
+     */
+    function cancelRedeem(uint256 id) external;
+
+    /**
+     * @notice Deadman trustless backstop: after the fulfill window elapses on an unfulfilled request,
+     *         its owner may self-fulfill via an oracle-free proportional unwind; pays USDC to `msg.sender`.
+     * @param id Request id (owner-gated).
+     * @param minAssetsOut Fresh slippage floor on the net payout.
+     * @return assetsOut USDC paid to the caller (6dp).
+     */
+    function emergencyRedeem(uint256 id, uint256 minAssetsOut) external returns (uint256 assetsOut);
+
+    /**
+     * @notice Advisory preview of the fast-path redeem.
+     * @param shares Vault shares to preview (12dp).
+     * @return assetsOut Predicted USDC out (0 when unpriceable or the payout floors to 0).
+     * @return fastOk True iff the fast path would price AND clear the LTV gate (advisory).
+     */
+    function previewRedeem(uint256 shares) external view returns (uint256 assetsOut, bool fastOk);
+
+    /// @notice The current strategy lifecycle state.
+    function state() external view returns (State);
+
+    /// @notice The SyndicateVault (share ERC-20) this strategy mints/burns against.
+    function vault() external view returns (address);
+}

--- a/src/interfaces/ILeveragedAeroCLStrategy.sol
+++ b/src/interfaces/ILeveragedAeroCLStrategy.sol
@@ -23,6 +23,7 @@ interface ILeveragedAeroCLStrategy {
         Pending, // 0
         Executed, // 1
         Settled // 2
+
     }
 
     /**

--- a/test/MamoLeveragedAeroStrategy.unit.t.sol
+++ b/test/MamoLeveragedAeroStrategy.unit.t.sol
@@ -1,0 +1,599 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {ERC1967Proxy} from "@contracts/ERC1967Proxy.sol";
+import {MamoLeveragedAeroStrategy} from "@contracts/MamoLeveragedAeroStrategy.sol";
+import {MamoLeveragedAeroStrategyFactory} from "@contracts/MamoLeveragedAeroStrategyFactory.sol";
+import {MamoStrategyRegistry} from "@contracts/MamoStrategyRegistry.sol";
+
+import {ILeveragedAeroCLStrategy} from "@interfaces/ILeveragedAeroCLStrategy.sol";
+
+import {MockLeveragedAeroCLStrategy} from "./mocks/MockLeveragedAeroCLStrategy.sol";
+import {MockSyndicateVault} from "./mocks/MockSyndicateVault.sol";
+import {MockToken} from "./mocks/MockToken.sol";
+
+import {Test} from "@forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title MamoLeveragedAeroStrategy unit tests
+ * @notice Fork-free unit suite (runs under `make test-unit`) for the per-user wrapper account and its
+ *         factory, exercised against mocks of the (undeployed) Sherwood vault + strategy.
+ */
+contract MamoLeveragedAeroStrategyUnitTest is Test {
+    // ---- events mirrored from the production contracts (for vm.expectEmit) ----
+    event Deposit(address indexed depositor, uint256 assets, uint256 shares);
+    event Withdraw(address indexed owner, uint256 shares, uint256 assetsOut);
+    event WithdrawRequested(uint256 indexed id, uint256 shares, uint256 minAssetsOut);
+    event WithdrawCancelled(uint256 indexed id);
+    event WithdrawEmergency(uint256 indexed id, uint256 assetsOut);
+    event UsdcClaimed(uint256 amount);
+    event StrategyCreated(address indexed user, address indexed strategy);
+    event StrategyOwnerUpdated(address indexed strategy, address indexed oldOwner, address indexed newOwner);
+
+    bytes32 public constant BACKEND_ROLE = keccak256("BACKEND_ROLE");
+
+    address public admin = makeAddr("admin");
+    address public backend = makeAddr("backend");
+    address public guardian = makeAddr("guardian");
+    address public user = makeAddr("user");
+    address public thirdParty = makeAddr("thirdParty");
+
+    MockToken public usdc;
+    MockSyndicateVault public vault;
+    MockLeveragedAeroCLStrategy public sherwood;
+    MamoStrategyRegistry public registry;
+    MamoLeveragedAeroStrategy public impl;
+    MamoLeveragedAeroStrategyFactory public factory;
+    uint256 public typeId;
+
+    // Convenience: 1000 USDC (6dp) deposits to 1000 whole shares (12dp) at par.
+    uint256 internal constant DEPOSIT = 1_000e6;
+    uint256 internal constant EXPECTED_SHARES = 1_000e12;
+
+    function setUp() public {
+        usdc = new MockToken("USD Coin", "USDC", 6);
+        vault = new MockSyndicateVault();
+        sherwood = new MockLeveragedAeroCLStrategy(address(vault), address(usdc));
+        vault.setStrategy(address(sherwood));
+
+        registry = new MamoStrategyRegistry(admin, backend, guardian);
+
+        impl = new MamoLeveragedAeroStrategy();
+
+        vm.prank(admin);
+        typeId = registry.whitelistImplementation(address(impl), 0);
+
+        factory = new MamoLeveragedAeroStrategyFactory(
+            admin, backend, address(registry), address(impl), typeId, address(sherwood), address(usdc)
+        );
+
+        vm.prank(admin);
+        registry.grantRole(BACKEND_ROLE, address(factory));
+    }
+
+    // ==================== HELPERS ====================
+
+    function _createStrategy(address forUser) internal returns (MamoLeveragedAeroStrategy) {
+        vm.prank(backend);
+        address strategy = factory.createStrategyForUser(forUser);
+        return MamoLeveragedAeroStrategy(payable(strategy));
+    }
+
+    /// @dev Funds `from` with `amount` USDC and approves the strategy to pull it.
+    function _fundAndApprove(address from, address strategy, uint256 amount) internal {
+        usdc.mint(from, amount);
+        vm.prank(from);
+        usdc.approve(strategy, amount);
+    }
+
+    function _deposit(MamoLeveragedAeroStrategy strategy, address from, uint256 amount)
+        internal
+        returns (uint256 shares)
+    {
+        _fundAndApprove(from, address(strategy), amount);
+        vm.prank(from);
+        shares = strategy.deposit(amount, 0);
+    }
+
+    // ==================== FACTORY: CREATE ====================
+
+    function testCreateAsBackend() public {
+        address predicted = factory.computeStrategyAddress(user);
+
+        vm.expectEmit(true, true, false, true, address(factory));
+        emit StrategyCreated(user, predicted);
+
+        vm.prank(backend);
+        address strategy = factory.createStrategyForUser(user);
+
+        assertEq(strategy, predicted, "address mismatch");
+        assertTrue(registry.isUserStrategy(user, strategy), "not registered");
+        assertEq(MamoLeveragedAeroStrategy(payable(strategy)).owner(), user, "owner");
+        assertEq(MamoLeveragedAeroStrategy(payable(strategy)).strategyTypeId(), typeId, "typeId");
+        assertEq(ERC1967Proxy(payable(strategy)).getImplementation(), address(impl), "impl");
+    }
+
+    function testCreateAsUserThemselves() public {
+        vm.prank(user);
+        address strategy = factory.createStrategyForUser(user);
+        assertTrue(registry.isUserStrategy(user, strategy));
+    }
+
+    function testCreateAsThirdPartyReverts() public {
+        vm.prank(thirdParty);
+        vm.expectRevert("Only backend or user can create strategy");
+        factory.createStrategyForUser(user);
+    }
+
+    function testCreateDuplicateReverts() public {
+        _createStrategy(user);
+
+        vm.prank(backend);
+        vm.expectRevert("Strategy already exists");
+        factory.createStrategyForUser(user);
+    }
+
+    function testCreateZeroUserReverts() public {
+        vm.prank(backend);
+        vm.expectRevert("Invalid user address");
+        factory.createStrategyForUser(address(0));
+    }
+
+    // ==================== FACTORY: CONSTRUCTOR VALIDATION ====================
+
+    function testConstructorZeroAdminReverts() public {
+        vm.expectRevert("Invalid admin address");
+        new MamoLeveragedAeroStrategyFactory(
+            address(0), backend, address(registry), address(impl), typeId, address(sherwood), address(usdc)
+        );
+    }
+
+    function testConstructorZeroBackendReverts() public {
+        vm.expectRevert("Invalid mamoBackend address");
+        new MamoLeveragedAeroStrategyFactory(
+            admin, address(0), address(registry), address(impl), typeId, address(sherwood), address(usdc)
+        );
+    }
+
+    function testConstructorZeroRegistryReverts() public {
+        vm.expectRevert("Invalid mamoStrategyRegistry address");
+        new MamoLeveragedAeroStrategyFactory(
+            admin, backend, address(0), address(impl), typeId, address(sherwood), address(usdc)
+        );
+    }
+
+    function testConstructorZeroImplementationReverts() public {
+        vm.expectRevert("Invalid strategyImplementation address");
+        new MamoLeveragedAeroStrategyFactory(
+            admin, backend, address(registry), address(0), typeId, address(sherwood), address(usdc)
+        );
+    }
+
+    function testConstructorNonContractImplementationReverts() public {
+        vm.expectRevert("Implementation must be a contract");
+        new MamoLeveragedAeroStrategyFactory(
+            admin, backend, address(registry), makeAddr("eoa"), typeId, address(sherwood), address(usdc)
+        );
+    }
+
+    function testConstructorZeroTypeIdReverts() public {
+        vm.expectRevert("Strategy type id not set");
+        new MamoLeveragedAeroStrategyFactory(
+            admin, backend, address(registry), address(impl), 0, address(sherwood), address(usdc)
+        );
+    }
+
+    function testConstructorZeroSherwoodReverts() public {
+        vm.expectRevert("Invalid sherwoodStrategy address");
+        new MamoLeveragedAeroStrategyFactory(
+            admin, backend, address(registry), address(impl), typeId, address(0), address(usdc)
+        );
+    }
+
+    function testConstructorZeroUsdcReverts() public {
+        vm.expectRevert("Invalid usdc address");
+        new MamoLeveragedAeroStrategyFactory(
+            admin, backend, address(registry), address(impl), typeId, address(sherwood), address(0)
+        );
+    }
+
+    // ==================== DEPOSIT ====================
+
+    function testDepositHappyPath() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _fundAndApprove(user, address(strategy), DEPOSIT);
+
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit Deposit(user, DEPOSIT, EXPECTED_SHARES);
+
+        vm.prank(user);
+        uint256 shares = strategy.deposit(DEPOSIT, 0);
+
+        assertEq(shares, EXPECTED_SHARES, "shares returned");
+        assertEq(strategy.sharesBalance(), EXPECTED_SHARES, "wrapper share balance");
+        assertEq(vault.balanceOf(address(strategy)), EXPECTED_SHARES, "vault share balance");
+        assertEq(usdc.balanceOf(user), 0, "USDC pulled");
+        assertEq(usdc.balanceOf(address(sherwood)), DEPOSIT, "USDC held by sherwood");
+    }
+
+    function testDepositPermissionlessFromThirdParty() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _fundAndApprove(thirdParty, address(strategy), DEPOSIT);
+
+        vm.prank(thirdParty);
+        strategy.deposit(DEPOSIT, 0);
+
+        // Shares are always custodied by the wrapper regardless of who funds.
+        assertEq(strategy.sharesBalance(), EXPECTED_SHARES);
+    }
+
+    function testDepositZeroAmountReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        vm.prank(user);
+        vm.expectRevert("Amount must be greater than 0");
+        strategy.deposit(0, 0);
+    }
+
+    function testDepositMinSharesReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _fundAndApprove(user, address(strategy), DEPOSIT);
+
+        vm.prank(user);
+        vm.expectRevert("MockSherwood: min shares");
+        strategy.deposit(DEPOSIT, EXPECTED_SHARES + 1);
+    }
+
+    function testDepositWhilePendingReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        sherwood.setState(ILeveragedAeroCLStrategy.State.Pending);
+        _fundAndApprove(user, address(strategy), DEPOSIT);
+
+        vm.prank(user);
+        vm.expectRevert("MockSherwood: not executed");
+        strategy.deposit(DEPOSIT, 0);
+    }
+
+    function testDepositWhileVaultPausedReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        vault.setPaused(true);
+        _fundAndApprove(user, address(strategy), DEPOSIT);
+
+        vm.prank(user);
+        vm.expectRevert("MockVault: paused");
+        strategy.deposit(DEPOSIT, 0);
+    }
+
+    // ==================== DEPOSIT IDLE ====================
+
+    function testDepositIdleSweepsInDirectTransfer() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        // Plain-transfer USDC directly to the account (no approve/deposit).
+        usdc.mint(address(strategy), DEPOSIT);
+
+        vm.prank(user);
+        uint256 shares = strategy.depositIdle(0);
+
+        assertEq(shares, EXPECTED_SHARES);
+        assertEq(strategy.sharesBalance(), EXPECTED_SHARES);
+        assertEq(usdc.balanceOf(address(strategy)), 0, "idle USDC swept");
+    }
+
+    function testDepositIdleEmptyReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        vm.prank(user);
+        vm.expectRevert("No idle USDC to deposit");
+        strategy.depositIdle(0);
+    }
+
+    // ==================== WITHDRAW (FAST PATH) ====================
+
+    function testWithdrawHappyPath() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit Withdraw(user, EXPECTED_SHARES, DEPOSIT);
+
+        vm.prank(user);
+        uint256 assetsOut = strategy.withdraw(EXPECTED_SHARES, DEPOSIT);
+
+        assertEq(assetsOut, DEPOSIT, "assetsOut");
+        assertEq(usdc.balanceOf(user), DEPOSIT, "owner paid");
+        assertEq(strategy.sharesBalance(), 0, "shares burned");
+    }
+
+    function testWithdrawAllHappyPath() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.prank(user);
+        uint256 assetsOut = strategy.withdrawAll(DEPOSIT);
+
+        assertEq(assetsOut, DEPOSIT);
+        assertEq(usdc.balanceOf(user), DEPOSIT);
+        assertEq(strategy.sharesBalance(), 0);
+    }
+
+    function testWithdrawProfitScenario() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        // 10% profit: each share worth more USDC. Fund the mock with the extra USDC to pay it out.
+        sherwood.setPricePerShareE18(1.1e18);
+        usdc.mint(address(sherwood), DEPOSIT); // ample liquidity
+
+        uint256 expected = (DEPOSIT * 11) / 10;
+        vm.prank(user);
+        uint256 assetsOut = strategy.withdrawAll(expected);
+        assertEq(assetsOut, expected, "profit paid out");
+        assertEq(usdc.balanceOf(user), expected);
+    }
+
+    function testWithdrawOnlyOwnerReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.prank(thirdParty);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", thirdParty));
+        strategy.withdraw(EXPECTED_SHARES, 0);
+    }
+
+    function testWithdrawZeroSharesReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        vm.prank(user);
+        vm.expectRevert("Amount must be greater than 0");
+        strategy.withdraw(0, 0);
+    }
+
+    function testWithdrawAllNoSharesReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        vm.prank(user);
+        vm.expectRevert("No shares to withdraw");
+        strategy.withdrawAll(0);
+    }
+
+    function testWithdrawFastPathBlockedReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+        sherwood.setFastPathBlocked(true);
+
+        vm.prank(user);
+        vm.expectRevert("FastRedeemExceedsLtv");
+        strategy.withdraw(EXPECTED_SHARES, 0);
+    }
+
+    function testWithdrawMinAssetsOutReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.prank(user);
+        vm.expectRevert("MockSherwood: min assets out");
+        strategy.withdraw(EXPECTED_SHARES, DEPOSIT + 1);
+    }
+
+    // ==================== ASYNC REDEEM ====================
+
+    function testRequestWithdrawEscrowsShares() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit WithdrawRequested(0, EXPECTED_SHARES, DEPOSIT);
+
+        vm.prank(user);
+        uint256 id = strategy.requestWithdraw(EXPECTED_SHARES, DEPOSIT);
+
+        assertEq(id, 0, "first id");
+        assertEq(strategy.sharesBalance(), 0, "shares escrowed off the wrapper");
+        assertEq(vault.balanceOf(address(sherwood)), EXPECTED_SHARES, "shares held by sherwood");
+    }
+
+    function testRequestWithdrawZeroReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        vm.prank(user);
+        vm.expectRevert("Amount must be greater than 0");
+        strategy.requestWithdraw(0, 0);
+    }
+
+    function testRequestWithdrawOnlyOwnerReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.prank(thirdParty);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", thirdParty));
+        strategy.requestWithdraw(EXPECTED_SHARES, 0);
+    }
+
+    function testCancelWithdrawReturnsShares() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.prank(user);
+        uint256 id = strategy.requestWithdraw(EXPECTED_SHARES, DEPOSIT);
+
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit WithdrawCancelled(id);
+
+        vm.prank(user);
+        strategy.cancelWithdraw(id);
+
+        assertEq(strategy.sharesBalance(), EXPECTED_SHARES, "shares returned to wrapper");
+    }
+
+    function testFulfillThenClaimWithdrawnUsdc() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.prank(user);
+        uint256 id = strategy.requestWithdraw(EXPECTED_SHARES, DEPOSIT);
+
+        // Backend/keeper fulfills off-band; USDC lands on the wrapper with no callback.
+        sherwood.fulfillRedeem(id);
+        assertEq(usdc.balanceOf(address(strategy)), DEPOSIT, "USDC on wrapper");
+
+        vm.expectEmit(false, false, false, true, address(strategy));
+        emit UsdcClaimed(DEPOSIT);
+
+        vm.prank(user);
+        uint256 amount = strategy.claimWithdrawnUsdc();
+
+        assertEq(amount, DEPOSIT);
+        assertEq(usdc.balanceOf(user), DEPOSIT, "owner swept");
+    }
+
+    function testClaimWithdrawnUsdcEmptyReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        vm.prank(user);
+        vm.expectRevert("No USDC to claim");
+        strategy.claimWithdrawnUsdc();
+    }
+
+    function testEmergencyWithdrawBeforeWindowReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.prank(user);
+        uint256 id = strategy.requestWithdraw(EXPECTED_SHARES, DEPOSIT);
+
+        vm.prank(user);
+        vm.expectRevert("MockSherwood: fulfill window not elapsed");
+        strategy.emergencyWithdraw(id, DEPOSIT);
+    }
+
+    function testEmergencyWithdrawAfterWindowForwardsToOwner() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.prank(user);
+        uint256 id = strategy.requestWithdraw(EXPECTED_SHARES, DEPOSIT);
+
+        vm.warp(block.timestamp + 2 days + 1);
+
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit WithdrawEmergency(id, DEPOSIT);
+
+        vm.prank(user);
+        uint256 assetsOut = strategy.emergencyWithdraw(id, DEPOSIT);
+
+        assertEq(assetsOut, DEPOSIT);
+        assertEq(usdc.balanceOf(user), DEPOSIT, "forwarded to owner");
+    }
+
+    // ==================== SETTLED STATE ====================
+
+    function testSettledBlocksDepositWithdrawRequest() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        sherwood.setState(ILeveragedAeroCLStrategy.State.Settled);
+
+        _fundAndApprove(user, address(strategy), DEPOSIT);
+        vm.prank(user);
+        vm.expectRevert("MockSherwood: not executed");
+        strategy.deposit(DEPOSIT, 0);
+
+        vm.prank(user);
+        vm.expectRevert("MockSherwood: not executed");
+        strategy.withdraw(EXPECTED_SHARES, 0);
+
+        vm.prank(user);
+        vm.expectRevert("MockSherwood: not executed");
+        strategy.requestWithdraw(EXPECTED_SHARES, 0);
+    }
+
+    function testSettledStillAllowsCancel() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.prank(user);
+        uint256 id = strategy.requestWithdraw(EXPECTED_SHARES, DEPOSIT);
+
+        sherwood.setState(ILeveragedAeroCLStrategy.State.Settled);
+
+        vm.prank(user);
+        strategy.cancelWithdraw(id);
+        assertEq(strategy.sharesBalance(), EXPECTED_SHARES);
+    }
+
+    function testSettledOwnerCanRecoverShares() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        sherwood.setState(ILeveragedAeroCLStrategy.State.Settled);
+
+        // Escape hatch: pull the raw vault shares out to the owner.
+        vm.prank(user);
+        strategy.recoverERC20(address(vault), user, EXPECTED_SHARES);
+
+        assertEq(vault.balanceOf(user), EXPECTED_SHARES, "shares recovered to owner");
+        assertEq(strategy.sharesBalance(), 0);
+    }
+
+    // ==================== OWNERSHIP / UPGRADE ====================
+
+    function testTransferOwnershipMirrorsIntoRegistry() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        address newOwner = makeAddr("newOwner");
+
+        vm.prank(user);
+        strategy.transferOwnership(newOwner);
+
+        assertEq(strategy.owner(), newOwner, "owner updated");
+        assertFalse(registry.isUserStrategy(user, address(strategy)), "old owner cleared");
+        assertTrue(registry.isUserStrategy(newOwner, address(strategy)), "new owner set");
+    }
+
+    function testUpgradeToSecondImplementation() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+
+        MamoLeveragedAeroStrategy impl2 = new MamoLeveragedAeroStrategy();
+        vm.prank(admin);
+        registry.whitelistImplementation(address(impl2), typeId);
+
+        vm.prank(user);
+        registry.upgradeStrategy(address(strategy), address(impl2));
+
+        assertEq(ERC1967Proxy(payable(address(strategy))).getImplementation(), address(impl2));
+    }
+
+    function testUpgradeByNonOwnerReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+
+        MamoLeveragedAeroStrategy impl2 = new MamoLeveragedAeroStrategy();
+        vm.prank(admin);
+        registry.whitelistImplementation(address(impl2), typeId);
+
+        vm.prank(thirdParty);
+        vm.expectRevert("Caller is not the owner of the strategy");
+        registry.upgradeStrategy(address(strategy), address(impl2));
+    }
+
+    // ==================== VIEWS ====================
+
+    function testPreviewWithdrawPassThrough() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+
+        (uint256 assetsOut, bool fastOk) = strategy.previewWithdraw(EXPECTED_SHARES);
+        assertEq(assetsOut, DEPOSIT, "preview assets");
+        assertTrue(fastOk, "fastOk when not blocked");
+
+        sherwood.setFastPathBlocked(true);
+        (, bool fastOk2) = strategy.previewWithdraw(EXPECTED_SHARES);
+        assertFalse(fastOk2, "fastOk false when blocked");
+    }
+
+    function testStrategyStatePassThrough() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        assertEq(strategy.strategyState(), uint8(ILeveragedAeroCLStrategy.State.Executed));
+
+        sherwood.setState(ILeveragedAeroCLStrategy.State.Settled);
+        assertEq(strategy.strategyState(), uint8(ILeveragedAeroCLStrategy.State.Settled));
+    }
+
+    function testComputeStrategyAddressMatches() public {
+        address predicted = factory.computeStrategyAddress(user);
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        assertEq(address(strategy), predicted);
+    }
+}

--- a/test/MamoLeveragedAeroStrategy.unit.t.sol
+++ b/test/MamoLeveragedAeroStrategy.unit.t.sol
@@ -171,9 +171,15 @@ contract MamoLeveragedAeroStrategyUnitTest is Test {
     }
 
     function testConstructorNonContractImplementationReverts() public {
+        // makeAddr derives from a publicly-known private key; on a Base fork the well-known "eoa"
+        // address carries an EIP-7702 delegation (non-empty code), so force-clear it to keep this
+        // test deterministic in both fork and non-fork runs (CI's Basic Tests job forks Base).
+        address eoa = makeAddr("eoa");
+        vm.etch(eoa, "");
+
         vm.expectRevert("Implementation must be a contract");
         new MamoLeveragedAeroStrategyFactory(
-            admin, backend, address(registry), makeAddr("eoa"), typeId, address(sherwood), address(usdc)
+            admin, backend, address(registry), eoa, typeId, address(sherwood), address(usdc)
         );
     }
 

--- a/test/MamoLeveragedAeroStrategy.unit.t.sol
+++ b/test/MamoLeveragedAeroStrategy.unit.t.sol
@@ -286,6 +286,56 @@ contract MamoLeveragedAeroStrategyUnitTest is Test {
         strategy.depositIdle(0);
     }
 
+    function testDepositIdleAsBackendSucceeds() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        usdc.mint(address(strategy), DEPOSIT);
+
+        // The registry backend (getBackendAddress) is a trusted actor and may nudge idle USDC in.
+        assertEq(registry.getBackendAddress(), backend, "backend is registry backend");
+        vm.prank(backend);
+        uint256 shares = strategy.depositIdle(0);
+
+        assertEq(shares, EXPECTED_SHARES);
+        assertEq(strategy.sharesBalance(), EXPECTED_SHARES);
+        assertEq(usdc.balanceOf(address(strategy)), 0, "idle USDC swept");
+    }
+
+    function testDepositIdleAsThirdPartyReverts() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        usdc.mint(address(strategy), DEPOSIT);
+
+        vm.prank(thirdParty);
+        vm.expectRevert("Not owner or backend");
+        strategy.depositIdle(0);
+    }
+
+    /// @notice Regression: an anonymous third party must NOT be able to force a fulfilled async
+    ///         withdrawal back into the leveraged position (repeatable re-lock griefing) by front-running
+    ///         the owner's {claimWithdrawnUsdc} with depositIdle(0). The owner's claim then succeeds.
+    function testDepositIdleReLockGriefingBlocked() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vm.prank(user);
+        uint256 id = strategy.requestWithdraw(EXPECTED_SHARES, DEPOSIT);
+
+        // Backend/keeper fulfills off-band; the withdrawal USDC lands idle on the wrapper.
+        sherwood.fulfillRedeem(id);
+        assertEq(usdc.balanceOf(address(strategy)), DEPOSIT, "fulfilled USDC idle on wrapper");
+
+        // Attacker front-runs the owner's claim to re-lock the funds — must revert.
+        vm.prank(thirdParty);
+        vm.expectRevert("Not owner or backend");
+        strategy.depositIdle(0);
+
+        // Owner still claims the fulfilled withdrawal.
+        vm.prank(user);
+        uint256 amount = strategy.claimWithdrawnUsdc();
+        assertEq(amount, DEPOSIT);
+        assertEq(usdc.balanceOf(user), DEPOSIT, "owner claimed the fulfilled withdrawal");
+        assertEq(strategy.sharesBalance(), 0, "not re-locked into the position");
+    }
+
     // ==================== WITHDRAW (FAST PATH) ====================
 
     function testWithdrawHappyPath() public {
@@ -361,6 +411,36 @@ contract MamoLeveragedAeroStrategyUnitTest is Test {
         vm.prank(user);
         vm.expectRevert("FastRedeemExceedsLtv");
         strategy.withdraw(EXPECTED_SHARES, 0);
+    }
+
+    /// @notice Redemptions must keep working while the vault is paused: pausing gates deposits (mint) but
+    ///         NOT burns, mirroring the real SyndicateVault where redeems stay open while paused.
+    function testWithdrawWhileVaultPausedSucceeds() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vault.setPaused(true);
+
+        vm.prank(user);
+        uint256 assetsOut = strategy.withdraw(EXPECTED_SHARES, DEPOSIT);
+
+        assertEq(assetsOut, DEPOSIT, "fast withdraw pays out while paused");
+        assertEq(usdc.balanceOf(user), DEPOSIT, "owner paid while paused");
+        assertEq(strategy.sharesBalance(), 0, "shares burned while paused");
+    }
+
+    function testWithdrawAllWhileVaultPausedSucceeds() public {
+        MamoLeveragedAeroStrategy strategy = _createStrategy(user);
+        _deposit(strategy, user, DEPOSIT);
+
+        vault.setPaused(true);
+
+        vm.prank(user);
+        uint256 assetsOut = strategy.withdrawAll(DEPOSIT);
+
+        assertEq(assetsOut, DEPOSIT, "withdrawAll pays out while paused");
+        assertEq(usdc.balanceOf(user), DEPOSIT, "owner paid while paused");
+        assertEq(strategy.sharesBalance(), 0, "shares burned while paused");
     }
 
     function testWithdrawMinAssetsOutReverts() public {
@@ -585,10 +665,10 @@ contract MamoLeveragedAeroStrategyUnitTest is Test {
 
     function testStrategyStatePassThrough() public {
         MamoLeveragedAeroStrategy strategy = _createStrategy(user);
-        assertEq(strategy.strategyState(), uint8(ILeveragedAeroCLStrategy.State.Executed));
+        assertEq(uint8(strategy.strategyState()), uint8(ILeveragedAeroCLStrategy.State.Executed));
 
         sherwood.setState(ILeveragedAeroCLStrategy.State.Settled);
-        assertEq(strategy.strategyState(), uint8(ILeveragedAeroCLStrategy.State.Settled));
+        assertEq(uint8(strategy.strategyState()), uint8(ILeveragedAeroCLStrategy.State.Settled));
     }
 
     function testComputeStrategyAddressMatches() public {

--- a/test/mocks/MockLeveragedAeroCLStrategy.sol
+++ b/test/mocks/MockLeveragedAeroCLStrategy.sol
@@ -118,7 +118,11 @@ contract MockLeveragedAeroCLStrategy is ILeveragedAeroCLStrategy {
 
         id = nextRequestId++;
         requests[id] = RedeemRequest({
-            owner: msg.sender, shares: shares, minAssetsOut: minAssetsOut, requestedAt: block.timestamp, settled: false
+            owner: msg.sender,
+            shares: shares,
+            minAssetsOut: minAssetsOut,
+            requestedAt: block.timestamp,
+            settled: false
         });
     }
 

--- a/test/mocks/MockLeveragedAeroCLStrategy.sol
+++ b/test/mocks/MockLeveragedAeroCLStrategy.sol
@@ -132,6 +132,8 @@ contract MockLeveragedAeroCLStrategy is ILeveragedAeroCLStrategy {
     }
 
     function emergencyRedeem(uint256 id, uint256 minAssetsOut) external override returns (uint256 assetsOut) {
+        require(state == State.Executed, "MockSherwood: not executed");
+
         RedeemRequest storage req = requests[id];
         require(req.owner == msg.sender, "MockSherwood: not request owner");
         require(!req.settled, "MockSherwood: already settled");

--- a/test/mocks/MockLeveragedAeroCLStrategy.sol
+++ b/test/mocks/MockLeveragedAeroCLStrategy.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {MockSyndicateVault} from "./MockSyndicateVault.sol";
+import {ILeveragedAeroCLStrategy} from "@interfaces/ILeveragedAeroCLStrategy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title MockLeveragedAeroCLStrategy
+ * @notice Simple-accounting stand-in for the vendored Sherwood LeveragedAerodromeCLStrategy, used by
+ *         the MamoLeveragedAeroStrategy wrapper unit tests. Implements the full
+ *         {ILeveragedAeroCLStrategy} surface plus a couple of test-only helpers.
+ *
+ * @dev Fixed-point convention (documented once, applied everywhere):
+ *      - USDC has 6 decimals; vault shares have 12 decimals (a 1e6 decimal gap).
+ *      - `pricePerShareE18` is the price scaled by 1e18. Its DEFAULT of 1e18 means "par": depositing
+ *        1 whole USDC (1e6 units) mints exactly 1 whole share (1e12 units), and redeeming 1 whole
+ *        share returns 1 whole USDC. Raising `pricePerShareE18` above 1e18 makes each share worth
+ *        MORE USDC (simulates strategy profit); lowering it simulates loss.
+ *
+ *        shares  = assets * DECIMAL_GAP * PRICE_SCALE / pricePerShareE18
+ *        assets  = shares * pricePerShareE18 / (DECIMAL_GAP * PRICE_SCALE)
+ *
+ *      The mock CUSTODIES the USDC deposited into it and pays redemptions out of that balance; tests
+ *      `deal`/`mint` extra USDC to the mock to fund profit scenarios.
+ */
+contract MockLeveragedAeroCLStrategy is ILeveragedAeroCLStrategy {
+    using SafeERC20 for IERC20;
+
+    uint256 private constant DECIMAL_GAP = 1e6; // 12dp shares vs 6dp USDC
+    uint256 private constant PRICE_SCALE = 1e18;
+
+    MockSyndicateVault public immutable vaultToken;
+    IERC20 public immutable usdc;
+
+    /// @notice Lifecycle state; defaults to Executed so deposit/redeem work out of the box. The
+    ///         auto-generated getter satisfies {ILeveragedAeroCLStrategy.state}.
+    State public override state = State.Executed;
+
+    /// @notice Price of a share, scaled by 1e18 (default 1e18 == par). Settable for profit/loss tests.
+    uint256 public pricePerShareE18 = 1e18;
+
+    /// @notice When true, the fast-path {redeem} reverts and {previewRedeem} reports fastOk == false,
+    ///         simulating an oracle-down / LTV-gate condition.
+    bool public fastPathBlocked;
+
+    struct RedeemRequest {
+        address owner;
+        uint256 shares;
+        uint256 minAssetsOut;
+        uint256 requestedAt;
+        bool settled;
+    }
+
+    mapping(uint256 => RedeemRequest) public requests;
+    uint256 public nextRequestId;
+
+    constructor(address vault_, address usdc_) {
+        vaultToken = MockSyndicateVault(vault_);
+        usdc = IERC20(usdc_);
+    }
+
+    // ==================== TEST SETTERS ====================
+
+    function setState(State state_) external {
+        state = state_;
+    }
+
+    function setPricePerShareE18(uint256 price_) external {
+        pricePerShareE18 = price_;
+    }
+
+    function setFastPathBlocked(bool blocked_) external {
+        fastPathBlocked = blocked_;
+    }
+
+    // ==================== CONVERSIONS ====================
+
+    function _sharesForAssets(uint256 assets) internal view returns (uint256) {
+        return (assets * DECIMAL_GAP * PRICE_SCALE) / pricePerShareE18;
+    }
+
+    function _assetsForShares(uint256 shares) internal view returns (uint256) {
+        return (shares * pricePerShareE18) / (DECIMAL_GAP * PRICE_SCALE);
+    }
+
+    // ==================== ILeveragedAeroCLStrategy ====================
+
+    function deposit(uint256 assets, uint256 minShares) external override returns (uint256 shares) {
+        require(state == State.Executed, "MockSherwood: not executed");
+
+        usdc.safeTransferFrom(msg.sender, address(this), assets);
+        shares = _sharesForAssets(assets);
+        require(shares >= minShares, "MockSherwood: min shares");
+
+        vaultToken.strategyMint(msg.sender, shares);
+    }
+
+    function redeem(uint256 shares, uint256 minAssetsOut) external override returns (uint256 assetsOut) {
+        require(state == State.Executed, "MockSherwood: not executed");
+        require(!fastPathBlocked, "FastRedeemExceedsLtv");
+
+        // Pull the shares in and burn them (mirrors the wrapper approving shares to us first).
+        IERC20(address(vaultToken)).safeTransferFrom(msg.sender, address(this), shares);
+        vaultToken.strategyBurn(shares);
+
+        assetsOut = _assetsForShares(shares);
+        require(assetsOut >= minAssetsOut, "MockSherwood: min assets out");
+
+        usdc.safeTransfer(msg.sender, assetsOut);
+    }
+
+    function requestRedeem(uint256 shares, uint256 minAssetsOut) external override returns (uint256 id) {
+        require(state == State.Executed, "MockSherwood: not executed");
+
+        IERC20(address(vaultToken)).safeTransferFrom(msg.sender, address(this), shares);
+
+        id = nextRequestId++;
+        requests[id] = RedeemRequest({
+            owner: msg.sender, shares: shares, minAssetsOut: minAssetsOut, requestedAt: block.timestamp, settled: false
+        });
+    }
+
+    function cancelRedeem(uint256 id) external override {
+        RedeemRequest storage req = requests[id];
+        require(req.owner == msg.sender, "MockSherwood: not request owner");
+        require(!req.settled, "MockSherwood: already settled");
+
+        req.settled = true;
+        IERC20(address(vaultToken)).safeTransfer(req.owner, req.shares);
+    }
+
+    function emergencyRedeem(uint256 id, uint256 minAssetsOut) external override returns (uint256 assetsOut) {
+        RedeemRequest storage req = requests[id];
+        require(req.owner == msg.sender, "MockSherwood: not request owner");
+        require(!req.settled, "MockSherwood: already settled");
+        require(block.timestamp > req.requestedAt + 2 days, "MockSherwood: fulfill window not elapsed");
+
+        assetsOut = _assetsForShares(req.shares);
+        require(assetsOut >= minAssetsOut, "MockSherwood: min assets out");
+
+        req.settled = true;
+        vaultToken.strategyBurn(req.shares);
+        usdc.safeTransfer(msg.sender, assetsOut);
+    }
+
+    function previewRedeem(uint256 shares) external view override returns (uint256 assetsOut, bool fastOk) {
+        return (_assetsForShares(shares), !fastPathBlocked);
+    }
+
+    function vault() external view override returns (address) {
+        return address(vaultToken);
+    }
+
+    // ==================== TEST-ONLY HELPER ====================
+
+    /**
+     * @notice Fulfills an escrowed async request: burns the escrowed shares, enforces the stored
+     *         `minAssetsOut`, and pays USDC to the request owner. No proposer gate (test helper).
+     */
+    function fulfillRedeem(uint256 id) external returns (uint256 assetsOut) {
+        RedeemRequest storage req = requests[id];
+        require(!req.settled, "MockSherwood: already settled");
+
+        assetsOut = _assetsForShares(req.shares);
+        require(assetsOut >= req.minAssetsOut, "MockSherwood: min assets out");
+
+        req.settled = true;
+        vaultToken.strategyBurn(req.shares);
+        usdc.safeTransfer(req.owner, assetsOut);
+    }
+}

--- a/test/mocks/MockSyndicateVault.sol
+++ b/test/mocks/MockSyndicateVault.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title MockSyndicateVault
+ * @notice Minimal stand-in for the (undeployed, un-vendored) Sherwood SyndicateVault share token.
+ * @dev A plain 12-decimal ERC20 whose mint/burn entrypoints are gated to a single configured
+ *      strategy address, mirroring how the real vault only lets its strategy mint/burn shares.
+ *      A settable `paused` flag blocks {strategyMint} (deposits) but deliberately NOT
+ *      {strategyBurn} (burns / redemptions) — matching the real vault, where redemptions keep
+ *      working while the vault is paused.
+ */
+contract MockSyndicateVault is ERC20 {
+    /// @notice The only address permitted to mint/burn shares.
+    address public strategy;
+
+    /// @notice When true, {strategyMint} reverts (deposits blocked); burns are unaffected.
+    bool public paused;
+
+    constructor() ERC20("Mock Syndicate Vault", "svUSDC") {}
+
+    function decimals() public pure override returns (uint8) {
+        return 12;
+    }
+
+    function setStrategy(address strategy_) external {
+        strategy = strategy_;
+    }
+
+    function setPaused(bool paused_) external {
+        paused = paused_;
+    }
+
+    modifier onlyStrategy() {
+        require(msg.sender == strategy, "MockVault: only strategy");
+        _;
+    }
+
+    /// @notice Mints `shares` to `to`. Reverts while paused.
+    function strategyMint(address to, uint256 shares) external onlyStrategy {
+        require(!paused, "MockVault: paused");
+        _mint(to, shares);
+    }
+
+    /// @notice Burns `shares` from the calling strategy's own balance. Allowed while paused.
+    function strategyBurn(uint256 shares) external onlyStrategy {
+        _burn(msg.sender, shares);
+    }
+}

--- a/test/mocks/MockToken.sol
+++ b/test/mocks/MockToken.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title MockToken
+ * @notice A minimal ERC20 with configurable decimals and open minting, for unit tests.
+ * @dev The repo's existing test/MockERC20.sol is hard-wired to 18 decimals; USDC (6dp) needs a
+ *      configurable-decimals mock, hence this one.
+ */
+contract MockToken is ERC20 {
+    uint8 private immutable _decimals;
+
+    constructor(string memory name, string memory symbol, uint8 decimals_) ERC20(name, symbol) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}


### PR DESCRIPTION
## What

New per-user Mamo account contract wrapping the vendored Sherwood leveraged Aerodrome CL strategy (#59), completing the Mamo-infra loop: registry-registered, factory-deployed, backend-hooked. Follows the account-contract pattern established by #44/#49 (mapped onto the post-rename `MamoMultiMarketStrategy`/`MamoStakingStrategy` conventions).

## Architecture

- **`MamoLeveragedAeroStrategy`** inherits Mamo `BaseStrategy` (UUPS, registry-gated upgrades, storage from slot 50). It can NOT extend the Sherwood strategy (incompatible vault/proposer base) — it custodies SyndicateVault shares (12dp) and drives the Sherwood strategy through a minimal, signature-verified `ILeveragedAeroCLStrategy` interface. USDC in/out on every path:
  - `deposit` (permissionless, donation-only) / `depositIdle` (owner-or-backend — gated per review to close a re-lock griefing vector) → sync mint of vault shares to the account
  - `withdraw` / `withdrawAll` (owner) → fast oracle-priced redeem; reverts when the oracle is down or the LTV gate trips → route async
  - `requestWithdraw` / `cancelWithdraw` (owner) → async escrow; the backend fulfills on the Sherwood side (`fulfillRedeem` is proposer-only); proceeds land on the account → `claimWithdrawnUsdc` sweeps to owner
  - `emergencyWithdraw` (owner) → trustless deadman after the 2-day `FULFILL_WINDOW`
  - `Settled` terminal state escape hatch: inherited `recoverERC20` pulls the raw shares for direct vault-queue exit (documented in natspec)
- **`MamoLeveragedAeroStrategyFactory`**: Create2-deterministic per-user proxies (custom `ERC1967Proxy`), creation gated backend-role-or-self, registers via `MamoStrategyRegistry.addStrategy`.

## Governance / deploy

- **`012_DeployLeveragedAeroAccountSystem`**: deploys impl + factory, whitelists the impl under **new `strategyTypeId = 5`** (verified free on Base mainnet: ids 1–4 taken, 5 empty), grants the factory `BACKEND_ROLE`, and calls `setOpenDeposits(true)` on the SyndicateVault.
  - Note: `preBuildMock` guards on `latestImplementationById(5) == 0` rather than the #49-era `nextStrategyTypeId() == id` — that counter only advances on auto-assign whitelists and currently reads a stale `4` on mainnet while ids 1–4 are all filled.
- **Deposit-gating decision** (agreed): open deposits, vault owned by `MAMO_MULTISIG`. `approveDepositor` is strictly `onlyOwner` upstream and the whitelist can't enforce exclusivity anyway (permissionless account creation + transferable shares); brakes remain `setOpenDeposits(false)` + `pause()` (redeems deliberately stay open while paused).
- Dedicated config JSON + loader (the Moonwell/Morpho `DeployAssetConfig` schema doesn't fit — no markets/reward tokens/CowSwap here).

## Not in this PR (blocked on the Sherwood deployment)

The Sherwood system (SyndicateVault + strategy) deploys separately — Tenderly vnet Base fork first, Base soon. Until the `SHERWOOD_LEVERAGED_AERO_STRATEGY` / `SHERWOOD_SYNDICATE_VAULT` keys land in `addresses/8453.json`, proposal 012 compiles but cannot be simulated end-to-end, and fork/integration tests against the live system are deferred. Unit coverage is mock-based by necessity (the vault implementation is not vendored, interfaces only).

## Tests

46 new unit tests (`test/MamoLeveragedAeroStrategy.unit.t.sol` + mocks): factory creation/validation/determinism, all deposit/withdraw/async/emergency flows, Settled-state gating + escape hatch, ownership mirroring into the registry, registry-gated upgrade path, vault-paused behavior. Full `make test-unit`: 378 passed, 0 failed. Covered by the existing CI `test-unit` job; `leveraged-aero-account` make target added to `test-all`.

## Known coordination footgun (documented, by design)

Idle USDC on an account is ambiguous: it may be pending re-deposit (`depositIdle`) **or** a fulfilled async withdrawal awaiting `claimWithdrawnUsdc`. Both act on the same balance; backend must only call `depositIdle` when a re-deposit is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
