### PR TITLE
spec: Mamo on Robinhood Chain — ranked strategy ideas + tested MVPs

### DIFF
--- a/docs/ROBINHOOD_CHAIN_SPEC.md
+++ b/docs/ROBINHOOD_CHAIN_SPEC.md
@@ -1,0 +1,166 @@
+# Mamo on Robinhood Chain — Product Spec & Ranked Strategy Ideas
+
+*Status: research + MVP prototypes. Nothing here is deployment-ready; the two prototype contracts under `src/robinhood/` are proofs of mechanics with passing unit suites, not audited code.*
+
+---
+
+## TL;DR
+
+Robinhood Chain (Arbitrum Orbit L2, chain ID 4663, launched 2026-07-01) has the primitives for a Mamo port — Morpho is the dominant credit layer (~$308M of ~$733M chain TVL), Chainlink is the exclusive oracle, Uniswap v3/v4 is live, and Merkl (which Mamo already uses on Base) is the rewards layer. But three findings reshape the plan versus a naive "fork it":
+
+1. **A pure USDG yield router is commercially dead on arrival.** Robinhood Earn shows a subsidized ~7% (organic ~1.6–4.3% + Merkl top-up **paid only to app depositors**, in vault shares, for ~a year). A third-party router showing 2–4.5% against that, in the incumbent's own app, loses.
+2. **Stock tokens are technically wide open and legally fenced.** They are plain ERC-20s (blocklist, not allowlist — any contract can hold and trade them), with per-equity Chainlink 24/5 feeds and an official Arbitrum tutorial that is literally an index-basket dApp. But they exclude US/UK/CA/CH/UAE persons, and the issuer retains pause/burn/confiscate powers. This is a **non-US product surface with a real regulatory tail** — and also the only surface Robinhood's subsidy doesn't crush.
+3. **Most of the port is already written.** The audit branch (PR #66 line) contains `MamoMultiMarketStrategy` + `MarketRegistry` + `MultiMarketStrategyFactory` — an N-venue allocation engine that reduces to Morpho-only by dropping the MTOKEN arm — and the oracle-anchored router-swap pattern that replaces CowSwap (which does not exist on Robinhood Chain) is already used by `MamoStakingStrategy.compound()` on that branch.
+
+**Recommendation:** lead with **Mamo Baskets** (curated stock baskets + USDG yield sleeve — the differentiator nobody's subsidy can replicate), on top of the **multi-vault USDG chassis** (the port of least resistance, with supply caps and multisig-scoped venues carried over from the Boosted USDC design), with **Boosted USDG (levered carry)** as the 2nd-wave product that can honestly beat the 7% headline, and the **MAMO flywheel** wired to all three from day one. Both lead ideas are prototyped in this branch with green unit suites (40 tests).
+
+---
+
+## 1. What we verified about the chain
+
+Dense summary of the three research passes (full reports available on request). Confidence: **[V]** = verified in canonical repos (Uniswap/Morpho/Chainlink/L2Beat GitHub registries), **[C]** = corroborated across independent sources, **[R]** = single reported source. On-chain RPC verification was not possible from this environment — §7 lists the reads to run first.
+
+### Rails
+- **Chain**: Arbitrum Orbit L2 on Ethereum, chain ID **4663**, ETH gas, ~100ms blocks, permissionless deployment, **MaxCodeSize 96KB** (4× EIP-170 — the size pressure that shaped `LeveragedAeroManager` doesn't exist here) [V].
+- **Governance caveat**: L2Beat classifies it "Other," not a rollup: whitelisted validators, and ArbOS 61 **transaction filtering that can nullify even force-included transactions** [V]. Mamo's "users can always withdraw" guarantee is strictly weaker here and must be disclosed honestly.
+- **Morpho**: deployed as **Blue + Vaults V2** — *not* MetaMorpho V1 (no metaMorphoFactory on 4663) [V]. Vault V2 is ERC-4626 + ERC-2612, but **`maxDeposit/maxMint/maxWithdraw/maxRedeem` always return 0 by design**, and vaults can set share/asset **gates** (`canReceiveShares` etc.). Key vaults: Steakhouse USDG `0xBeEff033F34C046626B8D0A041844C5d1A5409dd` (the Earn vault, ~1.6–1.9% organic), Steakhouse Turbo USDG (~4.3%), Ethena×Steakhouse, Grove. Collateral markets: spUSDG, USDe, syrupUSDG [C/R].
+- **No CoW Protocol** (confirmed by absence in cowprotocol repos for 4663) [V]. Uniswap v2/v3/v4 live with verified addresses (SwapRouter02 `0xcaf6...5cb2`), 1inch, LI.FI; UniswapX planned but unconfirmed [V/R]. **USDG depth on Uniswap ~$8.5M** — fine for reward swaps, thin for large rebalances [R].
+- **Chainlink exclusive**: Data Feeds + Data Streams + CCIP from block zero; per-equity **24/5 SVR feeds** (frozen on weekends, `oraclePaused()` advisory only); **Automation NOT in the launch list — do not design keepers around it until verified** [V/C].
+- **Merkl is the rewards layer** (Morpho URD deprecated chain-wide since MIP 111). The Earn subsidy is **paid in vault shares** — for the primary yield source there is *nothing to swap*; Merkl's `toggleOperator` lets each strategy authorize the Mamo backend to claim on its behalf [C/R].
+- **USDG**: `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168`, **6 decimals, no EIP-2612 permit**, Paxos-issued, ~64–68% of the chain's stablecoin float. **Bridged USDC is effectively empty (<500 USDC) — the base asset must be USDG** [V, 6-way corroborated].
+
+### Stock tokens
+- Issuer: **Robinhood Assets (Jersey) Ltd** — tokenized *debt* notes (economic exposure, no shareholder rights), 1:1 share-backed, ~95 tickers, plain ERC-20 18dp, **blocklist not allowlist** — arbitrary contracts can hold/trade them [C].
+- **ERC-8056 uiMultiplier**: corporate actions (dividends auto-reinvest, splits) adjust a display multiplier, never raw balances — vault reserve math survives corporate actions by design. **The Chainlink feed price already includes the multiplier**: use the feed for NAV and never multiply by `uiMultiplier()` again (the #1 accounting bug to avoid) [C].
+- **No dividend cash flow exists on-chain** (auto-reinvested into the multiplier) — "we compound your dividends" is not a sellable feature; no options venue; no securities-lending borrow rate (shorting goes through Lighter/Arcus perps). The yield on a basket comes from the **USDG sleeve**, not the stocks [C].
+- Jurisdictions: eligible in 120+ countries, **excluded: US, UK, Canada, Switzerland, UAE** + sanctioned. Front-end-enforced only; the "contracts route around geo-blocks" gap is already generating headlines (Coinfello warning, Aug 2026) and the issuer's `AccessControlsRegistry` can block a vault address in one transaction [C].
+- Stock-token AUM ~$70M and growing fast, but DEX flow is >80% memecoin-driven; stock/USDG LP is adversely selected (weekend = writing a free straddle to gap traders). **No confirmed live Morpho market with stock-token collateral yet** [R].
+
+### Competition
+- **Yieldfy** (pooled ERC-4626 USDG router + off-chain optimizer, targets tokenized equities, claims Chainlink Automation) is the closest analogue — early, TVL unpublished. Quiver, HoodVault, others: weeks-old, anonymous, unaudited. **No major Base yield agent has announced Robinhood Chain plans.** The seat is contested but not taken [R].
+- **Virtuals is live day one** with a ~$200M agent economy — the "AI agent" positioning fits the chain's narrative and has infrastructure to plug into [R].
+
+---
+
+## 2. Ranked ideas (strongest → weakest)
+
+### #1 — Mamo Baskets: curated stock baskets + USDG yield sleeve ⭐ *prototyped, 14/14 tests green*
+
+**One-liner:** "Own a slice of the market — and the cash half earns." Per-user strategy holding N tokenized stocks at target weights plus a Morpho USDG sleeve; the agent tilts weights, rebalances on drift bands, and keeps every idle dollar earning.
+
+**Why it's #1:**
+- It is the **only strategy surface Robinhood's 7% subsidy doesn't compete with** — Robinhood Earn is a savings product, not a portfolio product.
+- **Buildable today**: unrestricted ERC-20s, per-equity Chainlink feeds, Uniswap pools, and an official Arbitrum tutorial that is literally a stock-basket dApp. The infra is unusually friendly (ERC-8056 exists precisely so vaults survive corporate actions).
+- **Per-user strategies are a structural safety differentiator here, not just a preference.** The issuer can freeze/confiscate balances; every pooled competitor concentrates that blast radius across all depositors. Mamo's architecture bounds it to one user. This is a defensible, honest safety claim nobody else on the chain can make.
+- Differentiated vs. every "Base clone" yield router, including Yieldfy's pooled vault.
+
+**What the prototype proves** (`src/robinhood/StockBasketStrategy.sol`, `test/StockBasketStrategy.unit.t.sol`): deposit-to-sleeve-first (cheap deposits, agent-scheduled equity trading), two-pass drift-band rebalance (sell overweights → buy underweights → re-park remainder in sleeve), NAV preserved through oracle-parity trades, winners trimmed after price moves, withdrawals that drain sleeve first and only touch stocks when necessary, oracle-bounded router swaps that hard-revert when the pool deviates beyond slippage (the market-closed protection), and a `maxTotalStockBps` mandate the backend cannot exceed — the same "scope the agent with admin-set bounds" philosophy as the Boosted USDC pool-switching work.
+
+**Honest caveats:** non-US TAM (also excludes UK/CA/CH/UAE); rebalance capacity caps near **$1–2M AUM per basket** on current pool depth (route via RFQ/1inch Fusion above that); needs the **market-hours oracle guard** (§5) before production; regulatory tail risk — Robinhood's composability tolerance survives until the first enforcement inquiry, and their registry can block our addresses. Ship with caps small, jurisdiction-gate our own front end, and treat legal review as a launch gate.
+
+### #2 — The USDG multi-vault chassis: Morpho-only strategy + supply caps + scoped venues ⭐ *prototyped, 26/26 tests green*
+
+**One-liner:** the Base architecture, generalized: per-user strategy allocating across N allowlisted ERC-4626 vaults (Steakhouse USDG, Turbo, Ethena, Grove, future curators), backend rebalances within a **multisig-scoped allowlist**, global **supply cap** meters total deposits, Merkl claims + oracle-bounded Uniswap compounding replace the CoW loop.
+
+**Why it's #2 and not #1:** as a standalone headline it loses to the subsidized 7%. But it is (a) the **chassis every other idea runs on** — the basket's sleeve, Boosted USDG's unlevered layer, and the fee stream all live here; (b) the **cheapest port** — the audit branch's `MamoMultiMarketStrategy`/`MarketRegistry` already did the N-venue surgery, and dropping Moonwell *simplifies* it (single venue type, `getTotalBalance` becomes `view`); (c) honest positioning exists: "the agent that already runs $X on Base, now on Robinhood Chain, with more venues than Earn's single vault" — plus Merkl campaigns are open to any protocol if we ever choose to co-subsidize.
+
+**What the prototype proves** (`src/robinhood/MorphoVaultsStrategy.sol` + `MamoVaultConfig.sol`): weight-split deposits across N vaults; supply-cap enforcement with per-strategy tracked principal (withdrawals free capacity; clamp-down accounting so yield can't underflow the global meter — the same clamp rule as the audited `hedgedDebt` maintenance); registry-authenticated strategy self-reporting (spoof-resistant via `isUserStrategy`); backend rebalancing hard-scoped to the multisig allowlist; vault removal blocks new allocations without stranding funds; two-sided compound floor `max(backendMinOut, oracleFloor)` (the audited LeveragedAero pattern); compounded yield exempt from the cap. Written against Vault V2's quirks: no `max*` reliance anywhere.
+
+**Port notes:** reconcile `MamoVaultConfig` with the audit branch's `MarketRegistry` before shipping (one venue-registry contract, not two — adopt its append-only/soft-deactivate semantics, keep the cap accounting from this prototype). Full port sequencing in §4.
+
+### #3 — Boosted USDG: levered carry on Morpho Blue *(2nd wave, ~6 months)*
+
+**One-liner:** the Robinhood Chain sibling of Boosted USDC — but the venue is Morpho Blue instead of Aerodrome. Loop yield-bearing collateral (sUSDe ~4.5%, syrupUSDG ~4.6%, spUSDG ~3.2–4.2%) against USDG borrow to lever the carry spread; reported looped ROE on the chain is ~15–20% today.
+
+**Why it matters:** it's the product that can **honestly beat the subsidized 7%** — the answer to "why not just use Robinhood Earn?" It reuses the highest-value parts of the PR #66 work: the `LeveragedAeroVault` share-ledger lifecycle (Pending/Executed/Settled, `cloneAndBind`, permissionless `redeemSettled`), the `LeveragedAeroFees` HWM/crystallization library (pure, chain-agnostic), and the deposit-cap + admin-scoped-venue governance being added for Boosted USDC. The strategy layer is *simpler* than the Aerodrome CL book — no LP legs, no tick management; the loop is deposit-collateral/borrow/re-enter with an LTV target, and `adjustLeverage`-style persistence rules carry over.
+
+**Why not now:** carry spreads are young and partly incentive-driven; USDe/syrupUSDG depeg risk needs its own framework; liquidation sizing on a chain with sequencer/filtering centralization needs care; and the audit pipeline is already full with Boosted USDC. Spec after the chassis ships; the pooled-fund pattern is justified here (a levered book can't be sliced per user).
+
+### #4 — MAMO flywheel: fees → stakers, and staking-gated capacity *(wire from day one)*
+
+**One-liner:** every strategy already skims `compoundFee` (≤10%) on yield to `feeRecipient`. Point that at a `FeeSplitter` → treasury + `MultiRewards` staking, and make **supply-cap capacity itself the staking utility**.
+
+**Design:**
+- **Revenue share (reuse, near-zero new code):** `FeeSplitter` and `MultiRewards` (Synthetix fork, already handles mixed decimals) redeploy verbatim; `RewardsDistributorSafeModule` ports iff Safe is deployed on 4663 (verify; else a ~60-line Ownable-treasury variant of the same state machine). Flow: reward/basket-fee USDG → FeeSplitter → weekly "Mamo Drop" in USDG (+MAMO) to stakers. Real revenue, not emissions — the Aerodrome-fee model carried over, sourced from performance fees instead of LP fees.
+- **Staking-gated capacity (new, small):** the supply cap makes capacity scarce by construction. Extend `MamoVaultConfig` with tiered carve-outs: e.g. X% of remaining capacity reserved for users staking ≥N MAMO (config already tracks per-strategy principal; the gate is a few lines in `recordDeposit`). Scarce capacity in the highest-yield products (Boosted USDG at launch, new baskets) becomes the rational reason to hold/stake MAMO. This is the cleanest "utility that creates demand" available: it costs nothing, needs no emissions, and scales with product success.
+- **Not portable:** `Mamo.sol`'s Superchain bridge leg (OP-Stack predeploy) — an Orbit MAMO needs an Arbitrum-native bridge adapter or plain ERC20Votes; `BurnAndEarn`/`TransferAndEarn`/`DropAutomation` are Aerodrome-shaped end-to-end and stay behind. MAMO/USDG Uniswap pool fee capture can come later — chain DEX flow is real but memecoin-heavy today.
+
+### #5 — Everything we evaluated and ranked out
+
+| Idea | Verdict | Reason |
+|---|---|---|
+| Pure USDG router as the headline product | **Rejected as lead** | Loses to app-gated, subsidized 7% for ~a year; survives only as the chassis (#2) |
+| Stock/USDG LP strategies | **6+ months out** | Adversely selected flow (memecoin pairs, weekend gap traders); needs a v4 trading-hours hook and organic two-way retail flow |
+| Dividend auto-compounding | **Does not exist** | Dividends auto-reinvest inside the token's multiplier; no cash flow to capture |
+| Covered calls / options overlays | **Blocked** | No on-chain equity options venue anywhere with depth |
+| Securities-lending / short-interest yield | **Blocked** | Shorting routes through perps; no token borrow rate to harvest |
+| Stock-token-collateral lending markets | **Watch** | Possible and intended per docs; zero confirmed live markets; weekend-gap liquidations need Fri→Mon LLTV sizing |
+| Cross-issuer baskets (xStocks/Ondo/Dinari) | **Blocked for now** | None deployed or bridged to 4663 |
+| NAV mint/redeem arbitrage | **Structurally blocked** | Primary market is AP-only, KYB-gated |
+
+---
+
+## 3. What was built in this branch (MVP evidence)
+
+All under `src/robinhood/` + `test/`, unit-tested with mocks (no fork needed — one of the port's fringe benefits is losing the `--ffi`/fork-heavy CI path for core logic). **40 new tests, all green; full unit suite 91/91.**
+
+| File | What it is |
+|---|---|
+| `src/robinhood/MamoVaultConfig.sol` | Multisig-owned venue allowlist + family-wide supply cap with registry-authenticated, clamp-down principal accounting. The Boosted USDC governance asks (admin-scoped venue switching, deposit cap) applied to the per-user model. |
+| `src/robinhood/MorphoVaultsStrategy.sol` | The Base strategy generalized: N ERC-4626 vaults × bps weights, backend rebalance scoped to the allowlist, Merkl claim (configurable distributor), oracle-bounded Uniswap compound with two-sided floor, compound fee → `feeRecipient` (flywheel hook). Vault V2-aware (no `max*` reliance). |
+| `src/robinhood/StockBasketStrategy.sol` | Basket + sleeve: deposit-to-sleeve, two-pass drift rebalance, `maxTotalStockBps` mandate, oracle NAV, sleeve-first withdrawals with pro-rata stock sales, every swap oracle-bounded. |
+| `src/robinhood/interfaces/IUniswapV3SwapRouter.sol` | Fee-tier router interface (repo's existing `ISwapRouter` is the Aerodrome tickSpacing variant). |
+| `test/MorphoVaultsStrategy.unit.t.sol` | 26 tests: split/cap/rebalance/access/compound/slippage/governance, incl. cap-capacity lifecycle and removed-vault exit safety. |
+| `test/StockBasketStrategy.unit.t.sol` | 14 tests: buy-to-target, trim-winner, NAV under price moves, sleeve yield accrual, market-deviation revert, mandate enforcement. |
+| `test/mocks/RobinhoodMocks.sol` | MockERC4626 (the #1 test-infra gap flagged by the portability audit), registry/oracle/router/Merkl mocks. |
+
+Deliberate simplifications (prototype, not production): 18-dp mocks (USDG is 6 — the accounting is decimals-agnostic but tests should add a 6-dp matrix); no sequencer-uptime/market-hours staleness module yet (§5); `MamoVaultConfig` not yet reconciled with the audit branch's `MarketRegistry`; no factory/deploy scripts.
+
+---
+
+## 4. Port plan (from the codebase audit)
+
+The audit branch does most of the work. Execution order:
+
+1. **Rebase onto the multi-market work** from `feat/leveraged-aero-vanilla-vault`: `MarketRegistry`, `MamoMultiMarketStrategy`, `MultiMarketStrategyFactory`, `docs/MULTI_MARKET_DESIGN.md`.
+2. **Strip to ERC-4626-only**: delete the MTOKEN arms + `IMToken` + the WETH `receive()` wrap (OP-Stack predeploy `0x4200…0006` doesn't exist on Orbit); `_getTotalBalance` becomes `view`.
+3. **Delete the CoW leg entirely** (~150 lines: `isValidSignature`, appData JSON reconstruction, `DOMAIN_SEPARATOR`, `VAULT_RELAYER`, the standing max approval) and adopt the router compound with `max(backendMinOut, oracleFloor)` — the pattern already on the audit branch in `MamoStakingStrategy.compound()`. Fee becomes a plain transfer instead of a CoW pre-hook. CI loses `--ffi` and the CoW SDK dependency.
+4. **Oracle layer**: `SlippagePriceChecker` ports nearly as-is (`AggregatorV3Interface` is live), but add (a) a sequencer-uptime feed check, (b) the market-hours-aware staleness policy for equity feeds (§5). Chain-specific constants (`MERKLE_PROTOCOL_DISTRIBUTOR`, currently a hardcoded `constant`) become init/config parameters.
+5. **Merge the cap/allowlist**: one venue-registry contract — `MarketRegistry`'s append-only/soft-deactivate semantics + `MamoVaultConfig`'s supply cap and strategy authentication.
+6. **Config/deploy**: new `addresses/4663.json`, adopt the audit branch's `markets[]` config schema (drop `moonwellMarket`/`metamorphoVault` scalars), parameterize the three hardcoded keys in `DeploySystem.s.sol`; copy the `011_DeployMultiMarketSystem` proposal pattern. Verify Cancun/via-IR support on the Orbit node (audit-branch code uses transient-storage `ReentrancyGuardTransient`).
+7. **Flywheel** (§2 idea 4) once fees flow.
+
+**Registry, `BaseStrategy`, `MamoStrategyRegistry`, `Multicall`, `FeeSplitter`, `MultiRewards`, staking factory: port verbatim.** `StrategyFactory` is superseded by the multi-market factory. `BurnAndEarn`/`TransferAndEarn`/`DropAutomation`/`Mamo.sol`'s Superchain leg stay behind.
+
+---
+
+## 5. The market-hours oracle guard (required infra, unbuilt)
+
+Every stock-token-touching product needs one shared module; nobody on the chain appears to have built it well, which makes it quiet moat:
+
+- **NYSE-calendar-aware staleness**: equity feeds freeze on weekends/holidays with no heartbeat; a naive "revert if stale" bricks every weekend, no check at all means trading at Friday's price on Sunday. Policy: market-open → tight staleness bound; market-closed → NAV *views* may serve the last price flagged stale, but **state-changing paths that price equities (rebalance, stock sales) hard-halt**; sleeve-only operations (deposit, sleeve-covered withdrawals) continue 24/7. The basket prototype's deposit-to-sleeve and sleeve-first-withdrawal design was chosen precisely so the *common* paths never need an equity price.
+- **`oraclePaused()` + staged `newUIMultiplier`/`effectiveAt`** checks around corporate actions (advisory per Robinhood docs — the independent `updatedAt` check remains primary).
+- **Sequencer-uptime feed** check on every oracle read (standard Arbitrum-family practice; mandatory given the chain's centralization profile).
+
+---
+
+## 6. Verification checklist before any further commitment
+
+Single reads/calls, blocked from this environment (RPC egress denied), cheap from anywhere else:
+
+1. **Vault V2 gates on the Steakhouse vaults**: `receiveSharesGate()`/`sendSharesGate()` on `0xBeEff033…`. If a gate blocks third-party contracts, the chassis needs different target vaults — this one read could reshape idea #2.
+2. `eth_getCode` the Morpho/Uniswap addresses above (SDK-sourced, not chain-verified).
+3. **USDG depth + realistic slippage** at our trade sizes on Uniswap v3/v4; stock/USDG pool depth for the basket's rebalance cap.
+4. Chainlink feed directory for 4663 (`feeds-robinhood-mainnet.json`): confirm USDG/USD exists + per-equity feed coverage, heartbeats, decimals.
+5. Chainlink Automation / Gelato presence (keeper design), Safe deployment (RewardsDistributorSafeModule), MORPHO token bridged or not.
+6. Whether any live Morpho market takes stock-token collateral (idea-#3 adjacency).
+7. **Legal**: the Jersey base prospectus — whether third-party contracts holding tokens for mixed-jurisdiction users is a technical gap or a contractual breach; policy on vault addresses. This gates Mamo Baskets' launch scope.
+8. Gas-subsidy expiry (~Sept 29, 2026) → post-subsidy rebalance economics for per-user strategies.
+
+## 7. Suggested sequencing
+
+1. **Now**: run §6 checklist; legal review of the stock-token envelope; reconcile venue-registry design.
+2. **Wave 1 (chassis + baskets)**: port per §4; ship USDG chassis with conservative caps + 2–3 curated baskets (e.g. MAG7, AI, Blue-chip) jurisdiction-gated on our front end; flywheel wired (fees → stakers), staking-gated capacity from the first capped product. Positioning: "the yield agent with a portfolio brain — and per-user vaults that don't pool your risk."
+3. **Wave 2**: Boosted USDG levered carry (the honest 7%-beater) through the same audit pipeline as Boosted USDC; deepen basket liquidity routing (RFQ/Fusion); revisit stock-collateral markets and LP strategies as depth matures.
+
+The window is real but not indefinite — competitors are weeks old and unaudited, no Base incumbent has moved, and Mamo's audit history + per-user custody story is exactly the trust wedge this chain's early honeypot-ridden ecosystem lacks.

--- a/src/robinhood/MamoVaultConfig.sol
+++ b/src/robinhood/MamoVaultConfig.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {IERC4626} from "@interfaces/IERC4626.sol";
+import {IMamoStrategyRegistry} from "@interfaces/IMamoStrategyRegistry.sol";
+
+import {IERC173} from "@interfaces/IERC173.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+/**
+ * @title MamoVaultConfig
+ * @notice Shared, multisig-owned configuration for a family of MorphoVaultsStrategy instances on a single asset
+ * @dev Two responsibilities, both scoped to admin/multisig control rather than the backend:
+ *      1. The venue allowlist: the set of ERC4626 vaults the backend is allowed to allocate user funds
+ *         across. The backend rebalances freely WITHIN this set; only the owner (multisig, ideally behind
+ *         a timelock) can add or remove venues.
+ *      2. The supply cap: a limit on total user deposits across every strategy of this family, so exposure
+ *         to a young chain's venues can be grown deliberately.
+ *      Strategies self-report deposits/withdrawals; the config verifies the caller is a genuine registered
+ *      Mamo strategy via the MamoStrategyRegistry before trusting the report.
+ */
+contract MamoVaultConfig is Ownable2Step {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    /// @notice Upper bound on the number of allowlisted vaults, keeps strategy-side loops bounded
+    uint256 public constant MAX_VAULTS = 10;
+
+    /// @notice The underlying asset every allowlisted vault must use
+    address public immutable asset;
+
+    /// @notice Registry used to authenticate strategies reporting deposit/withdraw flows
+    IMamoStrategyRegistry public immutable mamoStrategyRegistry;
+
+    /// @notice Cap on total tracked user deposits across all strategies of this family (0 = uncapped)
+    uint256 public supplyCap;
+
+    /// @notice Sum of tracked user deposits across all strategies
+    uint256 public totalDeposited;
+
+    /// @notice Tracked user deposits per strategy, so withdrawals can never underflow the global total
+    mapping(address => uint256) public trackedDeposits;
+
+    EnumerableSet.AddressSet private _vaults;
+
+    event VaultAdded(address indexed vault);
+    event VaultRemoved(address indexed vault);
+    event SupplyCapUpdated(uint256 oldCap, uint256 newCap);
+    event DepositRecorded(address indexed strategy, uint256 amount, uint256 totalDeposited);
+    event WithdrawRecorded(address indexed strategy, uint256 amount, uint256 totalDeposited);
+
+    /**
+     * @param _asset The underlying asset of this strategy family
+     * @param _mamoStrategyRegistry The MamoStrategyRegistry used to authenticate strategies
+     * @param _owner The admin multisig (ideally behind a timelock)
+     * @param _supplyCap Initial supply cap in asset terms (0 = uncapped)
+     */
+    constructor(address _asset, address _mamoStrategyRegistry, address _owner, uint256 _supplyCap) Ownable(_owner) {
+        require(_asset != address(0), "Invalid asset address");
+        require(_mamoStrategyRegistry != address(0), "Invalid registry address");
+
+        asset = _asset;
+        mamoStrategyRegistry = IMamoStrategyRegistry(_mamoStrategyRegistry);
+        supplyCap = _supplyCap;
+    }
+
+    // ==================== OWNER FUNCTIONS ====================
+
+    /**
+     * @notice Adds a vault to the allowlist
+     * @dev Only callable by the owner. The vault must be an ERC4626 vault on this config's asset.
+     * @param vault The vault to allow
+     */
+    function addVault(address vault) external onlyOwner {
+        require(vault != address(0), "Invalid vault address");
+        require(IERC4626(vault).asset() == asset, "Vault asset mismatch");
+        require(_vaults.length() < MAX_VAULTS, "Max vaults reached");
+        require(_vaults.add(vault), "Vault already allowed");
+
+        emit VaultAdded(vault);
+    }
+
+    /**
+     * @notice Removes a vault from the allowlist
+     * @dev Removal blocks NEW allocations to the vault. Funds already in the vault stay withdrawable;
+     *      the backend is expected to rotate strategies out of it via updatePosition.
+     * @param vault The vault to remove
+     */
+    function removeVault(address vault) external onlyOwner {
+        require(_vaults.remove(vault), "Vault not allowed");
+
+        emit VaultRemoved(vault);
+    }
+
+    /**
+     * @notice Sets the supply cap
+     * @dev A cap below totalDeposited blocks new deposits without forcing exits
+     * @param _supplyCap The new cap in asset terms (0 = uncapped)
+     */
+    function setSupplyCap(uint256 _supplyCap) external onlyOwner {
+        emit SupplyCapUpdated(supplyCap, _supplyCap);
+        supplyCap = _supplyCap;
+    }
+
+    // ==================== STRATEGY FUNCTIONS ====================
+
+    /**
+     * @notice Records a user deposit and enforces the supply cap
+     * @dev Callable only by registered Mamo strategies
+     * @param amount The deposited amount in asset terms
+     */
+    function recordDeposit(uint256 amount) external onlyStrategy {
+        require(supplyCap == 0 || totalDeposited + amount <= supplyCap, "Supply cap exceeded");
+
+        trackedDeposits[msg.sender] += amount;
+        totalDeposited += amount;
+
+        emit DepositRecorded(msg.sender, amount, totalDeposited);
+    }
+
+    /**
+     * @notice Records a user withdrawal, freeing cap capacity
+     * @dev Clamps down to the strategy's tracked amount so yield withdrawals can't underflow the
+     *      global total or free more capacity than the strategy consumed
+     * @param amount The withdrawn amount in asset terms
+     */
+    function recordWithdraw(uint256 amount) external onlyStrategy {
+        uint256 tracked = trackedDeposits[msg.sender];
+        uint256 clamped = amount > tracked ? tracked : amount;
+
+        trackedDeposits[msg.sender] = tracked - clamped;
+        totalDeposited -= clamped;
+
+        emit WithdrawRecorded(msg.sender, clamped, totalDeposited);
+    }
+
+    // ==================== VIEW FUNCTIONS ====================
+
+    /**
+     * @notice Checks whether a vault is on the allowlist
+     */
+    function isAllowedVault(address vault) external view returns (bool) {
+        return _vaults.contains(vault);
+    }
+
+    /**
+     * @notice Returns the full vault allowlist
+     */
+    function getVaults() external view returns (address[] memory) {
+        return _vaults.values();
+    }
+
+    /**
+     * @notice Remaining deposit capacity under the cap (max uint if uncapped)
+     */
+    function remainingCapacity() external view returns (uint256) {
+        if (supplyCap == 0) return type(uint256).max;
+        return supplyCap > totalDeposited ? supplyCap - totalDeposited : 0;
+    }
+
+    /**
+     * @dev A caller is a genuine strategy iff the registry has it recorded for its current owner.
+     *      Only the registry backend can create that record, so it can't be spoofed.
+     */
+    modifier onlyStrategy() {
+        require(
+            mamoStrategyRegistry.isUserStrategy(IERC173(msg.sender).owner(), msg.sender),
+            "Caller is not a registered strategy"
+        );
+        _;
+    }
+}

--- a/src/robinhood/MorphoVaultsStrategy.sol
+++ b/src/robinhood/MorphoVaultsStrategy.sol
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {BaseStrategy} from "@contracts/BaseStrategy.sol";
+
+import {IERC4626} from "@interfaces/IERC4626.sol";
+import {ISlippagePriceChecker} from "@interfaces/ISlippagePriceChecker.sol";
+
+import {MamoVaultConfig} from "@contracts/robinhood/MamoVaultConfig.sol";
+import {IUniswapV3SwapRouter} from "@contracts/robinhood/interfaces/IUniswapV3SwapRouter.sol";
+
+import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface IMerkleDistributor {
+    function claim(
+        address[] calldata accounts,
+        address[] calldata rewardTokens,
+        uint256[] calldata rewardAmounts,
+        bytes32[][] calldata proofs
+    ) external;
+}
+
+/**
+ * @title MorphoVaultsStrategy
+ * @notice Per-user strategy that allocates a single ERC20 across N ERC4626 (MetaMorpho) vaults
+ * @notice IMPORTANT: This contract does not support fee-on-transfer tokens.
+ * @dev The Robinhood Chain counterpart of ERC20MoonwellMorphoStrategy, generalised for a chain where
+ *      Morpho is the only lending primitive:
+ *      - The fixed {Moonwell mToken, one MetaMorpho vault} pair becomes a dynamic set of ERC4626 vaults
+ *        with basis-point weights. The backend rebalances across the set, but only vaults allowlisted in
+ *        the multisig-owned MamoVaultConfig are eligible — venue changes are scoped to admin operations.
+ *      - User deposits are metered against a global supply cap in MamoVaultConfig.
+ *      - Reward compounding swaps through a Uniswap V3 style router with an oracle-derived minimum out
+ *        (via SlippagePriceChecker), replacing the CoW Protocol EIP-1271 flow, which does not exist on
+ *        Robinhood Chain. Rewards are claimed from a Merkl-style distributor, same as on Base.
+ */
+contract MorphoVaultsStrategy is Initializable, UUPSUpgradeable, BaseStrategy {
+    using SafeERC20 for IERC20;
+
+    /// @notice Total basis points used for split calculations (100%)
+    uint256 public constant SPLIT_TOTAL = 10000;
+
+    /// @notice The maximum allowed slippage in basis points
+    uint256 public constant MAX_SLIPPAGE_IN_BPS = 2500;
+
+    /// @notice The maximum allowed compound fee in basis points
+    uint256 public constant MAX_COMPOUND_FEE = 1000;
+
+    /// @notice Reference to the ERC20 token this strategy allocates
+    IERC20 public token;
+
+    /// @notice Shared multisig-owned config: vault allowlist + supply cap
+    MamoVaultConfig public vaultConfig;
+
+    /// @notice Oracle-based price checker used to bound reward swaps
+    ISlippagePriceChecker public slippagePriceChecker;
+
+    /// @notice Uniswap V3 style router used for reward swaps
+    IUniswapV3SwapRouter public dexRouter;
+
+    /// @notice Merkl-style distributor rewards are claimed from
+    address public merkleDistributor;
+
+    /// @notice Current vault set the position is spread across
+    address[] public vaults;
+
+    /// @notice Basis-point weight per vault, parallel to `vaults`, sums to SPLIT_TOTAL
+    uint256[] public weightsBps;
+
+    /// @notice The allowed slippage for reward swaps in basis points
+    uint256 public allowedSlippageInBps;
+
+    /// @notice The compound fee in basis points, skimmed from swapped rewards
+    uint256 public compoundFee;
+
+    /// @notice The fee recipient address
+    address public feeRecipient;
+
+    event Deposit(address indexed asset, uint256 amount);
+    event DepositIdle(address indexed asset, uint256 amount);
+    event Withdraw(address indexed asset, uint256 amount);
+    event PositionUpdated(address[] vaults, uint256[] weightsBps);
+    event SlippageUpdated(uint256 oldSlippage, uint256 newSlippage);
+    event FeeRecipientUpdated(address indexed oldFeeRecipient, address indexed newFeeRecipient);
+    event RewardsClaimed(address[] rewardTokens, uint256[] rewardAmounts);
+    event RewardsCompounded(address indexed rewardToken, uint256 amountIn, uint256 amountOut, uint256 feeAmount);
+
+    /// @notice Initialization parameters struct to avoid stack too deep errors
+    struct InitParams {
+        address mamoStrategyRegistry;
+        address token;
+        address vaultConfig;
+        address slippagePriceChecker;
+        address dexRouter;
+        address merkleDistributor;
+        address feeRecipient;
+        uint256 strategyTypeId;
+        address owner;
+        uint256 allowedSlippageInBps;
+        uint256 compoundFee;
+        address[] vaults;
+        uint256[] weightsBps;
+    }
+
+    /**
+     * @notice Restricts function access to the backend address only
+     */
+    modifier onlyBackend() {
+        require(msg.sender == mamoStrategyRegistry.getBackendAddress(), "Not backend");
+        _;
+    }
+
+    // ==================== INITIALIZER ====================
+
+    /**
+     * @notice Initializer function that sets all the parameters
+     * @param params The initialization parameters struct
+     */
+    function initialize(InitParams calldata params) external initializer {
+        require(params.mamoStrategyRegistry != address(0), "Invalid mamoStrategyRegistry address");
+        require(params.token != address(0), "Invalid token address");
+        require(params.vaultConfig != address(0), "Invalid vaultConfig address");
+        require(params.slippagePriceChecker != address(0), "Invalid slippagePriceChecker address");
+        require(params.dexRouter != address(0), "Invalid dexRouter address");
+        require(params.merkleDistributor != address(0), "Invalid merkleDistributor address");
+        require(params.feeRecipient != address(0), "Invalid fee recipient address");
+        require(params.strategyTypeId != 0, "Strategy type id not set");
+        require(params.allowedSlippageInBps <= MAX_SLIPPAGE_IN_BPS, "Slippage exceeds maximum");
+        require(params.compoundFee <= MAX_COMPOUND_FEE, "Compound fee exceeds maximum");
+        require(MamoVaultConfig(params.vaultConfig).asset() == params.token, "Config asset mismatch");
+
+        __BaseStrategy_init(params.mamoStrategyRegistry, params.strategyTypeId, params.owner);
+
+        token = IERC20(params.token);
+        vaultConfig = MamoVaultConfig(params.vaultConfig);
+        slippagePriceChecker = ISlippagePriceChecker(params.slippagePriceChecker);
+        dexRouter = IUniswapV3SwapRouter(params.dexRouter);
+        merkleDistributor = params.merkleDistributor;
+        feeRecipient = params.feeRecipient;
+        allowedSlippageInBps = params.allowedSlippageInBps;
+        compoundFee = params.compoundFee;
+
+        _setAllocations(params.vaults, params.weightsBps);
+    }
+
+    // ==================== OWNER FUNCTIONS ====================
+
+    /**
+     * @notice Sets a new slippage tolerance value
+     * @param _newSlippageInBps The new slippage tolerance in basis points
+     */
+    function setSlippage(uint256 _newSlippageInBps) external onlyOwner {
+        require(_newSlippageInBps <= MAX_SLIPPAGE_IN_BPS, "Slippage exceeds maximum");
+
+        emit SlippageUpdated(allowedSlippageInBps, _newSlippageInBps);
+        allowedSlippageInBps = _newSlippageInBps;
+    }
+
+    /**
+     * @notice Withdraws funds from the strategy
+     * @dev Pulls idle balance first, then withdraws from vaults in order until the amount is covered,
+     *      so it stays robust when actual vault balances have drifted from the target weights
+     * @param amount The amount to withdraw
+     */
+    function withdraw(uint256 amount) external onlyOwner {
+        require(amount > 0, "Amount must be greater than 0");
+        require(getTotalBalance() >= amount, "Withdrawal amount exceeds available balance in strategy");
+
+        uint256 idleBalance = token.balanceOf(address(this));
+
+        if (idleBalance < amount) {
+            uint256 remaining = amount - idleBalance;
+
+            for (uint256 i = 0; i < vaults.length && remaining > 0; i++) {
+                IERC4626 vault = IERC4626(vaults[i]);
+                // NOTE: Morpho Vault V2 returns 0 from maxWithdraw/maxDeposit by design, so available
+                // liquidity is derived from the share balance instead of the max* views
+                uint256 available = vault.convertToAssets(vault.balanceOf(address(this)));
+                if (available == 0) continue;
+
+                uint256 toWithdraw = remaining > available ? available : remaining;
+                vault.withdraw(toWithdraw, address(this), address(this));
+                remaining -= toWithdraw;
+            }
+        }
+
+        require(token.balanceOf(address(this)) >= amount, "Withdrawal failed: insufficient funds");
+
+        vaultConfig.recordWithdraw(amount);
+
+        token.safeTransfer(msg.sender, amount);
+
+        emit Withdraw(address(token), amount);
+    }
+
+    /**
+     * @notice Withdraws all funds from the strategy
+     */
+    function withdrawAll() external onlyOwner {
+        _redeemAllFromVaults();
+
+        uint256 finalBalance = token.balanceOf(address(this));
+        require(finalBalance > 0, "No tokens to withdraw");
+
+        vaultConfig.recordWithdraw(finalBalance);
+
+        token.safeTransfer(msg.sender, finalBalance);
+
+        emit Withdraw(address(token), finalBalance);
+    }
+
+    // ==================== BACKEND FUNCTIONS ====================
+
+    /**
+     * @notice Rebalances the position to a new vault set and weights
+     * @dev Only vaults allowlisted in the MamoVaultConfig are eligible, so the backend can move funds
+     *      freely between approved venues but can never introduce a new venue on its own
+     * @param newVaults The new vault set
+     * @param newWeightsBps The new basis-point weights, parallel to newVaults
+     */
+    function updatePosition(address[] calldata newVaults, uint256[] calldata newWeightsBps) external onlyBackend {
+        _redeemAllFromVaults();
+
+        uint256 totalTokenBalance = token.balanceOf(address(this));
+        require(totalTokenBalance > 0, "Nothing to rebalance");
+
+        _setAllocations(newVaults, newWeightsBps);
+
+        _depositInternal(totalTokenBalance);
+
+        emit PositionUpdated(newVaults, newWeightsBps);
+    }
+
+    /**
+     * @notice Claims rewards from the Merkl-style distributor on behalf of this strategy
+     * @param rewardTokens The addresses of the reward tokens
+     * @param rewardAmounts The amounts of the reward tokens
+     * @param proofs The proofs of the reward tokens
+     */
+    function claimRewards(
+        address[] calldata rewardTokens,
+        uint256[] calldata rewardAmounts,
+        bytes32[][] calldata proofs
+    ) external onlyBackend {
+        require(rewardTokens.length == rewardAmounts.length, "Reward tokens and amounts length mismatch");
+        require(rewardTokens.length == proofs.length, "Reward tokens and proofs length mismatch");
+
+        address[] memory accounts = new address[](rewardTokens.length);
+        for (uint256 i = 0; i < rewardTokens.length; i++) {
+            accounts[i] = address(this);
+        }
+
+        IMerkleDistributor(merkleDistributor).claim(accounts, rewardTokens, rewardAmounts, proofs);
+
+        emit RewardsClaimed(rewardTokens, rewardAmounts);
+    }
+
+    /**
+     * @notice Swaps the full balance of a reward token into the strategy token and redeposits it
+     * @dev Replaces the CoW Protocol flow on chains without CoW. The minimum output is derived from the
+     *      oracle price via SlippagePriceChecker, so the backend chooses WHEN to swap and through WHICH
+     *      fee tier, but can never accept a worse price than the oracle-bounded slippage allows.
+     * @param rewardToken The reward token to compound
+     * @param poolFee The Uniswap V3 fee tier to route through
+     * @param backendMinOut Backend-supplied minimum output; the effective floor is the max of this and
+     *        the oracle floor, so neither a careless keeper nor a manipulated pool can realize rewards
+     *        below the bound (the two-sided floor pattern from the audited LeveragedAero compound path)
+     */
+    function compoundRewards(address rewardToken, uint24 poolFee, uint256 backendMinOut) external onlyBackend {
+        require(rewardToken != address(token), "Cannot compound the strategy token");
+        require(slippagePriceChecker.isRewardToken(rewardToken), "Token not configured as reward");
+
+        uint256 amountIn = IERC20(rewardToken).balanceOf(address(this));
+        require(amountIn > 0, "No rewards to compound");
+
+        uint256 expectedOut = slippagePriceChecker.getExpectedOut(amountIn, rewardToken, address(token));
+        uint256 oracleFloor = (expectedOut * (SPLIT_TOTAL - allowedSlippageInBps)) / SPLIT_TOTAL;
+        uint256 minOut = backendMinOut > oracleFloor ? backendMinOut : oracleFloor;
+
+        IERC20(rewardToken).forceApprove(address(dexRouter), amountIn);
+
+        uint256 amountOut = dexRouter.exactInputSingle(
+            IUniswapV3SwapRouter.ExactInputSingleParams({
+                tokenIn: rewardToken,
+                tokenOut: address(token),
+                fee: poolFee,
+                recipient: address(this),
+                deadline: block.timestamp,
+                amountIn: amountIn,
+                amountOutMinimum: minOut,
+                sqrtPriceLimitX96: 0
+            })
+        );
+
+        uint256 feeAmount = (amountOut * compoundFee) / SPLIT_TOTAL;
+        if (feeAmount > 0) {
+            token.safeTransfer(feeRecipient, feeAmount);
+        }
+
+        _depositInternal(amountOut - feeAmount);
+
+        emit RewardsCompounded(rewardToken, amountIn, amountOut, feeAmount);
+    }
+
+    /**
+     * @notice Sets a new fee recipient address
+     * @param _newFeeRecipient The new fee recipient address
+     */
+    function setFeeRecipient(address _newFeeRecipient) external onlyBackend {
+        require(_newFeeRecipient != address(0), "Invalid fee recipient address");
+
+        emit FeeRecipientUpdated(feeRecipient, _newFeeRecipient);
+        feeRecipient = _newFeeRecipient;
+    }
+
+    // ==================== PERMISSIONLESS FUNCTIONS ====================
+
+    /**
+     * @notice Deposits funds into the strategy
+     * @dev Metered against the family-wide supply cap in MamoVaultConfig
+     * @param amount The amount of tokens to deposit
+     */
+    function deposit(uint256 amount) external {
+        require(amount > 0, "Amount must be greater than 0");
+
+        token.safeTransferFrom(msg.sender, address(this), amount);
+
+        vaultConfig.recordDeposit(amount);
+
+        _depositInternal(amount);
+
+        emit Deposit(address(token), amount);
+    }
+
+    /**
+     * @notice Deposits any idle token balance into the vaults based on the current weights
+     * @dev Permissionless. Idle balance originates from compounded rewards, not user principal,
+     *      so it is not metered against the supply cap.
+     * @return amount The amount of tokens deposited
+     */
+    function depositIdleTokens() external returns (uint256) {
+        uint256 tokenBalance = token.balanceOf(address(this));
+        require(tokenBalance > 0, "No tokens to deposit");
+
+        _depositInternal(tokenBalance);
+
+        emit DepositIdle(address(token), tokenBalance);
+
+        return tokenBalance;
+    }
+
+    // ======================= VIEW FUNCTIONS ==========================
+
+    /**
+     * @notice Gets the total balance of tokens across all vaults plus the idle balance
+     */
+    function getTotalBalance() public view returns (uint256) {
+        uint256 total = token.balanceOf(address(this));
+
+        for (uint256 i = 0; i < vaults.length; i++) {
+            IERC4626 vault = IERC4626(vaults[i]);
+            uint256 shares = vault.balanceOf(address(this));
+            if (shares > 0) {
+                total += vault.convertToAssets(shares);
+            }
+        }
+
+        return total;
+    }
+
+    /**
+     * @notice Returns the current vault set and weights
+     */
+    function getAllocations() external view returns (address[] memory, uint256[] memory) {
+        return (vaults, weightsBps);
+    }
+
+    // ==================== INTERNAL FUNCTIONS ====================
+
+    /**
+     * @notice Validates and stores a new vault set and weights
+     */
+    function _setAllocations(address[] memory newVaults, uint256[] memory newWeightsBps) internal {
+        require(newVaults.length > 0, "Empty vault set");
+        require(newVaults.length == newWeightsBps.length, "Vaults and weights length mismatch");
+
+        uint256 weightSum;
+        for (uint256 i = 0; i < newVaults.length; i++) {
+            require(vaultConfig.isAllowedVault(newVaults[i]), "Vault not allowlisted");
+            require(newWeightsBps[i] > 0, "Zero weight");
+
+            for (uint256 j = 0; j < i; j++) {
+                require(newVaults[j] != newVaults[i], "Duplicate vault");
+            }
+
+            weightSum += newWeightsBps[i];
+        }
+        require(weightSum == SPLIT_TOTAL, "Weights must add up to SPLIT_TOTAL");
+
+        vaults = newVaults;
+        weightsBps = newWeightsBps;
+    }
+
+    /**
+     * @notice Deposits tokens across the vault set according to the current weights
+     */
+    function _depositInternal(uint256 amount) internal {
+        for (uint256 i = 0; i < vaults.length; i++) {
+            uint256 target = (amount * weightsBps[i]) / SPLIT_TOTAL;
+            if (target == 0) continue;
+
+            token.forceApprove(vaults[i], target);
+            IERC4626(vaults[i]).deposit(target, address(this));
+        }
+    }
+
+    /**
+     * @notice Redeems every share in every vault in the current set
+     */
+    function _redeemAllFromVaults() internal {
+        for (uint256 i = 0; i < vaults.length; i++) {
+            IERC4626 vault = IERC4626(vaults[i]);
+            uint256 shares = vault.balanceOf(address(this));
+            if (shares > 0) {
+                vault.redeem(shares, address(this), address(this));
+            }
+        }
+    }
+}

--- a/src/robinhood/StockBasketStrategy.sol
+++ b/src/robinhood/StockBasketStrategy.sol
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {BaseStrategy} from "@contracts/BaseStrategy.sol";
+
+import {IERC4626} from "@interfaces/IERC4626.sol";
+import {ISlippagePriceChecker} from "@interfaces/ISlippagePriceChecker.sol";
+
+import {IUniswapV3SwapRouter} from "@contracts/robinhood/interfaces/IUniswapV3SwapRouter.sol";
+
+import {Initializable} from "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title StockBasketStrategy
+ * @notice Per-user strategy holding a curated basket of tokenized stocks plus a USDG yield sleeve
+ * @notice IMPORTANT: This contract does not support fee-on-transfer tokens.
+ * @dev The differentiated Robinhood Chain product: "own a slice of the market, and the idle half earns".
+ *      Position = one ERC4626 yield sleeve on the base asset (e.g. a Morpho USDG vault) + N tokenized
+ *      stocks at basis-point target weights. The backend adjusts weights and rebalances; every swap is
+ *      routed through a Uniswap V3 style router with an oracle-derived minimum out, so the agent decides
+ *      WHEN to trade but can never trade at a worse price than the oracle-bounded slippage allows.
+ *
+ *      Scoping mirrors the Boosted USDC governance model:
+ *      - The stock set and the yield sleeve are fixed at initialization (factory/admin decision).
+ *      - The total stock allocation is bounded by maxTotalStockBps, set at initialization — the backend
+ *        can tilt within the band but can never push equity exposure past the product's mandate.
+ *
+ *      Deposits land in the yield sleeve first ("deposit is cheap"); the agent's next rebalance buys the
+ *      basket to target. Withdrawals drain idle + sleeve first and only sell stocks when needed, so the
+ *      common exit path never touches equity markets.
+ */
+contract StockBasketStrategy is Initializable, UUPSUpgradeable, BaseStrategy {
+    using SafeERC20 for IERC20;
+
+    /// @notice Total basis points used for weight calculations (100%)
+    uint256 public constant WEIGHT_TOTAL = 10000;
+
+    /// @notice The maximum allowed slippage in basis points
+    uint256 public constant MAX_SLIPPAGE_IN_BPS = 2500;
+
+    /// @notice Maximum number of stocks in a basket, keeps loops bounded
+    uint256 public constant MAX_STOCKS = 12;
+
+    /// @notice The base asset (e.g. USDG)
+    IERC20 public token;
+
+    /// @notice The ERC4626 yield sleeve on the base asset
+    IERC4626 public yieldVault;
+
+    /// @notice The curated stock tokens, fixed at initialization
+    address[] public stockTokens;
+
+    /// @notice Target basis-point weight per stock, parallel to stockTokens
+    uint256[] public stockWeightsBps;
+
+    /// @notice Upper bound on the summed stock weights, fixed at initialization
+    uint256 public maxTotalStockBps;
+
+    /// @notice Oracle-based price checker used to value stocks and bound swaps
+    ISlippagePriceChecker public slippagePriceChecker;
+
+    /// @notice Uniswap V3 style router used for basket trades
+    IUniswapV3SwapRouter public dexRouter;
+
+    /// @notice Uniswap V3 fee tier used for stock/base-asset pools
+    uint24 public poolFee;
+
+    /// @notice The allowed slippage for basket trades in basis points
+    uint256 public allowedSlippageInBps;
+
+    event Deposit(address indexed asset, uint256 amount);
+    event Withdraw(address indexed asset, uint256 amount);
+    event WeightsUpdated(uint256[] stockWeightsBps);
+    event Rebalanced(uint256 navBefore, uint256 navAfter);
+    event SlippageUpdated(uint256 oldSlippage, uint256 newSlippage);
+    event StockSold(address indexed stock, uint256 amountIn, uint256 amountOut);
+    event StockBought(address indexed stock, uint256 amountIn, uint256 amountOut);
+
+    /// @notice Initialization parameters struct to avoid stack too deep errors
+    struct InitParams {
+        address mamoStrategyRegistry;
+        address token;
+        address yieldVault;
+        address slippagePriceChecker;
+        address dexRouter;
+        uint256 strategyTypeId;
+        address owner;
+        uint256 allowedSlippageInBps;
+        uint256 maxTotalStockBps;
+        uint24 poolFee;
+        address[] stockTokens;
+        uint256[] stockWeightsBps;
+    }
+
+    /**
+     * @notice Restricts function access to the backend address only
+     */
+    modifier onlyBackend() {
+        require(msg.sender == mamoStrategyRegistry.getBackendAddress(), "Not backend");
+        _;
+    }
+
+    // ==================== INITIALIZER ====================
+
+    /**
+     * @notice Initializer function that sets all the parameters
+     * @param params The initialization parameters struct
+     */
+    function initialize(InitParams calldata params) external initializer {
+        require(params.mamoStrategyRegistry != address(0), "Invalid mamoStrategyRegistry address");
+        require(params.token != address(0), "Invalid token address");
+        require(params.yieldVault != address(0), "Invalid yieldVault address");
+        require(params.slippagePriceChecker != address(0), "Invalid slippagePriceChecker address");
+        require(params.dexRouter != address(0), "Invalid dexRouter address");
+        require(params.strategyTypeId != 0, "Strategy type id not set");
+        require(params.allowedSlippageInBps <= MAX_SLIPPAGE_IN_BPS, "Slippage exceeds maximum");
+        require(params.maxTotalStockBps <= WEIGHT_TOTAL, "Max stock bps exceeds total");
+        require(IERC4626(params.yieldVault).asset() == params.token, "Vault asset mismatch");
+        require(params.stockTokens.length > 0, "Empty stock set");
+        require(params.stockTokens.length <= MAX_STOCKS, "Too many stocks");
+
+        __BaseStrategy_init(params.mamoStrategyRegistry, params.strategyTypeId, params.owner);
+
+        token = IERC20(params.token);
+        yieldVault = IERC4626(params.yieldVault);
+        slippagePriceChecker = ISlippagePriceChecker(params.slippagePriceChecker);
+        dexRouter = IUniswapV3SwapRouter(params.dexRouter);
+        allowedSlippageInBps = params.allowedSlippageInBps;
+        maxTotalStockBps = params.maxTotalStockBps;
+        poolFee = params.poolFee;
+
+        for (uint256 i = 0; i < params.stockTokens.length; i++) {
+            require(params.stockTokens[i] != address(0), "Invalid stock address");
+            require(params.stockTokens[i] != params.token, "Stock cannot be base asset");
+
+            for (uint256 j = 0; j < i; j++) {
+                require(params.stockTokens[j] != params.stockTokens[i], "Duplicate stock");
+            }
+        }
+        stockTokens = params.stockTokens;
+
+        _setStockWeights(params.stockWeightsBps);
+    }
+
+    // ==================== OWNER FUNCTIONS ====================
+
+    /**
+     * @notice Sets a new slippage tolerance value
+     * @param _newSlippageInBps The new slippage tolerance in basis points
+     */
+    function setSlippage(uint256 _newSlippageInBps) external onlyOwner {
+        require(_newSlippageInBps <= MAX_SLIPPAGE_IN_BPS, "Slippage exceeds maximum");
+
+        emit SlippageUpdated(allowedSlippageInBps, _newSlippageInBps);
+        allowedSlippageInBps = _newSlippageInBps;
+    }
+
+    /**
+     * @notice Withdraws base-asset value from the strategy
+     * @dev Drains idle balance, then the yield sleeve, and only then sells stocks pro-rata. Selling
+     *      through the router is oracle-bounded; if equity pools are stale (markets closed) the sale —
+     *      and only then the withdrawal — reverts rather than filling at a bad price.
+     * @param amount The amount of base asset to withdraw
+     */
+    function withdraw(uint256 amount) external onlyOwner {
+        require(amount > 0, "Amount must be greater than 0");
+
+        uint256 idleBalance = token.balanceOf(address(this));
+
+        if (idleBalance < amount) {
+            uint256 remaining = amount - idleBalance;
+
+            // pull from the yield sleeve first
+            uint256 sleeveAvailable = yieldVault.maxWithdraw(address(this));
+            if (sleeveAvailable > 0) {
+                uint256 fromSleeve = remaining > sleeveAvailable ? sleeveAvailable : remaining;
+                yieldVault.withdraw(fromSleeve, address(this), address(this));
+                remaining -= fromSleeve;
+            }
+
+            // sell stocks pro-rata for whatever is still missing
+            if (remaining > 0) {
+                _sellStocksForExactBase(remaining);
+            }
+        }
+
+        require(token.balanceOf(address(this)) >= amount, "Withdrawal failed: insufficient funds");
+
+        token.safeTransfer(msg.sender, amount);
+
+        emit Withdraw(address(token), amount);
+    }
+
+    /**
+     * @notice Withdraws everything: sells the full basket and drains the sleeve
+     */
+    function withdrawAll() external onlyOwner {
+        for (uint256 i = 0; i < stockTokens.length; i++) {
+            uint256 stockBalance = IERC20(stockTokens[i]).balanceOf(address(this));
+            if (stockBalance > 0) {
+                _swap(stockTokens[i], address(token), stockBalance);
+                emit StockSold(stockTokens[i], stockBalance, 0);
+            }
+        }
+
+        uint256 sleeveShares = yieldVault.balanceOf(address(this));
+        if (sleeveShares > 0) {
+            yieldVault.redeem(sleeveShares, address(this), address(this));
+        }
+
+        uint256 finalBalance = token.balanceOf(address(this));
+        require(finalBalance > 0, "No tokens to withdraw");
+
+        token.safeTransfer(msg.sender, finalBalance);
+
+        emit Withdraw(address(token), finalBalance);
+    }
+
+    // ==================== BACKEND FUNCTIONS ====================
+
+    /**
+     * @notice Updates the target stock weights within the immutable stock set and exposure band
+     * @param newStockWeightsBps New basis-point weights, parallel to stockTokens
+     */
+    function setStockWeights(uint256[] calldata newStockWeightsBps) external onlyBackend {
+        _setStockWeights(newStockWeightsBps);
+
+        emit WeightsUpdated(newStockWeightsBps);
+    }
+
+    /**
+     * @notice Rebalances holdings to the target weights
+     * @dev Two passes: sell every overweight stock into the base asset, then buy every underweight
+     *      stock, then push the remaining base asset into the yield sleeve. Trades below minTradeValue
+     *      are skipped so dust never burns gas or spread.
+     * @param minTradeValue Minimum base-asset value of a trade worth executing
+     */
+    function rebalance(uint256 minTradeValue) external onlyBackend {
+        uint256 navBefore = getTotalBalance();
+        require(navBefore > 0, "Nothing to rebalance");
+
+        // Pass 1: sell overweights
+        for (uint256 i = 0; i < stockTokens.length; i++) {
+            uint256 currentValue = _stockValue(stockTokens[i]);
+            uint256 targetValue = (navBefore * stockWeightsBps[i]) / WEIGHT_TOTAL;
+
+            if (currentValue > targetValue + minTradeValue) {
+                uint256 excessValue = currentValue - targetValue;
+                uint256 stockBalance = IERC20(stockTokens[i]).balanceOf(address(this));
+                uint256 amountToSell = (stockBalance * excessValue) / currentValue;
+
+                if (amountToSell > 0) {
+                    uint256 received = _swap(stockTokens[i], address(token), amountToSell);
+                    emit StockSold(stockTokens[i], amountToSell, received);
+                }
+            }
+        }
+
+        // Pass 2: buy underweights with idle + sleeve funds
+        for (uint256 i = 0; i < stockTokens.length; i++) {
+            uint256 currentValue = _stockValue(stockTokens[i]);
+            uint256 targetValue = (navBefore * stockWeightsBps[i]) / WEIGHT_TOTAL;
+
+            if (targetValue > currentValue + minTradeValue) {
+                uint256 needed = targetValue - currentValue;
+
+                uint256 idleBalance = token.balanceOf(address(this));
+                if (idleBalance < needed) {
+                    uint256 sleeveAvailable = yieldVault.maxWithdraw(address(this));
+                    uint256 fromSleeve = needed - idleBalance;
+                    if (fromSleeve > sleeveAvailable) fromSleeve = sleeveAvailable;
+                    if (fromSleeve > 0) {
+                        yieldVault.withdraw(fromSleeve, address(this), address(this));
+                    }
+                }
+
+                uint256 spendable = token.balanceOf(address(this));
+                uint256 toSpend = needed > spendable ? spendable : needed;
+
+                if (toSpend > 0) {
+                    uint256 received = _swap(address(token), stockTokens[i], toSpend);
+                    emit StockBought(stockTokens[i], toSpend, received);
+                }
+            }
+        }
+
+        // Park whatever base asset remains in the yield sleeve
+        uint256 remainder = token.balanceOf(address(this));
+        if (remainder > 0) {
+            token.forceApprove(address(yieldVault), remainder);
+            yieldVault.deposit(remainder, address(this));
+        }
+
+        emit Rebalanced(navBefore, getTotalBalance());
+    }
+
+    // ==================== PERMISSIONLESS FUNCTIONS ====================
+
+    /**
+     * @notice Deposits base asset into the strategy
+     * @dev Lands in the yield sleeve; the agent's next rebalance buys the basket to target. This keeps
+     *      user deposits cheap and keeps equity trading on the agent's schedule (market hours aware).
+     * @param amount The amount of base asset to deposit
+     */
+    function deposit(uint256 amount) external {
+        require(amount > 0, "Amount must be greater than 0");
+
+        token.safeTransferFrom(msg.sender, address(this), amount);
+
+        token.forceApprove(address(yieldVault), amount);
+        yieldVault.deposit(amount, address(this));
+
+        emit Deposit(address(token), amount);
+    }
+
+    // ======================= VIEW FUNCTIONS ==========================
+
+    /**
+     * @notice Net asset value in base-asset terms: idle + sleeve + oracle value of every stock holding
+     */
+    function getTotalBalance() public view returns (uint256) {
+        uint256 total = token.balanceOf(address(this));
+
+        uint256 sleeveShares = yieldVault.balanceOf(address(this));
+        if (sleeveShares > 0) {
+            total += yieldVault.convertToAssets(sleeveShares);
+        }
+
+        for (uint256 i = 0; i < stockTokens.length; i++) {
+            total += _stockValue(stockTokens[i]);
+        }
+
+        return total;
+    }
+
+    /**
+     * @notice Returns the stock set and current target weights
+     */
+    function getBasket() external view returns (address[] memory, uint256[] memory) {
+        return (stockTokens, stockWeightsBps);
+    }
+
+    // ==================== INTERNAL FUNCTIONS ====================
+
+    /**
+     * @notice Values a stock holding in base-asset terms via the oracle
+     */
+    function _stockValue(address stock) internal view returns (uint256) {
+        uint256 balance = IERC20(stock).balanceOf(address(this));
+        if (balance == 0) return 0;
+
+        return slippagePriceChecker.getExpectedOut(balance, stock, address(token));
+    }
+
+    /**
+     * @notice Validates and stores new stock weights
+     */
+    function _setStockWeights(uint256[] memory newWeights) internal {
+        require(newWeights.length == stockTokens.length, "Weights length mismatch");
+
+        uint256 totalStockBps;
+        for (uint256 i = 0; i < newWeights.length; i++) {
+            totalStockBps += newWeights[i];
+        }
+        require(totalStockBps <= maxTotalStockBps, "Stock allocation exceeds mandate");
+
+        stockWeightsBps = newWeights;
+    }
+
+    /**
+     * @notice Sells stocks pro-rata to their current value until `baseNeeded` of base asset is raised
+     */
+    function _sellStocksForExactBase(uint256 baseNeeded) internal {
+        uint256 totalStockValue;
+        for (uint256 i = 0; i < stockTokens.length; i++) {
+            totalStockValue += _stockValue(stockTokens[i]);
+        }
+        require(totalStockValue > 0, "Withdrawal amount exceeds available balance in strategy");
+
+        // sell slightly above the exact need so slippage can't leave the withdrawal short
+        uint256 grossNeeded = (baseNeeded * (WEIGHT_TOTAL + allowedSlippageInBps)) / WEIGHT_TOTAL;
+        if (grossNeeded > totalStockValue) grossNeeded = totalStockValue;
+
+        for (uint256 i = 0; i < stockTokens.length; i++) {
+            uint256 stockValue = _stockValue(stockTokens[i]);
+            if (stockValue == 0) continue;
+
+            uint256 valueToSell = (grossNeeded * stockValue) / totalStockValue;
+            uint256 stockBalance = IERC20(stockTokens[i]).balanceOf(address(this));
+            uint256 amountToSell = (stockBalance * valueToSell) / stockValue;
+
+            if (amountToSell > 0) {
+                uint256 received = _swap(stockTokens[i], address(token), amountToSell);
+                emit StockSold(stockTokens[i], amountToSell, received);
+            }
+        }
+    }
+
+    /**
+     * @notice Swaps through the router with an oracle-derived minimum out
+     */
+    function _swap(address tokenIn, address tokenOut, uint256 amountIn) internal returns (uint256) {
+        uint256 expectedOut = slippagePriceChecker.getExpectedOut(amountIn, tokenIn, tokenOut);
+        require(expectedOut > 0, "No oracle price for pair");
+
+        uint256 minOut = (expectedOut * (WEIGHT_TOTAL - allowedSlippageInBps)) / WEIGHT_TOTAL;
+
+        IERC20(tokenIn).forceApprove(address(dexRouter), amountIn);
+
+        return dexRouter.exactInputSingle(
+            IUniswapV3SwapRouter.ExactInputSingleParams({
+                tokenIn: tokenIn,
+                tokenOut: tokenOut,
+                fee: poolFee,
+                recipient: address(this),
+                deadline: block.timestamp,
+                amountIn: amountIn,
+                amountOutMinimum: minOut,
+                sqrtPriceLimitX96: 0
+            })
+        );
+    }
+}

--- a/src/robinhood/interfaces/IUniswapV3SwapRouter.sol
+++ b/src/robinhood/interfaces/IUniswapV3SwapRouter.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+/// @title Uniswap V3 style router interface (fee-tier based, unlike the Aerodrome tickSpacing variant)
+/// @notice Minimal surface used by MorphoVaultsStrategy for reward compounding on chains without CoW Protocol
+interface IUniswapV3SwapRouter {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Swaps `amountIn` of one token for as much as possible of another token
+    /// @return amountOut The amount of the received token
+    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+}

--- a/test/MorphoVaultsStrategy.unit.t.sol
+++ b/test/MorphoVaultsStrategy.unit.t.sol
@@ -6,14 +6,14 @@ import {Test} from "@forge-std/Test.sol";
 import {MamoVaultConfig} from "@contracts/robinhood/MamoVaultConfig.sol";
 import {MorphoVaultsStrategy} from "@contracts/robinhood/MorphoVaultsStrategy.sol";
 
-import {MockERC20} from "@test/MockERC20.sol";
+import {MockERC20} from "./MockERC20.sol";
 import {
     MockERC4626,
     MockMerkleDistributor,
     MockSlippagePriceChecker,
     MockStrategyRegistry,
     MockSwapRouter
-} from "@test/mocks/RobinhoodMocks.sol";
+} from "./mocks/RobinhoodMocks.sol";
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/MorphoVaultsStrategy.unit.t.sol
+++ b/test/MorphoVaultsStrategy.unit.t.sol
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Test} from "@forge-std/Test.sol";
+
+import {MamoVaultConfig} from "@contracts/robinhood/MamoVaultConfig.sol";
+import {MorphoVaultsStrategy} from "@contracts/robinhood/MorphoVaultsStrategy.sol";
+
+import {MockERC20} from "@test/MockERC20.sol";
+import {
+    MockERC4626,
+    MockMerkleDistributor,
+    MockSlippagePriceChecker,
+    MockStrategyRegistry,
+    MockSwapRouter
+} from "@test/mocks/RobinhoodMocks.sol";
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract MorphoVaultsStrategyUnitTest is Test {
+    uint256 public constant SUPPLY_CAP = 1_000_000e18;
+    uint256 public constant STRATEGY_TYPE_ID = 1;
+    uint256 public constant SLIPPAGE_BPS = 100; // 1%
+    uint256 public constant COMPOUND_FEE_BPS = 500; // 5%
+
+    address public admin = makeAddr("adminMultisig");
+    address public backend = makeAddr("backend");
+    address public user = makeAddr("user");
+    address public feeRecipient = makeAddr("feeRecipient");
+
+    MockERC20 public usdg;
+    MockERC20 public morphoToken;
+    MockERC4626 public vaultA;
+    MockERC4626 public vaultB;
+    MockERC4626 public vaultC;
+    MockStrategyRegistry public registry;
+    MockSlippagePriceChecker public priceChecker;
+    MockSwapRouter public router;
+    MockMerkleDistributor public distributor;
+    MamoVaultConfig public config;
+    MorphoVaultsStrategy public strategy;
+
+    function setUp() public {
+        usdg = new MockERC20("Global Dollar", "USDG");
+        morphoToken = new MockERC20("Morpho", "MORPHO");
+
+        vaultA = new MockERC4626(IERC20(address(usdg)), "Vault A", "vA");
+        vaultB = new MockERC4626(IERC20(address(usdg)), "Vault B", "vB");
+        vaultC = new MockERC4626(IERC20(address(usdg)), "Vault C", "vC");
+
+        registry = new MockStrategyRegistry(backend);
+        priceChecker = new MockSlippagePriceChecker();
+        router = new MockSwapRouter();
+        distributor = new MockMerkleDistributor();
+
+        config = new MamoVaultConfig(address(usdg), address(registry), admin, SUPPLY_CAP);
+
+        vm.startPrank(admin);
+        config.addVault(address(vaultA));
+        config.addVault(address(vaultB));
+        config.addVault(address(vaultC));
+        vm.stopPrank();
+
+        priceChecker.setRewardToken(address(morphoToken), true);
+        // oracle: 1 MORPHO = 2 USDG; pool executes at parity with the oracle by default
+        priceChecker.setRate(address(morphoToken), address(usdg), 2e18);
+        router.setExecRate(address(morphoToken), address(usdg), 2e18);
+
+        strategy = MorphoVaultsStrategy(payable(_deployStrategy(user)));
+        registry.setUserStrategy(user, address(strategy), true);
+
+        usdg.mint(user, 10_000_000e18);
+        vm.prank(user);
+        usdg.approve(address(strategy), type(uint256).max);
+    }
+
+    function _defaultVaults() internal view returns (address[] memory vaults, uint256[] memory weights) {
+        vaults = new address[](2);
+        vaults[0] = address(vaultA);
+        vaults[1] = address(vaultB);
+        weights = new uint256[](2);
+        weights[0] = 6000;
+        weights[1] = 4000;
+    }
+
+    function _initParams(address owner) internal view returns (MorphoVaultsStrategy.InitParams memory params) {
+        (address[] memory vaults, uint256[] memory weights) = _defaultVaults();
+        params = MorphoVaultsStrategy.InitParams({
+            mamoStrategyRegistry: address(registry),
+            token: address(usdg),
+            vaultConfig: address(config),
+            slippagePriceChecker: address(priceChecker),
+            dexRouter: address(router),
+            merkleDistributor: address(distributor),
+            feeRecipient: feeRecipient,
+            strategyTypeId: STRATEGY_TYPE_ID,
+            owner: owner,
+            allowedSlippageInBps: SLIPPAGE_BPS,
+            compoundFee: COMPOUND_FEE_BPS,
+            vaults: vaults,
+            weightsBps: weights
+        });
+    }
+
+    function _deployStrategy(address owner) internal returns (address) {
+        MorphoVaultsStrategy implementation = new MorphoVaultsStrategy();
+        bytes memory initData = abi.encodeCall(MorphoVaultsStrategy.initialize, (_initParams(owner)));
+        return address(new ERC1967Proxy(address(implementation), initData));
+    }
+
+    // ==================== INITIALIZATION ====================
+
+    function testInitializeSetsState() public view {
+        assertEq(address(strategy.token()), address(usdg));
+        assertEq(address(strategy.vaultConfig()), address(config));
+        assertEq(strategy.owner(), user);
+        assertEq(strategy.compoundFee(), COMPOUND_FEE_BPS);
+
+        (address[] memory vaults, uint256[] memory weights) = strategy.getAllocations();
+        assertEq(vaults.length, 2);
+        assertEq(vaults[0], address(vaultA));
+        assertEq(weights[0], 6000);
+        assertEq(weights[1], 4000);
+    }
+
+    function testInitializeRevertsWhenWeightsDoNotSum() public {
+        MorphoVaultsStrategy implementation = new MorphoVaultsStrategy();
+        MorphoVaultsStrategy.InitParams memory params = _initParams(user);
+        params.weightsBps[0] = 5000; // 5000 + 4000 != 10000
+
+        vm.expectRevert("Weights must add up to SPLIT_TOTAL");
+        new ERC1967Proxy(address(implementation), abi.encodeCall(MorphoVaultsStrategy.initialize, (params)));
+    }
+
+    function testInitializeRevertsWithNonAllowlistedVault() public {
+        MockERC4626 rogueVault = new MockERC4626(IERC20(address(usdg)), "Rogue", "vR");
+
+        MorphoVaultsStrategy implementation = new MorphoVaultsStrategy();
+        MorphoVaultsStrategy.InitParams memory params = _initParams(user);
+        params.vaults[1] = address(rogueVault);
+
+        vm.expectRevert("Vault not allowlisted");
+        new ERC1967Proxy(address(implementation), abi.encodeCall(MorphoVaultsStrategy.initialize, (params)));
+    }
+
+    function testInitializeRevertsOnConfigAssetMismatch() public {
+        MockERC20 otherToken = new MockERC20("Other", "OTH");
+
+        MorphoVaultsStrategy implementation = new MorphoVaultsStrategy();
+        MorphoVaultsStrategy.InitParams memory params = _initParams(user);
+        params.token = address(otherToken);
+
+        vm.expectRevert("Config asset mismatch");
+        new ERC1967Proxy(address(implementation), abi.encodeCall(MorphoVaultsStrategy.initialize, (params)));
+    }
+
+    // ==================== DEPOSITS & SUPPLY CAP ====================
+
+    function testDepositSplitsAcrossVaultsByWeights() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        assertEq(vaultA.convertToAssets(vaultA.balanceOf(address(strategy))), 600e18);
+        assertEq(vaultB.convertToAssets(vaultB.balanceOf(address(strategy))), 400e18);
+        assertEq(strategy.getTotalBalance(), 1000e18);
+        assertEq(config.totalDeposited(), 1000e18);
+    }
+
+    function testDepositRevertsOverSupplyCap() public {
+        vm.prank(user);
+        vm.expectRevert("Supply cap exceeded");
+        strategy.deposit(SUPPLY_CAP + 1);
+
+        // exactly at cap is fine
+        vm.prank(user);
+        strategy.deposit(SUPPLY_CAP);
+        assertEq(config.remainingCapacity(), 0);
+    }
+
+    function testWithdrawFreesSupplyCapCapacity() public {
+        vm.prank(user);
+        strategy.deposit(SUPPLY_CAP);
+
+        vm.prank(user);
+        strategy.withdraw(400_000e18);
+        assertEq(config.remainingCapacity(), 400_000e18);
+
+        vm.prank(user);
+        strategy.deposit(400_000e18);
+        assertEq(config.remainingCapacity(), 0);
+    }
+
+    function testRecordDepositRevertsForNonStrategyCaller() public {
+        // a contract with an owner() that is NOT registered in the registry
+        MorphoVaultsStrategy impostor = MorphoVaultsStrategy(payable(_deployStrategy(makeAddr("attacker"))));
+
+        vm.expectRevert("Caller is not a registered strategy");
+        vm.prank(address(impostor));
+        config.recordDeposit(1e18);
+    }
+
+    // ==================== WITHDRAWALS ====================
+
+    function testWithdrawPartialPullsFromVaults() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        uint256 balanceBefore = usdg.balanceOf(user);
+
+        vm.prank(user);
+        strategy.withdraw(700e18);
+
+        assertEq(usdg.balanceOf(user) - balanceBefore, 700e18);
+        assertEq(strategy.getTotalBalance(), 300e18);
+    }
+
+    function testWithdrawRevertsOverBalance() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        vm.prank(user);
+        vm.expectRevert("Withdrawal amount exceeds available balance in strategy");
+        strategy.withdraw(1001e18);
+    }
+
+    function testWithdrawAllEmptiesVaults() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        uint256 balanceBefore = usdg.balanceOf(user);
+
+        vm.prank(user);
+        strategy.withdrawAll();
+
+        assertEq(usdg.balanceOf(user) - balanceBefore, 1000e18);
+        assertEq(strategy.getTotalBalance(), 0);
+        assertEq(config.totalDeposited(), 0);
+    }
+
+    function testWithdrawOnlyOwner() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        vm.prank(backend);
+        vm.expectRevert();
+        strategy.withdraw(100e18);
+    }
+
+    // ==================== REBALANCING ====================
+
+    function testUpdatePositionMovesFundsToNewVaultSet() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        address[] memory newVaults = new address[](1);
+        newVaults[0] = address(vaultC);
+        uint256[] memory newWeights = new uint256[](1);
+        newWeights[0] = 10000;
+
+        vm.prank(backend);
+        strategy.updatePosition(newVaults, newWeights);
+
+        assertEq(vaultA.balanceOf(address(strategy)), 0);
+        assertEq(vaultB.balanceOf(address(strategy)), 0);
+        assertEq(vaultC.convertToAssets(vaultC.balanceOf(address(strategy))), 1000e18);
+        assertEq(strategy.getTotalBalance(), 1000e18);
+    }
+
+    function testUpdatePositionRevertsForNonAllowlistedVault() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        MockERC4626 rogueVault = new MockERC4626(IERC20(address(usdg)), "Rogue", "vR");
+        address[] memory newVaults = new address[](1);
+        newVaults[0] = address(rogueVault);
+        uint256[] memory newWeights = new uint256[](1);
+        newWeights[0] = 10000;
+
+        vm.prank(backend);
+        vm.expectRevert("Vault not allowlisted");
+        strategy.updatePosition(newVaults, newWeights);
+    }
+
+    function testUpdatePositionRevertsForDuplicateVault() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        address[] memory newVaults = new address[](2);
+        newVaults[0] = address(vaultA);
+        newVaults[1] = address(vaultA);
+        uint256[] memory newWeights = new uint256[](2);
+        newWeights[0] = 5000;
+        newWeights[1] = 5000;
+
+        vm.prank(backend);
+        vm.expectRevert("Duplicate vault");
+        strategy.updatePosition(newVaults, newWeights);
+    }
+
+    function testUpdatePositionOnlyBackend() public {
+        (address[] memory vaults, uint256[] memory weights) = _defaultVaults();
+
+        vm.prank(user);
+        vm.expectRevert("Not backend");
+        strategy.updatePosition(vaults, weights);
+    }
+
+    // ==================== YIELD & COMPOUNDING ====================
+
+    function testYieldAccrualIncreasesTotalBalance() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        // simulate 10% yield in vault A by minting underlying directly to it
+        usdg.mint(address(vaultA), 60e18);
+
+        // 1 wei tolerance for ERC4626 virtual-share rounding
+        assertApproxEqAbs(strategy.getTotalBalance(), 1060e18, 1);
+    }
+
+    function testCompoundRewardsSwapsSkimsFeeAndRedeposits() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        // 100 MORPHO landed from a Merkl claim; oracle says 1 MORPHO = 2 USDG
+        morphoToken.mint(address(strategy), 100e18);
+
+        vm.prank(backend);
+        strategy.compoundRewards(address(morphoToken), 3000, 0);
+
+        // 200 USDG out, 5% fee = 10 USDG to feeRecipient, 190 USDG redeposited
+        assertEq(usdg.balanceOf(feeRecipient), 10e18);
+        assertEq(strategy.getTotalBalance(), 1190e18);
+        assertEq(morphoToken.balanceOf(address(strategy)), 0);
+        // compounded yield does not consume supply cap
+        assertEq(config.totalDeposited(), 1000e18);
+    }
+
+    function testCompoundRewardsRevertsWhenPoolPriceTooLow() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        morphoToken.mint(address(strategy), 100e18);
+
+        // pool executes 2% below oracle, above the 1% slippage bound
+        router.setExecRate(address(morphoToken), address(usdg), 1.96e18);
+
+        vm.prank(backend);
+        vm.expectRevert("Too little received");
+        strategy.compoundRewards(address(morphoToken), 3000, 0);
+    }
+
+    function testCompoundRewardsOnlyBackend() public {
+        vm.prank(user);
+        vm.expectRevert("Not backend");
+        strategy.compoundRewards(address(morphoToken), 3000, 0);
+    }
+
+    function testCompoundRewardsRevertsForUnconfiguredToken() public {
+        MockERC20 randomToken = new MockERC20("Random", "RND");
+        randomToken.mint(address(strategy), 100e18);
+
+        vm.prank(backend);
+        vm.expectRevert("Token not configured as reward");
+        strategy.compoundRewards(address(randomToken), 3000, 0);
+    }
+
+    function testClaimRewardsPullsFromDistributor() public {
+        address[] memory rewardTokens = new address[](1);
+        rewardTokens[0] = address(morphoToken);
+        uint256[] memory rewardAmounts = new uint256[](1);
+        rewardAmounts[0] = 50e18;
+        bytes32[][] memory proofs = new bytes32[][](1);
+        proofs[0] = new bytes32[](0);
+
+        vm.prank(backend);
+        strategy.claimRewards(rewardTokens, rewardAmounts, proofs);
+
+        assertEq(morphoToken.balanceOf(address(strategy)), 50e18);
+    }
+
+    // ==================== CONFIG GOVERNANCE ====================
+
+    function testAddVaultOnlyOwner() public {
+        MockERC4626 newVault = new MockERC4626(IERC20(address(usdg)), "New", "vN");
+
+        vm.prank(backend);
+        vm.expectRevert();
+        config.addVault(address(newVault));
+
+        vm.prank(admin);
+        config.addVault(address(newVault));
+        assertTrue(config.isAllowedVault(address(newVault)));
+    }
+
+    function testAddVaultRevertsOnAssetMismatch() public {
+        MockERC20 otherToken = new MockERC20("Other", "OTH");
+        MockERC4626 wrongVault = new MockERC4626(IERC20(address(otherToken)), "Wrong", "vW");
+
+        vm.prank(admin);
+        vm.expectRevert("Vault asset mismatch");
+        config.addVault(address(wrongVault));
+    }
+
+    function testRemovedVaultBlocksNewAllocationsButAllowsExit() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        vm.prank(admin);
+        config.removeVault(address(vaultA));
+
+        // rebalancing INTO the removed vault fails
+        (address[] memory vaults, uint256[] memory weights) = _defaultVaults();
+        vm.prank(backend);
+        vm.expectRevert("Vault not allowlisted");
+        strategy.updatePosition(vaults, weights);
+
+        // but the user can still exit in full
+        uint256 balanceBefore = usdg.balanceOf(user);
+        vm.prank(user);
+        strategy.withdrawAll();
+        assertEq(usdg.balanceOf(user) - balanceBefore, 1000e18);
+    }
+
+    function testSetSupplyCapBelowCurrentBlocksNewDepositsOnly() public {
+        vm.prank(user);
+        strategy.deposit(1000e18);
+
+        vm.prank(admin);
+        config.setSupplyCap(500e18);
+
+        vm.prank(user);
+        vm.expectRevert("Supply cap exceeded");
+        strategy.deposit(1e18);
+
+        // existing funds remain withdrawable
+        vm.prank(user);
+        strategy.withdraw(600e18);
+    }
+}

--- a/test/StockBasketStrategy.unit.t.sol
+++ b/test/StockBasketStrategy.unit.t.sol
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Test} from "@forge-std/Test.sol";
+
+import {StockBasketStrategy} from "@contracts/robinhood/StockBasketStrategy.sol";
+
+import {MockERC20} from "@test/MockERC20.sol";
+import {
+    MockERC4626,
+    MockSlippagePriceChecker,
+    MockStrategyRegistry,
+    MockSwapRouter
+} from "@test/mocks/RobinhoodMocks.sol";
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract StockBasketStrategyUnitTest is Test {
+    uint256 public constant STRATEGY_TYPE_ID = 2;
+    uint256 public constant SLIPPAGE_BPS = 100; // 1%
+    uint256 public constant MAX_STOCK_BPS = 7000; // equity exposure mandate: max 70%
+    uint24 public constant POOL_FEE = 3000;
+
+    address public backend = makeAddr("backend");
+    address public user = makeAddr("user");
+
+    MockERC20 public usdg;
+    MockERC20 public nvda;
+    MockERC20 public aapl;
+    MockERC4626 public sleeve;
+    MockStrategyRegistry public registry;
+    MockSlippagePriceChecker public priceChecker;
+    MockSwapRouter public router;
+    StockBasketStrategy public strategy;
+
+    function setUp() public {
+        usdg = new MockERC20("Global Dollar", "USDG");
+        nvda = new MockERC20("NVIDIA Stock Token", "NVDAt");
+        aapl = new MockERC20("Apple Stock Token", "AAPLt");
+
+        sleeve = new MockERC4626(IERC20(address(usdg)), "USDG Sleeve", "sUSDG");
+        registry = new MockStrategyRegistry(backend);
+        priceChecker = new MockSlippagePriceChecker();
+        router = new MockSwapRouter();
+
+        // oracle: NVDA = 180 USDG, AAPL = 220 USDG; router executes at oracle parity by default
+        _setPrice(address(nvda), 180e18);
+        _setPrice(address(aapl), 220e18);
+
+        strategy = StockBasketStrategy(payable(_deployStrategy(user)));
+
+        usdg.mint(user, 1_000_000e18);
+        vm.prank(user);
+        usdg.approve(address(strategy), type(uint256).max);
+    }
+
+    function _setPrice(address stock, uint256 usdgPerToken) internal {
+        priceChecker.setRate(stock, address(usdg), usdgPerToken);
+        priceChecker.setRate(address(usdg), stock, 1e36 / usdgPerToken);
+        router.setExecRate(stock, address(usdg), usdgPerToken);
+        router.setExecRate(address(usdg), stock, 1e36 / usdgPerToken);
+    }
+
+    function _initParams(address owner) internal view returns (StockBasketStrategy.InitParams memory params) {
+        address[] memory stocks = new address[](2);
+        stocks[0] = address(nvda);
+        stocks[1] = address(aapl);
+        // 30% NVDA, 20% AAPL, implied 50% yield sleeve
+        uint256[] memory weights = new uint256[](2);
+        weights[0] = 3000;
+        weights[1] = 2000;
+
+        params = StockBasketStrategy.InitParams({
+            mamoStrategyRegistry: address(registry),
+            token: address(usdg),
+            yieldVault: address(sleeve),
+            slippagePriceChecker: address(priceChecker),
+            dexRouter: address(router),
+            strategyTypeId: STRATEGY_TYPE_ID,
+            owner: owner,
+            allowedSlippageInBps: SLIPPAGE_BPS,
+            maxTotalStockBps: MAX_STOCK_BPS,
+            poolFee: POOL_FEE,
+            stockTokens: stocks,
+            stockWeightsBps: weights
+        });
+    }
+
+    function _deployStrategy(address owner) internal returns (address) {
+        StockBasketStrategy implementation = new StockBasketStrategy();
+        bytes memory initData = abi.encodeCall(StockBasketStrategy.initialize, (_initParams(owner)));
+        return address(new ERC1967Proxy(address(implementation), initData));
+    }
+
+    // ==================== INITIALIZATION ====================
+
+    function testInitializeSetsState() public view {
+        assertEq(address(strategy.token()), address(usdg));
+        assertEq(address(strategy.yieldVault()), address(sleeve));
+        assertEq(strategy.owner(), user);
+        assertEq(strategy.maxTotalStockBps(), MAX_STOCK_BPS);
+
+        (address[] memory stocks, uint256[] memory weights) = strategy.getBasket();
+        assertEq(stocks.length, 2);
+        assertEq(stocks[0], address(nvda));
+        assertEq(weights[0], 3000);
+        assertEq(weights[1], 2000);
+    }
+
+    function testInitializeRevertsWhenWeightsExceedMandate() public {
+        StockBasketStrategy implementation = new StockBasketStrategy();
+        StockBasketStrategy.InitParams memory params = _initParams(user);
+        params.stockWeightsBps[0] = 6000; // 6000 + 2000 > 7000 mandate
+
+        vm.expectRevert("Stock allocation exceeds mandate");
+        new ERC1967Proxy(address(implementation), abi.encodeCall(StockBasketStrategy.initialize, (params)));
+    }
+
+    // ==================== DEPOSIT & REBALANCE ====================
+
+    function testDepositLandsInYieldSleeve() public {
+        vm.prank(user);
+        strategy.deposit(10_000e18);
+
+        assertApproxEqAbs(sleeve.convertToAssets(sleeve.balanceOf(address(strategy))), 10_000e18, 1);
+        assertEq(nvda.balanceOf(address(strategy)), 0);
+        assertApproxEqAbs(strategy.getTotalBalance(), 10_000e18, 1);
+    }
+
+    function testRebalanceBuysBasketToTargets() public {
+        vm.prank(user);
+        strategy.deposit(10_000e18);
+
+        vm.prank(backend);
+        strategy.rebalance(1e18);
+
+        // 30% NVDA @ 180 → ~16.67 NVDA, 20% AAPL @ 220 → ~9.09 AAPL, 50% stays earning
+        assertApproxEqRel(nvda.balanceOf(address(strategy)), uint256(3000e18) / 180, 0.01e18);
+        assertApproxEqRel(aapl.balanceOf(address(strategy)), uint256(2000e18) / 220, 0.01e18);
+        assertApproxEqRel(sleeve.convertToAssets(sleeve.balanceOf(address(strategy))), 5000e18, 0.01e18);
+        // NAV preserved through the trades (router executes at oracle parity)
+        assertApproxEqRel(strategy.getTotalBalance(), 10_000e18, 0.001e18);
+    }
+
+    function testRebalanceSellsWinnerAfterPriceMove() public {
+        vm.prank(user);
+        strategy.deposit(10_000e18);
+        vm.prank(backend);
+        strategy.rebalance(1e18);
+
+        // NVDA doubles: basket is now overweight NVDA
+        _setPrice(address(nvda), 360e18);
+
+        uint256 navAfterMove = strategy.getTotalBalance();
+        assertApproxEqRel(navAfterMove, 13_000e18, 0.01e18); // 3000 NVDA value doubled
+
+        uint256 nvdaBefore = nvda.balanceOf(address(strategy));
+
+        vm.prank(backend);
+        strategy.rebalance(1e18);
+
+        // rebalance trims NVDA back toward 30% of the (larger) NAV
+        uint256 nvdaAfter = nvda.balanceOf(address(strategy));
+        assertLt(nvdaAfter, nvdaBefore);
+
+        uint256 nvdaValue = priceChecker.getExpectedOut(nvdaAfter, address(nvda), address(usdg));
+        assertApproxEqRel(nvdaValue, (navAfterMove * 3000) / 10000, 0.02e18);
+    }
+
+    function testSetStockWeightsRespectsMandate() public {
+        uint256[] memory newWeights = new uint256[](2);
+        newWeights[0] = 5000;
+        newWeights[1] = 2500;
+
+        vm.prank(backend);
+        vm.expectRevert("Stock allocation exceeds mandate");
+        strategy.setStockWeights(newWeights);
+
+        newWeights[0] = 4000;
+        newWeights[1] = 3000;
+        vm.prank(backend);
+        strategy.setStockWeights(newWeights);
+
+        (, uint256[] memory weights) = strategy.getBasket();
+        assertEq(weights[0], 4000);
+    }
+
+    function testSetStockWeightsOnlyBackend() public {
+        uint256[] memory newWeights = new uint256[](2);
+        newWeights[0] = 1000;
+        newWeights[1] = 1000;
+
+        vm.prank(user);
+        vm.expectRevert("Not backend");
+        strategy.setStockWeights(newWeights);
+    }
+
+    function testRebalanceOnlyBackend() public {
+        vm.prank(user);
+        vm.expectRevert("Not backend");
+        strategy.rebalance(1e18);
+    }
+
+    // ==================== WITHDRAWALS ====================
+
+    function testWithdrawFromSleeveOnlyWhenSufficient() public {
+        vm.prank(user);
+        strategy.deposit(10_000e18);
+        vm.prank(backend);
+        strategy.rebalance(1e18);
+
+        uint256 nvdaBefore = nvda.balanceOf(address(strategy));
+        uint256 balanceBefore = usdg.balanceOf(user);
+
+        // 3000 < ~5000 sleeve: no stock should be touched
+        vm.prank(user);
+        strategy.withdraw(3000e18);
+
+        assertEq(usdg.balanceOf(user) - balanceBefore, 3000e18);
+        assertEq(nvda.balanceOf(address(strategy)), nvdaBefore);
+    }
+
+    function testWithdrawSellsStocksWhenSleeveInsufficient() public {
+        vm.prank(user);
+        strategy.deposit(10_000e18);
+        vm.prank(backend);
+        strategy.rebalance(1e18);
+
+        uint256 nvdaBefore = nvda.balanceOf(address(strategy));
+        uint256 balanceBefore = usdg.balanceOf(user);
+
+        // 8000 > ~5000 sleeve: stocks must be sold pro-rata
+        vm.prank(user);
+        strategy.withdraw(8000e18);
+
+        assertEq(usdg.balanceOf(user) - balanceBefore, 8000e18);
+        assertLt(nvda.balanceOf(address(strategy)), nvdaBefore);
+    }
+
+    function testWithdrawAllExitsEverything() public {
+        vm.prank(user);
+        strategy.deposit(10_000e18);
+        vm.prank(backend);
+        strategy.rebalance(1e18);
+
+        uint256 balanceBefore = usdg.balanceOf(user);
+
+        vm.prank(user);
+        strategy.withdrawAll();
+
+        // full exit at oracle parity: NAV round-trips minus rounding dust
+        assertApproxEqRel(usdg.balanceOf(user) - balanceBefore, 10_000e18, 0.001e18);
+        assertEq(nvda.balanceOf(address(strategy)), 0);
+        assertEq(aapl.balanceOf(address(strategy)), 0);
+        assertEq(sleeve.balanceOf(address(strategy)), 0);
+    }
+
+    function testWithdrawRevertsWhenPoolDeviatesFromOracle() public {
+        vm.prank(user);
+        strategy.deposit(10_000e18);
+        vm.prank(backend);
+        strategy.rebalance(1e18);
+
+        // pool now fills NVDA sales 3% below oracle — beyond the 1% slippage bound
+        router.setExecRate(address(nvda), address(usdg), 174.6e18);
+        router.setExecRate(address(aapl), address(usdg), 213.4e18);
+
+        vm.prank(user);
+        vm.expectRevert("Too little received");
+        strategy.withdraw(8000e18);
+
+        // sleeve-covered withdrawals still work fine
+        vm.prank(user);
+        strategy.withdraw(3000e18);
+    }
+
+    // ==================== NAV & YIELD ====================
+
+    function testSleeveYieldAccruesToNav() public {
+        vm.prank(user);
+        strategy.deposit(10_000e18);
+        vm.prank(backend);
+        strategy.rebalance(1e18);
+
+        // 10% yield on the ~5000 USDG sleeve
+        usdg.mint(address(sleeve), 500e18);
+
+        assertApproxEqRel(strategy.getTotalBalance(), 10_500e18, 0.001e18);
+    }
+
+    function testNavTracksStockPrices() public {
+        vm.prank(user);
+        strategy.deposit(10_000e18);
+        vm.prank(backend);
+        strategy.rebalance(1e18);
+
+        // AAPL -50%: 2000 of AAPL value halves
+        _setPrice(address(aapl), 110e18);
+
+        assertApproxEqRel(strategy.getTotalBalance(), 9_000e18, 0.01e18);
+    }
+}

--- a/test/StockBasketStrategy.unit.t.sol
+++ b/test/StockBasketStrategy.unit.t.sol
@@ -7,10 +7,7 @@ import {StockBasketStrategy} from "@contracts/robinhood/StockBasketStrategy.sol"
 
 import {MockERC20} from "@test/MockERC20.sol";
 import {
-    MockERC4626,
-    MockSlippagePriceChecker,
-    MockStrategyRegistry,
-    MockSwapRouter
+    MockERC4626, MockSlippagePriceChecker, MockStrategyRegistry, MockSwapRouter
 } from "@test/mocks/RobinhoodMocks.sol";
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/test/StockBasketStrategy.unit.t.sol
+++ b/test/StockBasketStrategy.unit.t.sol
@@ -5,10 +5,8 @@ import {Test} from "@forge-std/Test.sol";
 
 import {StockBasketStrategy} from "@contracts/robinhood/StockBasketStrategy.sol";
 
-import {MockERC20} from "@test/MockERC20.sol";
-import {
-    MockERC4626, MockSlippagePriceChecker, MockStrategyRegistry, MockSwapRouter
-} from "@test/mocks/RobinhoodMocks.sol";
+import {MockERC20} from "./MockERC20.sol";
+import {MockERC4626, MockSlippagePriceChecker, MockStrategyRegistry, MockSwapRouter} from "./mocks/RobinhoodMocks.sol";
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/mocks/RobinhoodMocks.sol
+++ b/test/mocks/RobinhoodMocks.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {MockERC20} from "../MockERC20.sol";
 import {IUniswapV3SwapRouter} from "@contracts/robinhood/interfaces/IUniswapV3SwapRouter.sol";
-import {MockERC20} from "@test/MockERC20.sol";
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/mocks/RobinhoodMocks.sol
+++ b/test/mocks/RobinhoodMocks.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {IUniswapV3SwapRouter} from "@contracts/robinhood/interfaces/IUniswapV3SwapRouter.sol";
+import {MockERC20} from "@test/MockERC20.sol";
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @notice Plain OZ ERC4626 vault. Yield is simulated by minting underlying directly to the vault.
+contract MockERC4626 is ERC4626 {
+    constructor(IERC20 asset_, string memory name_, string memory symbol_) ERC4626(asset_) ERC20(name_, symbol_) {}
+}
+
+/// @notice Minimal stand-in for MamoStrategyRegistry: backend address + user→strategy records
+contract MockStrategyRegistry {
+    address public backend;
+    mapping(address => mapping(address => bool)) private _userStrategies;
+
+    constructor(address _backend) {
+        backend = _backend;
+    }
+
+    function getBackendAddress() external view returns (address) {
+        return backend;
+    }
+
+    function setUserStrategy(address user, address strategy, bool isStrategy) external {
+        _userStrategies[user][strategy] = isStrategy;
+    }
+
+    function isUserStrategy(address user, address strategy) external view returns (bool) {
+        return _userStrategies[user][strategy];
+    }
+
+    function updateStrategyOwner(address newOwner) external {}
+}
+
+/// @notice Oracle stub: expectedOut = amountIn * rate / 1e18 per (from, to) pair
+contract MockSlippagePriceChecker {
+    mapping(address => bool) public isRewardToken;
+    mapping(address => mapping(address => uint256)) public rate;
+
+    function setRewardToken(address token, bool allowed) external {
+        isRewardToken[token] = allowed;
+    }
+
+    function setRate(address fromToken, address toToken, uint256 rate1e18) external {
+        rate[fromToken][toToken] = rate1e18;
+    }
+
+    function getExpectedOut(uint256 amountIn, address fromToken, address toToken) external view returns (uint256) {
+        return (amountIn * rate[fromToken][toToken]) / 1e18;
+    }
+}
+
+/// @notice Router stub: pays out tokenOut at execRate, enforcing amountOutMinimum like Uniswap V3
+contract MockSwapRouter is IUniswapV3SwapRouter {
+    using SafeERC20 for IERC20;
+
+    // execution rate per (tokenIn, tokenOut), 1e18-scaled — set below oracle rate to simulate slippage
+    mapping(address => mapping(address => uint256)) public execRate;
+
+    function setExecRate(address tokenIn, address tokenOut, uint256 rate1e18) external {
+        execRate[tokenIn][tokenOut] = rate1e18;
+    }
+
+    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut) {
+        IERC20(params.tokenIn).safeTransferFrom(msg.sender, address(this), params.amountIn);
+
+        amountOut = (params.amountIn * execRate[params.tokenIn][params.tokenOut]) / 1e18;
+        require(amountOut >= params.amountOutMinimum, "Too little received");
+
+        MockERC20(params.tokenOut).mint(msg.sender, amountOut);
+    }
+}
+
+/// @notice Distributor stub: mints the claimed amounts to the accounts, ignoring proofs
+contract MockMerkleDistributor {
+    function claim(
+        address[] calldata accounts,
+        address[] calldata rewardTokens,
+        uint256[] calldata rewardAmounts,
+        bytes32[][] calldata
+    ) external {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            MockERC20(rewardTokens[i]).mint(accounts[i], rewardAmounts[i]);
+        }
+    }
+}


### PR DESCRIPTION
## What this is

A research-driven spec + two prototyped strategies for launching a Mamo-style product on **Robinhood Chain** (Arbitrum Orbit, chain 4663). Three parallel research passes (chain infra, stock-token yield viability, codebase portability incl. the PR #66 audit branch) fed a ranked idea list, and the top two ideas were proven out as contracts with green unit suites before writing anything up. **This is a proposal branch — prototypes are proofs of mechanics, not deployment-ready code.**

## Key findings that reshaped the plan

- **Morpho on 4663 is Blue + Vaults V2, not MetaMorpho V1.** Still ERC-4626, but `maxDeposit/maxWithdraw` return 0 by design and vaults can set share gates — the prototypes are written against these quirks, and checking gates on the Steakhouse vaults is the #1 pre-commitment on-chain read.
- **No CoW Protocol on the chain** — the EIP-1271 flow can't port. Replaced with backend-executed Uniswap swaps bounded by `max(backendMinOut, oracleFloor)`, the same oracle-anchored pattern the audit branch already uses in `MamoStakingStrategy.compound()`.
- **Merkl is the rewards layer** (URD deprecated) and the Robinhood Earn subsidy is paid *in vault shares* — the primary yield source needs no swap at all.
- **A pure USDG router is commercially DOA**: Robinhood Earn shows a subsidized ~7% (app-gated Merkl top-up) vs ~2–4.5% organic. The differentiated plays are stock baskets (which the subsidy can't touch) and, later, levered carry.
- **Stock tokens are plain ERC-20s (blocklist, not allowlist)** with per-equity Chainlink 24/5 feeds — technically composable today, but excluded for US/UK/CA/CH/UAE persons and the issuer retains freeze/confiscate powers. Per-user strategies bound that blast radius to one user — a structural safety claim no pooled competitor on the chain can make.
- **Most of the port already exists** on the `feat/leveraged-aero-vanilla-vault` branch (`MamoMultiMarketStrategy` + `MarketRegistry`): Morpho-only is a *reduction* of that work, not new surgery.

## Ranked ideas (detail in `docs/ROBINHOOD_CHAIN_SPEC.md`)

1. **Mamo Baskets** — curated stock baskets + USDG yield sleeve (prototyped)
2. **USDG multi-vault chassis** — supply caps + multisig-scoped venues, the engine under everything (prototyped)
3. **Boosted USDG** — levered carry on Morpho Blue, the honest 7%-beater (2nd wave; reuses the LeveragedAeroVault lifecycle + fee/HWM library)
4. **MAMO flywheel** — compound fees → FeeSplitter → MultiRewards, plus staking-gated supply-cap capacity
5. Ranked out: stock LP (adverse selection), dividend harvesting (doesn't exist on-chain), covered calls, securities lending (all blocked)

## What's in the diff

| File | Purpose |
|---|---|
| `docs/ROBINHOOD_CHAIN_SPEC.md` | The spec: findings, ranked ideas, port plan, flywheel, verification checklist |
| `src/robinhood/MorphoVaultsStrategy.sol` | Per-user strategy across N allowlisted ERC-4626 vaults; Merkl claim; oracle-bounded compound |
| `src/robinhood/MamoVaultConfig.sol` | Multisig-owned venue allowlist + global supply cap with clamp-down principal accounting (the Boosted USDC governance asks, applied to the per-user model) |
| `src/robinhood/StockBasketStrategy.sol` | Basket + sleeve: drift-band rebalance, equity-mandate cap, sleeve-first withdrawals |
| `src/robinhood/interfaces/IUniswapV3SwapRouter.sol` | Fee-tier router interface (existing `ISwapRouter` is the Aerodrome tickSpacing variant) |
| `test/*.unit.t.sol` + `test/mocks/RobinhoodMocks.sol` | 40 mock-based unit tests incl. the `MockERC4626` the repo lacked |

## Verification

- `forge test --match-path "test/MorphoVaultsStrategy.unit.t.sol"` → **26/26 pass**
- `forge test --match-path "test/StockBasketStrategy.unit.t.sol"` → **14/14 pass**
- Full unit suite (`test/*.unit.t.sol`) → **91/91 pass** (no regressions)
- No fork/`--ffi` needed for any of the new tests

## Known gaps

- Market-hours/sequencer-uptime oracle guard is specified (spec §5) but not built — required before any stock-token product ships.
- `MamoVaultConfig` should be reconciled with the audit branch's `MarketRegistry` (one venue registry, not two) when this work rebases onto the multi-market branch.
- Mocks are 18-dp; USDG is 6-dp (accounting is decimals-agnostic; a 6-dp test matrix should be added).
- Chain facts are research-sourced; the spec's §6 checklist lists the on-chain reads (Vault V2 gates, USDG depth, feed directory) that gate further commitment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RS5Vj98v4NAsSrYgW5L7ud

---
_Generated by [Claude Code](https://claude.ai/code/session_01RS5Vj98v4NAsSrYgW5L7ud)_