### PR TITLE
feat: owner-staged venue migration for the leveraged aero fund

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,13 @@ weth-price-checker:
 strategy-factory:
 	export ASSET_CONFIG_PATH="./config/strategies/cbBTCStrategyConfig.json" && forge test --fork-url base --ffi --mc StrategyFactoryIntegrationTest
 
+# NO --fork-url here: MulticallIntegrationTest self-forks at a PINNED block via vm.createSelectFork in
+# setUp (with the vm.fee(0) op-revm Isthmus workaround). Passing --fork-url base in addition makes
+# foundry init the OP-stack L1Block handler against the CLI fork and panic before vm.fee(0) runs — the
+# same reason lp-auto-balancer-v2 / lp-v2-setup omit it. Pinning also removes the "could not calculate
+# block delta" flake the unpinned `latest` fork produced inside Moonwell's timestamp accrual.
 strategy-multicall:
-	export ASSET_CONFIG_PATH="./config/strategies/cbBTCStrategyConfig.json" && forge test --fork-url base --ffi --mc MulticallIntegrationTest
+	export ASSET_CONFIG_PATH="./config/strategies/cbBTCStrategyConfig.json" && forge test --ffi --mc MulticallIntegrationTest
 
 mamo-staking:
 	forge test --fork-url base --ffi --mc MamoStaking -vvv

--- a/docs/integrations/LEVERAGED_AERO_REBALANCER.md
+++ b/docs/integrations/LEVERAGED_AERO_REBALANCER.md
@@ -588,8 +588,8 @@ same vault, same share token, same user accounts, no user action. Three new stra
 |---|---|---|
 | `stageVenue(bytes32)` | **vault owner (multisig)** | Commit `keccak256(abi.encode(LeveragedAeroVenue.VenueParams))` for the destination venue; `0` clears. Inert until executed. |
 | `flatten(minRewardUsdcOut, minIdleUsdcOut)` | proposer | `settleImpl`'s exact unwind (exit gauge+CL, repay both legs, redeem all collateral, sweep legs → USDC) but **no settle**: state stays `Executed`, USDC stays in the strategy, deposits/redeems keep working (flat NAV = idle USDC, oracle-free). **Calm-gated** before the burn, and it **sells the reward tranche** the unwind auto-claims (L9 oracle floor + your `minRewardUsdcOut`) so the flat NAV is the whole book. `minIdleUsdcOut` is your aggregate floor on the realised unwind. Idempotent. |
-| `migrateVenue(VenueParams)` | proposer | Executes the staged rewrite. Requires byte-exact hash match AND a flat book (`tokenId == 0`, hedged bases 0, zero debt on both current leg markets). Re-runs full init-grade validation (incl. a `gauge.pool() == pool` binding check) and rewrites the venue subset of storage. Moves **no funds**. |
-| `redeploy()` | proposer | Re-opens a **fresh** position from the flat book — `executeImpl`'s genesis sequence, entire idle balance, stored width/target-LTV. `deployIdle` can NOT do this (it `increaseLiquidity`s the stored tokenId, 0 when flat); conversely `redeploy` reverts `PositionAlreadyOpen` on a live book. |
+| `migrateVenue(VenueParams)` | proposer | Executes the staged rewrite. Requires byte-exact hash match AND a flat book (`tokenId == 0`, hedged bases 0, zero debt on both current leg markets). Re-runs full init-grade validation (incl. the **two-way** gauge↔pool binding `gauge.pool() == pool` *and* `pool.gauge() == gauge`, and a probe that the reward token has an Aerodrome v2 volatile USDC route) and rewrites the venue subset of storage. Moves **no funds**. |
+| `redeploy(minLiquidity)` | proposer | Re-opens a **fresh** position from the flat book — `executeImpl`'s genesis sequence, entire idle balance, stored width/target-LTV, floored by your `minLiquidity`. **Clears any staged venue hash.** `deployIdle` can NOT do this (it `increaseLiquidity`s the stored tokenId, 0 when flat); conversely `redeploy` reverts `PositionAlreadyOpen` on a live book. |
 
 **Runbook (per migration):**
 
@@ -606,14 +606,26 @@ same vault, same share token, same user accounts, no user action. Three new stra
    expected realised unwind; pass a nonzero `minRewardUsdcOut` whenever a tranche is pending.
 3. Rebalancer: `migrateVenue(params)` — pure config rewrite; NAV is provably unchanged (flat NAV is
    the idle-USDC balance, which no venue field touches).
-4. Rebalancer: `redeploy()`; afterwards sweep old-leg unwind dust with `rescueToVault(oldLeg)`
-   (former legs leave the deny-list at the rewrite; the NEW legs enter it).
+4. Rebalancer: `redeploy(minLiquidity)`; afterwards sweep old-leg unwind dust with
+   `rescueToVault(oldLeg)` (former legs leave the deny-list at the rewrite; the NEW legs enter it).
 
 **Trust split:** the owner alone picks the venue (hash-committed, byte-exact); the proposer alone
 sequences execution and can neither deviate from the committed config nor move funds out of the
-contract at any step. **Rollback:** before step 3, `redeploy()` re-enters the *old* venue (nothing
-changed) and the owner can `stageVenue(0)`; a failed step 3 reverts atomically; after step 3, stage
-the old venue's params and repeat.
+contract at any step.
+
+**Residual owner trust (state it plainly).** The bound above is on the *proposer*, not on the owner.
+A compromised owner multisig can stage a venue whose contracts it controls, and `redeploy` then mints
+the position NFT into that venue's gauge. Validation narrows this but does not erase it: the gauge
+must be attested by the pool (`pool.gauge()`) as well as attesting the pool itself, so a hostile gauge
+alone no longer suffices — the attacker must control the *pool*, which in turn must satisfy the leg /
+market / spacing / feed-decimal / width / LTV checks and expose a working reward route. It is still a
+smaller step than `stageVenue`'s existing authority implies, and it is the same trust root that
+already governs `rescueToVault`'s owner leg and the vault's fee configuration. Treat owner-key
+compromise as fund-loss, not merely config-loss.
+
+**Rollback:** before step 3, `redeploy(minLiquidity)` re-enters the *old* venue (nothing changed) and
+**clears the staged hash as a side effect** — re-stage if the migration is still intended. A failed
+step 3 reverts atomically; after step 3, stage the old venue's params and repeat.
 
 **Pair constraints:** both legs need live borrowable Moonwell markets and Chainlink USD feeds on
 Base; asset-mode (leg-B slot == USDC) is selected emergently by the config exactly as at init.

--- a/docs/integrations/LEVERAGED_AERO_REBALANCER.md
+++ b/docs/integrations/LEVERAGED_AERO_REBALANCER.md
@@ -587,18 +587,23 @@ same vault, same share token, same user accounts, no user action. Three new stra
 | Call | Who | What |
 |---|---|---|
 | `stageVenue(bytes32)` | **vault owner (multisig)** | Commit `keccak256(abi.encode(LeveragedAeroVenue.VenueParams))` for the destination venue; `0` clears. Inert until executed. |
-| `flatten()` | proposer | `settleImpl`'s exact unwind (exit gauge+CL, repay both legs, redeem all collateral, sweep legs → USDC) but **no settle**: state stays `Executed`, USDC stays in the strategy, deposits/redeems keep working (flat NAV = idle USDC, oracle-free). Idempotent. |
+| `flatten(minRewardUsdcOut, minIdleUsdcOut)` | proposer | `settleImpl`'s exact unwind (exit gauge+CL, repay both legs, redeem all collateral, sweep legs → USDC) but **no settle**: state stays `Executed`, USDC stays in the strategy, deposits/redeems keep working (flat NAV = idle USDC, oracle-free). **Calm-gated** before the burn, and it **sells the reward tranche** the unwind auto-claims (L9 oracle floor + your `minRewardUsdcOut`) so the flat NAV is the whole book. `minIdleUsdcOut` is your aggregate floor on the realised unwind. Idempotent. |
 | `migrateVenue(VenueParams)` | proposer | Executes the staged rewrite. Requires byte-exact hash match AND a flat book (`tokenId == 0`, hedged bases 0, zero debt on both current leg markets). Re-runs full init-grade validation (incl. a `gauge.pool() == pool` binding check) and rewrites the venue subset of storage. Moves **no funds**. |
 | `redeploy()` | proposer | Re-opens a **fresh** position from the flat book — `executeImpl`'s genesis sequence, entire idle balance, stored width/target-LTV. `deployIdle` can NOT do this (it `increaseLiquidity`s the stored tokenId, 0 when flat); conversely `redeploy` reverts `PositionAlreadyOpen` on a live book. |
 
 **Runbook (per migration):**
 
 1. Owner multisig: `stageVenue(keccak256(abi.encode(params)))` — encode the exact `VenueParams`
-   struct (legs, markets, feeds, pool, gauge, spacings, width band, LTV params; the non-migratable
-   core — usdc/mUsdc/comptroller/npm/router/usdcFeed/sequencerFeed/aeroUsdFeed/oracle-calm
-   params/fees — is read from live storage and is NOT in the struct).
-2. Rebalancer: `flatten()` (oracle must be live — the leg sweeps are Chainlink-floored via
-   `maxSlippageBps`).
+   struct (legs, markets, leg feeds, **the reward feed `aeroUsdFeed`**, pool, gauge, spacings, width
+   band, LTV params; the non-migratable core — usdc/mUsdc/comptroller/npm/router/usdcFeed/
+   sequencerFeed/oracle-calm params/fees — is read from live storage and is NOT in the struct).
+   The reward feed travels WITH the gauge on purpose: the gauge determines `rewardToken()`, so
+   pinning its feed separately would let a migration price a new reward token at AERO's price and
+   mis-scale the L9 harvest floor.
+2. Rebalancer: `flatten(minRewardUsdcOut, minIdleUsdcOut)` (oracle must be live — the leg sweeps and
+   the reward sale are Chainlink-floored via `maxSlippageBps`, and the pool is calm-gated, so a
+   shoved tick reverts rather than unwinding at a manipulated price). Size `minIdleUsdcOut` off the
+   expected realised unwind; pass a nonzero `minRewardUsdcOut` whenever a tranche is pending.
 3. Rebalancer: `migrateVenue(params)` — pure config rewrite; NAV is provably unchanged (flat NAV is
    the idle-USDC balance, which no venue field touches).
 4. Rebalancer: `redeploy()`; afterwards sweep old-leg unwind dust with `rescueToVault(oldLeg)`

--- a/docs/integrations/LEVERAGED_AERO_REBALANCER.md
+++ b/docs/integrations/LEVERAGED_AERO_REBALANCER.md
@@ -578,6 +578,43 @@ the clone rather than assuming the launch pair:
 
 ---
 
+## G2. Venue migration — owner-staged pool/pair change
+
+The fund can move to a **different Slipstream pool — including a different token pair — in place**:
+same vault, same share token, same user accounts, no user action. Three new strategy entry points
+(impls in `LeveragedAeroVenue.sol`, the third delegatecall library):
+
+| Call | Who | What |
+|---|---|---|
+| `stageVenue(bytes32)` | **vault owner (multisig)** | Commit `keccak256(abi.encode(LeveragedAeroVenue.VenueParams))` for the destination venue; `0` clears. Inert until executed. |
+| `flatten()` | proposer | `settleImpl`'s exact unwind (exit gauge+CL, repay both legs, redeem all collateral, sweep legs → USDC) but **no settle**: state stays `Executed`, USDC stays in the strategy, deposits/redeems keep working (flat NAV = idle USDC, oracle-free). Idempotent. |
+| `migrateVenue(VenueParams)` | proposer | Executes the staged rewrite. Requires byte-exact hash match AND a flat book (`tokenId == 0`, hedged bases 0, zero debt on both current leg markets). Re-runs full init-grade validation (incl. a `gauge.pool() == pool` binding check) and rewrites the venue subset of storage. Moves **no funds**. |
+| `redeploy()` | proposer | Re-opens a **fresh** position from the flat book — `executeImpl`'s genesis sequence, entire idle balance, stored width/target-LTV. `deployIdle` can NOT do this (it `increaseLiquidity`s the stored tokenId, 0 when flat); conversely `redeploy` reverts `PositionAlreadyOpen` on a live book. |
+
+**Runbook (per migration):**
+
+1. Owner multisig: `stageVenue(keccak256(abi.encode(params)))` — encode the exact `VenueParams`
+   struct (legs, markets, feeds, pool, gauge, spacings, width band, LTV params; the non-migratable
+   core — usdc/mUsdc/comptroller/npm/router/usdcFeed/sequencerFeed/aeroUsdFeed/oracle-calm
+   params/fees — is read from live storage and is NOT in the struct).
+2. Rebalancer: `flatten()` (oracle must be live — the leg sweeps are Chainlink-floored via
+   `maxSlippageBps`).
+3. Rebalancer: `migrateVenue(params)` — pure config rewrite; NAV is provably unchanged (flat NAV is
+   the idle-USDC balance, which no venue field touches).
+4. Rebalancer: `redeploy()`; afterwards sweep old-leg unwind dust with `rescueToVault(oldLeg)`
+   (former legs leave the deny-list at the rewrite; the NEW legs enter it).
+
+**Trust split:** the owner alone picks the venue (hash-committed, byte-exact); the proposer alone
+sequences execution and can neither deviate from the committed config nor move funds out of the
+contract at any step. **Rollback:** before step 3, `redeploy()` re-enters the *old* venue (nothing
+changed) and the owner can `stageVenue(0)`; a failed step 3 reverts atomically; after step 3, stage
+the old venue's params and repeat.
+
+**Pair constraints:** both legs need live borrowable Moonwell markets and Chainlink USD feeds on
+Base; asset-mode (leg-B slot == USDC) is selected emergently by the config exactly as at init.
+Pending withdraw-queue requests survive the whole sequence (share-denominated, fulfillable against
+post-migration NAV).
+
 ## H. Testing rebalance operations on the vnet
 
 Rebalance operations **are** testable on the Tenderly vnet — the fork is not frozen in the way it first

--- a/script/tenderly/run-leveraged-aero-stack.sh
+++ b/script/tenderly/run-leveraged-aero-stack.sh
@@ -173,7 +173,7 @@ SEED="${SEED:-100000000000}"          # 100,000 USDC (6dp). A seed is MANDATORY:
                                       # ExecuteZeroBalance inside execute(), not in the vault.
 ETH_FUND_HEX=0x56BC75E2D63100000      # 100 ETH
 # Base per-tx gas cap is 16,777,216 (2^24): estimate x multiplier must stay under it. The
-# template CREATE (+ its 3 delegatecall libraries) is the big one — 200% clears it. The two
+# template CREATE (+ its 4 delegatecall libraries) is the big one — 200% clears it. The two
 # heavy sends get EXPLICIT limits instead of trusting the vnet's estimate, which
 # under-reports deep nested delegatecalls (the LPV2 harness hit an OOG at forge's 1.3x).
 DEPLOY_GAS_MULT=200

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -1212,7 +1212,14 @@ library LeveragedAeroManager {
             uint256 cbBal2 = IERC20($.cbBTC).balanceOf(address(this));
             if (cbBal2 > 0) {
                 IERC20($.cbBTC).forceApprove($.mCbBTC, cbBal2);
-                _repay($.mCbBTC, type(uint256).max);
+                // SAME SHAPE `_settleRepayDebts` closes above: `max` pulls the FULL accrued debt
+                // while the approve is sized off the BALANCE, and the funding swap only guarantees
+                // `debtRem * (1 - maxSlippageBps)` — so a min-fill leaves balance < debt and reverts
+                // the whole unwind (and therefore `flatten`, and therefore `migrateVenue`). Repay the
+                // balance in that case. No fresh market read is needed: `_settleRepayDebts` ran
+                // `borrowBalanceCurrent` on this market in this tx and no time has passed since, so
+                // `cbDebtRem` IS the accrued debt.
+                _repay($.mCbBTC, cbBal2 >= cbDebtRem ? type(uint256).max : cbBal2);
             }
         }
         // Cover WETH shortfall (bounded by its own oracle budget, not the full idle balance — M1;
@@ -1222,7 +1229,7 @@ library LeveragedAeroManager {
             uint256 wBal2 = IERC20($.weth).balanceOf(address(this));
             if (wBal2 > 0) {
                 IERC20($.weth).forceApprove($.mWeth, wBal2);
-                _repay($.mWeth, type(uint256).max);
+                _repay($.mWeth, wBal2 >= wethDebtRem ? type(uint256).max : wBal2); // see the cbBTC leg
             }
         }
     }

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -172,7 +172,7 @@ library LeveragedAeroManager {
         // ── appended for the config-emergent pool shape (keep byte-identical) ──
         bool legBIsAsset; // DERIVED at init: leg-B slot == usdc → asset-as-a-leg shape (packs above)
         // ── appended for the borrow-interest hedge (keep byte-identical) ──
-        uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with the widths above)
+        uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with hedgedDebtB below)
         uint128 hedgedDebtB; // leg-B borrowed principal the LP hedges (0 in asset-mode: leg B never borrows)
         // ── LAST field: appended for the owner-staged venue migration (keep byte-identical) ──
         bytes32 stagedVenueHash; // keccak256(abi.encode(VenueParams)) staged by the vault owner; 0 == none
@@ -213,7 +213,16 @@ library LeveragedAeroManager {
     ///      library already at the EIP-170 margin, for no behavioural change. Asset-mode is the case that
     ///      LOOKS worst — `assetModeSplit` reads the live `sqrtP` for its sizing before any gate — but
     ///      the mint that consumes that sizing is gated, so a shoved tick still unwinds the whole op.
-    function executeImpl() public {
+    ///
+    /// @param minLiquidity Caller's floor on the CL liquidity the genesis mint must produce, on top of
+    ///                     the §8 two-sided `maxSlippageBps` mins the mint already enforces. Activation
+    ///                     (`execute`) passes 0 — it runs ONCE, owner-driven, on a book that holds only
+    ///                     the seed, and there is no prior state for a bad fill to dilute. `redeploy`
+    ///                     passes the proposer's own value: it re-enters the WHOLE book, repeatedly,
+    ///                     against live depositors, and the in-mint mins are derived from the same
+    ///                     `slot0()` the mint executes at — self-referential, exactly the criticism
+    ///                     `flattenImpl` levels at `settleImpl`'s unwind mins.
+    function executeImpl(uint256 minLiquidity) public {
         Layout storage $ = _layout();
         uint256 usdcAmt = IERC20($.usdc).balanceOf(address(this));
         if (usdcAmt == 0) revert ExecuteZeroBalance();
@@ -224,7 +233,7 @@ library LeveragedAeroManager {
         (int24 tickLower, int24 tickUpper) = LeveragedAeroValuation.centeredTickRange($.pool, $.tickSpacing, $.width);
         (uint256 cbBTCAmt, uint256 wethAmt) = _supplyAndBorrow(usdcAmt, tickLower, tickUpper);
         _wrapNativeEth();
-        _mintAndStake(cbBTCAmt, wethAmt, tickLower, tickUpper);
+        _mintAndStake(cbBTCAmt, wethAmt, tickLower, tickUpper, minLiquidity);
         _assertHealthy();
     }
 
@@ -457,6 +466,11 @@ library LeveragedAeroManager {
         //    fair6 = aeroBal(18dp) × price(8dp) / 1e20 → USDC 6dp; floor haircuts by maxSlippageBps.
         uint256 floor =
             Math.mulDiv(aeroBal, _readUsd8($.aeroUsdFeed), 1e20) * (10000 - uint256($.maxSlippageBps)) / 10000;
+        //    DUST NO-OP, same branch (and same rationale) as `LeveragedAeroVenue._sellRewardBalance`: a
+        //    balance worth under one micro-USD floors to 0 and the router fills it at 0, so the nonzero
+        //    `minUsdcOut` this function already demands would revert every call. Without it a donation
+        //    of reward-token dust to a gauge with no live emissions bricks `compound` outright.
+        if (floor == 0) return 0;
 
         // 3. Swap ALL claimed AERO → USDC via the Aerodrome v2 volatile pool, passing the caller's
         //    minUsdcOut to the router. The measured-fill floor below is the robust guard (router-honesty
@@ -570,7 +584,7 @@ library LeveragedAeroManager {
         //    compound's `minUsdcOut`).
         (uint256 amt0, uint256 amt1) =
             _amounts01(IERC20($.cbBTC).balanceOf(address(this)), IERC20($.weth).balanceOf(address(this)));
-        (uint256 newTokenId, uint256 used0, uint256 used1) = _mintPosition(amt0, amt1, tickLower, tickUpper);
+        (uint256 newTokenId,, uint256 used0, uint256 used1) = _mintPosition(amt0, amt1, tickLower, tickUpper);
         if (used0 < minLiq0 || used1 < minLiq1) revert InsufficientLiquidity();
 
         // 5. Restake the new NFT to resume AERO gauge rewards (mirrors _mintAndStake).
@@ -666,7 +680,20 @@ library LeveragedAeroManager {
         // untouched, so health = c / d ⇒ targetDebt = c × 1e4 / targetHealth).
         uint256 targetHealth = (minHealth * (10000 + uint256(DELEVERAGE_BUFFER_BPS))) / 10000;
         uint256 targetDebt = (collateralBefore * 10000) / targetHealth;
-        if (debtBefore > targetDebt) _leverDown(debtBefore - targetDebt, debtBefore, minOut);
+        if (debtBefore > targetDebt) {
+            // CLAMP, don't inherit the full-unwind rejection. In the collateral≈0 tail `targetDebt`
+            // floors to 0, so the requested repay equals the whole debt and `_leverDown`'s
+            // orphaned-NFT guard (`repayUsd >= debtUsd`) reverts `FullUnwindNotSupported` — turning the
+            // PERMISSIONLESS health valve off in exactly the state it exists for. Leaving one unit of
+            // debt keeps `num < den`, so `mulDiv` leaves ≥1 liquidity and the re-stake fires, and the
+            // position NFT cannot be orphaned. The recovery gate below still has to pass, so this
+            // widens what deleverage can attempt, never what it can leave behind. The guard itself is
+            // untouched for `adjustLeverage`, where a full-unwind request is a caller error and
+            // `flatten()` is the correct op.
+            uint256 repayUsd = debtBefore - targetDebt;
+            if (repayUsd >= debtBefore) repayUsd = debtBefore - 1;
+            _leverDown(repayUsd, debtBefore, minOut);
+        }
 
         // Recovery gate: health strictly improved AND the Moonwell shortfall cleared or reduced.
         (uint256 collateralAfter, uint256 debtAfter) = _readCollateralDebt();
@@ -757,8 +784,10 @@ library LeveragedAeroManager {
         // `tokenId`, `rerangeImpl` replaces it with a fresh mint); `_leverDown` does neither, so it
         // would leave a live `$.tokenId` pointing at an NFT the gauge no longer holds. Every later
         // venue op opens with `ICLGauge.withdraw($.tokenId)` — settle, flatten, rerange, deployIdle,
-        // compound, migrateVenue, redeploy and BOTH async-redeem exits — so the book would be
-        // permanently bricked, including the trustless `emergencyRedeem` deadman.
+        // compound and BOTH async-redeem exits — so the book would be permanently bricked, including
+        // the trustless `emergencyRedeem` deadman. (`migrateVenue` and `redeploy` are NOT in that list:
+        // both require a flat book and never touch the gauge with a live `tokenId`. They are bricked
+        // transitively — reaching them requires `flatten`, which is in the list.)
         //
         // Rejecting is the fix rather than retiring the position (`$.tokenId = 0`): the collateral is
         // still supplied at this point, and `nav()`'s `tokenId == 0` branch prices ONLY idle USDC, so
@@ -1014,7 +1043,7 @@ library LeveragedAeroManager {
     ///      `rerange` layers an additional caller-supplied two-sided guard on `used0`/`used1`.
     function _mintPosition(uint256 amt0, uint256 amt1, int24 tickLower, int24 tickUpper)
         private
-        returns (uint256 tokenId_, uint256 used0, uint256 used1)
+        returns (uint256 tokenId_, uint128 liq, uint256 used0, uint256 used1)
     {
         Layout storage $ = _layout();
         address npm_ = $.npm;
@@ -1042,17 +1071,21 @@ library LeveragedAeroManager {
             deadline: block.timestamp + 600,
             sqrtPriceX96: 0
         });
-        (tokenId_,, used0, used1) = INonfungiblePositionManager(npm_).mint(mp);
+        (tokenId_, liq, used0, used1) = INonfungiblePositionManager(npm_).mint(mp);
         if (tokenId_ == 0) revert NpmMintFailed();
     }
 
     /// @dev Mint the CL position, stake in gauge, and persist state. The range is supplied by the caller
     ///      (`executeImpl`), which calm-gates and derives it once — so the asset-mode sizing and this
     ///      mint provably target the SAME range rather than re-deriving it.
-    function _mintAndStake(uint256 cbBTCAmt, uint256 wethAmt, int24 tickLower, int24 tickUpper) private {
+    function _mintAndStake(uint256 cbBTCAmt, uint256 wethAmt, int24 tickLower, int24 tickUpper, uint256 minLiquidity)
+        private
+    {
         Layout storage $ = _layout();
         (uint256 amt0, uint256 amt1) = _amounts01(cbBTCAmt, wethAmt);
-        (uint256 tokenId_,,) = _mintPosition(amt0, amt1, tickLower, tickUpper);
+        (uint256 tokenId_, uint128 liq,,) = _mintPosition(amt0, amt1, tickLower, tickUpper);
+        // Caller's floor on the minted liquidity, mirroring `_addLiquidity`'s guard on the add path.
+        if (uint256(liq) < minLiquidity) revert InsufficientLiquidity();
         _approveAndStake($.gauge, tokenId_);
         // Persist position state (so nav()/positions() see the live position)
         $.tokenId = tokenId_;
@@ -1127,8 +1160,16 @@ library LeveragedAeroManager {
         address mWeth_ = $.mWeth;
         address cbBTC_ = $.cbBTC;
         address weth_ = $.weth;
-        uint256 cbDebt = IMoonwellMarket(mCbBTC_).borrowBalanceStored(address(this));
-        uint256 wethDebt = IMoonwellMarket(mWeth_).borrowBalanceStored(address(this));
+        // ACCRUE, *THEN* MEASURE. These two reads decide `full repay` vs `partial repay`, and the repay
+        // they gate pulls the ACCRUED debt while the approval above it is sized off the token BALANCE.
+        // With the stored index, a book whose balance covers the stale debt but not the accrued debt
+        // takes the `type(uint256).max` branch and Moonwell then tries to pull more than was approved —
+        // the whole unwind reverts. That was tolerable while this ran only inside the terminal,
+        // owner-driven `settle()`; `flatten` made it a routine proposer op AND the precondition for
+        // `migrateVenue`, so a stale read here can block a migration. `borrowBalanceCurrent` is
+        // non-view (it advances the market's index) and returns the balance, not an error code.
+        uint256 cbDebt = IMoonwellMarket(mCbBTC_).borrowBalanceCurrent(address(this));
+        uint256 wethDebt = IMoonwellMarket(mWeth_).borrowBalanceCurrent(address(this));
         // Repay cbBTC
         uint256 cbBal = IERC20(cbBTC_).balanceOf(address(this));
         if (cbBal > 0 && cbDebt > 0) {

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -84,6 +84,9 @@ library LeveragedAeroManager {
     error BelowOracleFloor(); // compound swap fill < AERO/USD oracle floor (L9)
     error FastRedeemExceedsLtv(uint256 ltvBps, uint256 maxLtvBps); // fast-path redeem would breach maxLtvBps
     error UnsupportedLeg(); // a swap was routed for a token that is neither configured leg
+    // A lever-down would repay the ENTIRE debt, which removes 100% of the liquidity and orphans the
+    // staked position NFT (see the guard in `_leverDown`). Route full unwinds through `flatten()`.
+    error FullUnwindNotSupported();
     // NOTE: `InsufficientIdleForLeverUp` (asset-mode lever-up, see `_leverUp`) is NOT declared here — it
     // is raised by `LeveragedAeroValuation.assetModeLeverUpPair`, alongside the arithmetic that sizes the
     // draw, exactly as `DegenerateRange` is. Same convention: valuation-raised errors are not mirrored.
@@ -746,6 +749,22 @@ library LeveragedAeroManager {
     ///      Balanced legs (the common case) leave no residual → no swap → `minOut` unused.
     function _leverDown(uint256 repayUsd, uint256 debtUsd, uint256 minOut) private {
         Layout storage $ = _layout();
+        // FULL-UNWIND GUARD (load-bearing, do not relax to a clamp).
+        //
+        // `repayUsd == debtUsd` drives `_unwindLiquidity` down its `num == den` branch, which removes
+        // 100% of the liquidity and — because nothing remains to earn — SKIPS the re-stake. The two
+        // callers that legitimately take that branch dispose of the position first (`settleImpl` zeroes
+        // `tokenId`, `rerangeImpl` replaces it with a fresh mint); `_leverDown` does neither, so it
+        // would leave a live `$.tokenId` pointing at an NFT the gauge no longer holds. Every later
+        // venue op opens with `ICLGauge.withdraw($.tokenId)` — settle, flatten, rerange, deployIdle,
+        // compound, migrateVenue, redeploy and BOTH async-redeem exits — so the book would be
+        // permanently bricked, including the trustless `emergencyRedeem` deadman.
+        //
+        // Rejecting is the fix rather than retiring the position (`$.tokenId = 0`): the collateral is
+        // still supplied at this point, and `nav()`'s `tokenId == 0` branch prices ONLY idle USDC, so
+        // clearing the id would erase the mUSDC collateral from NAV. A genuine full unwind must redeem
+        // the collateral too — that is `flatten()`, which reaches a flat book the NAV branch can price.
+        if (repayUsd >= debtUsd) revert FullUnwindNotSupported();
         _unwindLiquidity(repayUsd, debtUsd);
         (uint256 cbShort, uint256 wethShort) = _redeemRepayFromCollected(repayUsd, debtUsd, 0, 0);
         // Two independent `if`s (NOT else-if): a dual-leg IL shortfall covers BOTH legs (L6), mirroring

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -168,9 +168,11 @@ library LeveragedAeroManager {
         uint24 maxWidth; // upper bound for a proposer-supplied rerange width
         // ── appended for the config-emergent pool shape (keep byte-identical) ──
         bool legBIsAsset; // DERIVED at init: leg-B slot == usdc → asset-as-a-leg shape (packs above)
-        // ── LAST fields: appended for the borrow-interest hedge (keep byte-identical) ──
+        // ── appended for the borrow-interest hedge (keep byte-identical) ──
         uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with the widths above)
         uint128 hedgedDebtB; // leg-B borrowed principal the LP hedges (0 in asset-mode: leg B never borrows)
+        // ── LAST field: appended for the owner-staged venue migration (keep byte-identical) ──
+        bytes32 stagedVenueHash; // keccak256(abi.encode(VenueParams)) staged by the vault owner; 0 == none
     }
 
     /// @dev keccak256(abi.encode(uint256(keccak256("leveraged.aero.cl.storage")) - 1)) & ~bytes32(uint256(0xff))

--- a/src/leveraged-aero/LeveragedAeroValuation.sol
+++ b/src/leveraged-aero/LeveragedAeroValuation.sol
@@ -32,6 +32,14 @@ interface IAeroRouter {
     ) external returns (uint256[] memory amounts);
 }
 
+/// @dev Aerodrome v2 (AMM) PoolFactory — the registry the Route above names, used to PROVE a
+///      reward→USDC route exists before a venue is adopted. Note the arity difference from
+///      Slipstream's `ICLFactory.getPool(address,address,int24)`: v2 pools are keyed by a
+///      stable/volatile flag, not a tick spacing.
+interface IAeroV2Factory {
+    function getPool(address tokenA, address tokenB, bool stable) external view returns (address pool);
+}
+
 /// @title  LeveragedAeroValuation
 /// @notice Net-equity **oracle** NAV for the leveraged Aerodrome CL strategy. This is
 ///         the single safety-critical computation — it prices DEPOSITS, so a wrong
@@ -545,6 +553,18 @@ library LeveragedAeroValuation {
     address private constant AERO_V2_ROUTER = 0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43;
     /// @dev Aerodrome v2 PoolFactory on Base (`router.defaultFactory()`), required by the Route.
     address private constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
+
+    /// @notice The Aerodrome v2 VOLATILE pool `swapAeroToUsdc` would route `reward → usdc` through,
+    ///         or `address(0)` when no such pool is registered.
+    /// @dev Exists so venue validation can probe the reward leg the same way it probes the two
+    ///      leg↔USDC CL swap pools. The route below is byte-for-byte the one `swapAeroToUsdc`
+    ///      constructs (same factory, `stable == false`), so a nonzero answer here is exactly the
+    ///      condition under which that swap can resolve a pool at all. Reads the factory rather than
+    ///      the router's `poolFor` helper: the helper is a deterministic CREATE2 predictor and
+    ///      returns a nonzero address for pairs that were never deployed.
+    function aeroV2VolatilePool(address tokenA, address tokenB) public view returns (address) {
+        return IAeroV2Factory(AERO_V2_FACTORY).getPool(tokenA, tokenB, false);
+    }
 
     /// @notice Swap `amountIn` AERO to USDC through the Aerodrome v2 volatile pool and report the
     ///         MEASURED fill (balance delta, not the router's own return value).

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {LeveragedAeroManager} from "./LeveragedAeroManager.sol";
+import {IMoonwellMarket} from "./sherwood/interfaces/IMoonwellMarket.sol";
+import {ICLFactory, ICLGauge, ICLPool} from "./sherwood/interfaces/ISlipstream.sol";
+import {TickMath} from "./sherwood/libraries/TickMath.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+/// @title LeveragedAeroVenue
+/// @notice Venue-migration companion to `LeveragedAerodromeCLStrategy` (delegatecalled, like
+///         `LeveragedAeroManager`): the venue-validation block shared by `_initialize` and the
+///         owner-staged venue migration, plus the three migration ops — `stageImpl` (owner commits a
+///         hash of the destination venue), `flattenImpl` (proposer unwinds the whole book to idle
+///         USDC without settling), and `migrateImpl` (proposer executes the staged venue rewrite on a
+///         flat book).
+///
+///         WHY A THIRD LIBRARY: the strategy and the manager both sit within ~350 bytes of the
+///         EIP-170 cap, so neither can host new logic. Extracting the init venue block here is what
+///         frees the strategy bytes the three new entry-point stubs cost.
+///
+///         TRUST SPLIT (see the strategy's `stageVenue`/`migrateVenue` docs): the VAULT OWNER alone
+///         picks the destination venue (hash-committed, byte-exact); the PROPOSER alone sequences
+///         execution. `applyVenue` re-runs every init-grade venue check against live storage, so a
+///         staged config that no longer validates (market delisted, feed swapped) reverts rather
+///         than migrating into a broken venue.
+///
+/// @dev CORRUPTION-CRITICAL slot discipline: `Layout`, `RedeemRequest`, `STORAGE_SLOT` and
+///      `_layout()` are byte-identical to the strategy's and the manager's copies — see the
+///      CORRUPTION-CRITICAL note in `LeveragedAerodromeCLStrategy` and `layout_parity.sh`. Do not
+///      touch any of the three copies without the others.
+library LeveragedAeroVenue {
+    // ── Errors (shared selectors with the strategy / BaseStrategy where names collide) ──
+    error ZeroAddress();
+    error VenueMismatch(); // pool/gauge/market wiring does not match the declared legs or tickSpacing
+    error UnsupportedLeg(); // leg A is the unit of account, or a leg is the gauge reward token
+    error UnexpectedFeedDecimals();
+    error LegDecimalsOutOfRange(); // a leg token reports decimals outside [2, 18]
+    error WidthOutOfBounds();
+    error TargetLtvExceedsMax();
+    error MinHealthTooLow(); // minHealthBps < 10500 (1.05x floor)
+    error MaxLtvExceedsCF(); // maxLtvBps >= Moonwell USDC collateral factor
+    error MinHealthMaxLtvConflict();
+    error ComptrollerCallFailed();
+    error VenueNotStaged(); // migrate without a staged hash, or params that do not match it
+    error BookNotFlat(); // migrate while a CL position, hedged basis, or leg debt is still live
+    error PositionAlreadyOpen(); // redeploy on a book that already has a CL position (use deployIdle)
+
+    // ── Events (emitted from the strategy's address via delegatecall) ──
+    /// @notice A destination venue hash was staged (or cleared, when `venueHash == 0`) by the vault owner.
+    event VenueStaged(bytes32 venueHash);
+    /// @notice The whole book was unwound to idle USDC without settling (strategy stays Executed).
+    event Flattened(uint256 idleUsdc);
+    /// @notice The staged venue rewrite executed on a flat book.
+    event VenueMigrated(address indexed oldPool, address indexed newPool);
+
+    /// @notice The venue subset of the strategy's config — everything a pool/pair change touches.
+    ///         Field semantics are LEG SLOTS exactly as in `InitParams` (names historical): `weth*`
+    ///         is leg A (the natively-wrappable, always-borrowed slot), `cbBTC*` is leg B (the slot
+    ///         that may be the unit of account — that IS asset-mode). The non-migratable core (usdc,
+    ///         mUsdc, comptroller, npm, swapRouter, usdcFeed, sequencerFeed, aeroUsdFeed, oracle/calm
+    ///         params, maxSlippageBps, fee params) is read from live storage, never from here.
+    struct VenueParams {
+        address mCbBTC; // Moonwell market for leg B (must be mUsdc in asset-mode)
+        address mWeth; // Moonwell market for leg A
+        address cbBTC; // leg B underlying (== usdc selects asset-mode)
+        address weth; // leg A underlying
+        address pool; // Aerodrome Slipstream CL pool for the leg A/B pair
+        address gauge; // Gauge for the pool (AERO rewards); must report `pool()` == pool
+        address cbBTCFeed; // leg B/USD aggregator (must be the USDC/USD feed in asset-mode)
+        address wethFeed; // leg A/USD aggregator
+        int24 tickSpacing; // LP pool tickSpacing (asserted against `pool.tickSpacing()`)
+        int24 cbBTCSwapTickSpacing; // leg B↔USDC swap-pool tickSpacing (0 in asset-mode)
+        int24 wethSwapTickSpacing; // leg A↔USDC swap-pool tickSpacing
+        bool wethDeliversNative; // leg A's Moonwell market pays native ETH on borrow
+        uint24 width; // full range width in ticks for the next deploy
+        uint24 minWidth; // lower bound for a proposer-supplied rerange width
+        uint24 maxWidth; // upper bound for a proposer-supplied rerange width
+        uint16 targetLtvBps; // standing target LTV against the new markets
+        uint16 maxLtvBps; // LTV cap against the new markets
+        uint16 minHealthBps; // health floor against the new markets
+    }
+
+    // ── Diamond storage — Layout/STORAGE_SLOT/_layout()/RedeemRequest byte-identical to
+    //    `LeveragedAerodromeCLStrategy` and `LeveragedAeroManager` (see the CORRUPTION-CRITICAL
+    //    note there and layout_parity.sh). ──
+
+    /// @dev Byte-identical to the strategy's / manager's `RedeemRequest`.
+    struct RedeemRequest {
+        address owner; // request creator; the only address that can cancel / emergency-redeem it
+        uint256 shares; // vault shares escrowed in the strategy at request time
+        uint256 minAssetsOut; // slippage floor enforced at fulfill (fresh arg at emergencyRedeem)
+        uint40 requestedAt; // request timestamp; FULFILL_WINDOW deadman clock anchor
+        bool settled; // set once fulfilled / cancelled / emergency-redeemed (double-spend guard)
+    }
+
+    /// @custom:storage-location erc7201:leveraged.aero.cl.storage
+    struct Layout {
+        // valuation config: token / venue / feed addresses
+        address usdc;
+        address mUsdc;
+        address mCbBTC; // LeveragedAeroValuation.Config.cbBTCMarket
+        address mWeth; // LeveragedAeroValuation.Config.wethMarket
+        address cbBTC;
+        address weth;
+        address pool;
+        address cbBTCFeed;
+        address wethFeed;
+        address usdcFeed;
+        address sequencerFeed;
+        uint256 maxDelay;
+        uint256 gracePeriod;
+        uint16 calmDeviationTicks;
+        uint32 twapWindow;
+        // venue / protocol addresses (not in Config)
+        address comptroller;
+        address npm;
+        address gauge;
+        address swapRouter;
+        int24 tickSpacing;
+        // risk params
+        uint16 targetLtvBps;
+        uint16 maxLtvBps;
+        uint16 minHealthBps;
+        uint16 maxSlippageBps;
+        uint16 usdcCollateralFactorBps; // USDC collateral factor from Moonwell at init (8800 = 88%)
+        // position state (all zero pre-deploy / post-settle)
+        uint256 tokenId; // active CL position; 0 == flat book
+        int24 posTickLower;
+        int24 posTickUpper;
+        // fee params + state
+        uint16 managementFeeBps;
+        uint16 performanceFeeBps;
+        address feeRecipient;
+        uint256 hwmPerShare; // HWM nav-per-share (1e18 WAD), 0 until first deposit
+        uint256 lastFeeAccrualTimestamp;
+        uint256 protocolFeeOwed; // accrued protocol-fee USDC liability (6dp); discharged in redeem/compound/settle
+        // ── appended for the L9 compound oracle floor (keep byte-identical in the strategy/manager) ──
+        address aeroUsdFeed; // AERO/USD aggregator (8dp) — floors compound()'s AERO→USDC swap
+        // ── appended for the escrowed async-redeem queue (keep byte-identical) ──
+        uint256 nextRedeemRequestId; // monotonic id cursor for `redeemRequests`
+        mapping(uint256 => RedeemRequest) redeemRequests; // id → escrowed async redeem
+        // ── appended for any-pool generalization (keep byte-identical) ──
+        uint8 cbBTCDecimals; // leg B decimals, read from the token at init
+        uint8 wethDecimals; // leg A decimals, read from the token at init
+        bool wethIsToken0; // leg A sorts as the pool's token0 (derived from pool.token0() at init)
+        bool wethDeliversNative; // leg A's Moonwell market pays native ETH on borrow → wrap it
+        int24 cbBTCSwapTickSpacing; // leg B↔USDC swap-pool tickSpacing (NOT the LP pool's)
+        int24 wethSwapTickSpacing; // leg A↔USDC swap-pool tickSpacing (NOT the LP pool's)
+        // ── appended for the per-cycle rerange width band (keep byte-identical) ──
+        uint24 width; // current full range width in ticks (rerange spans width/2 each side)
+        uint24 minWidth; // lower bound for a proposer-supplied rerange width
+        uint24 maxWidth; // upper bound for a proposer-supplied rerange width
+        // ── appended for the config-emergent pool shape (keep byte-identical) ──
+        bool legBIsAsset; // DERIVED at init: leg-B slot == usdc → asset-as-a-leg shape (packs above)
+        // ── appended for the borrow-interest hedge (keep byte-identical) ──
+        uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with the widths above)
+        uint128 hedgedDebtB; // leg-B borrowed principal the LP hedges (0 in asset-mode: leg B never borrows)
+        // ── LAST field: appended for the owner-staged venue migration (keep byte-identical) ──
+        bytes32 stagedVenueHash; // keccak256(abi.encode(VenueParams)) staged by the vault owner; 0 == none
+    }
+
+    /// @dev keccak256(abi.encode(uint256(keccak256("leveraged.aero.cl.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant STORAGE_SLOT = 0x405ae0b144079093e970849fdffdcb2a514e44968598c6c5c73444496e844900;
+
+    /// @dev ERC-7201 diamond-storage accessor (byte-identical across strategy + manager).
+    function _layout() private pure returns (Layout storage $) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            $.slot := STORAGE_SLOT
+        }
+    }
+
+    // ── Migration ops (auth + state gates live in the strategy's entry points) ──
+
+    /// @notice Stage `venueHash` as the committed destination venue (0 clears). Auth (vault owner)
+    ///         is enforced by the strategy's `stageVenue`; staging is inert — no live venue state,
+    ///         position, or share pricing changes until `migrateImpl` consumes it.
+    function stageImpl(bytes32 venueHash) public {
+        _layout().stagedVenueHash = venueHash;
+        emit VenueStaged(venueHash);
+    }
+
+    /// @notice Unwind the WHOLE book to idle USDC without settling: exit gauge + CL position, repay
+    ///         both leg debts (self-funding any shortfall), redeem all mUSDC collateral, sweep
+    ///         residual legs to USDC — `LeveragedAeroManager.settleImpl`'s exact unwind — then zero
+    ///         the hedged-principal bases the way `_settle` does. UNLIKE `_settle`: no protocol-fee
+    ///         discharge (the liability persists, `nav()` stays net of it), no push-to-vault, and no
+    ///         state transition — the strategy stays `Executed`, so deposits/redeems keep working
+    ///         against the flat book (NAV == idle USDC, no oracle).
+    /// @dev Slippage on the unwind swaps is Chainlink-floored inside `settleImpl` via
+    ///      `maxSlippageBps` (same guard as a real settle); a down oracle fail-closes the flatten.
+    ///      Idempotent on an already-flat book (the unwind and repays are no-ops).
+    function flattenImpl() public {
+        LeveragedAeroManager.settleImpl();
+        Layout storage $ = _layout();
+        // Same pathological-case belt as `_settle`: repays drive the bases to 0 through `_repay`'s
+        // clamp except when residual debt could not be covered at all — zero them explicitly so a
+        // flat book never carries a stale hedge basis into the next venue.
+        $.hedgedDebtA = 0;
+        $.hedgedDebtB = 0;
+        emit Flattened(IERC20($.usdc).balanceOf(address(this)));
+    }
+
+    /// @notice Execute the staged venue rewrite: verify `p` byte-matches the owner-staged hash,
+    ///         verify the book is FLAT (no CL position, no hedged basis, no live debt on either
+    ///         current leg market), re-run the full init-grade venue validation against `p`, rewrite
+    ///         the venue subset of storage, and consume the staged hash. Value-neutral by
+    ///         construction: on a flat book NAV is the idle USDC balance, which no venue field
+    ///         touches — share pricing is continuous across the rewrite.
+    /// @dev The flat-book gate reads only strategy-internal state and the two CURRENT leg markets'
+    ///      `borrowBalanceStored` (exact after a full repay: zero principal reads zero at any index).
+    ///      Deliberately NOT gated on residual collateral or token balances — those are rescuable /
+    ///      re-deployable and a 1-wei donation must not brick a migration.
+    function migrateImpl(VenueParams memory p) public {
+        Layout storage $ = _layout();
+        bytes32 staged = $.stagedVenueHash;
+        if (staged == bytes32(0) || keccak256(abi.encode(p)) != staged) revert VenueNotStaged();
+        if ($.tokenId != 0 || $.hedgedDebtA != 0 || $.hedgedDebtB != 0) revert BookNotFlat();
+        if (IMoonwellMarket($.mCbBTC).borrowBalanceStored(address(this)) != 0) revert BookNotFlat();
+        if (IMoonwellMarket($.mWeth).borrowBalanceStored(address(this)) != 0) revert BookNotFlat();
+        address oldPool = $.pool;
+        applyVenue(p);
+        $.stagedVenueHash = bytes32(0);
+        emit VenueMigrated(oldPool, p.pool);
+    }
+
+    /// @notice Open a FRESH position from a flat `Executed` book (the migration's last leg, and the
+    ///         recovery from any flatten): `LeveragedAeroManager.executeImpl`'s exact genesis
+    ///         sequence — enterMarkets (idempotent), calm-gate, centred range at the stored width,
+    ///         supply + borrow at the stored target LTV, mint + stake, health assert — deploying the
+    ///         strategy's ENTIRE idle USDC balance.
+    /// @dev `deployIdle` cannot serve this state: it `increaseLiquidity`s the stored `tokenId`,
+    ///      which is 0 on a flat book (a real gauge/NPM reverts on it). Conversely this path is
+    ///      fresh-mint ONLY — with a live position it would double-open, so it reverts
+    ///      `PositionAlreadyOpen` and the caller routes to `deployIdle`. Slippage posture matches
+    ///      the activation genesis: calm-gate up front plus the §8 two-sided `maxSlippageBps` floor
+    ///      inside the mint (no caller min-out, exactly like `execute`).
+    function redeployImpl() public {
+        if (_layout().tokenId != 0) revert PositionAlreadyOpen();
+        LeveragedAeroManager.executeImpl();
+    }
+
+    // ── Shared venue validation + store (init AND migrate) ──
+
+    /// @notice Validate `p` to the exact standard `_initialize` enforced in-line before this block
+    ///         was extracted, then persist the venue subset of `Layout`. Reads the non-migratable
+    ///         core (usdc, mUsdc, usdcFeed, comptroller) from live storage — at init the strategy
+    ///         stores those BEFORE calling here; at migrate they are the live values by definition.
+    ///         Check order mirrors the original `_initialize` so the same input reverts with the
+    ///         same error; the one ADDITION is the `gauge.pool() == pool` binding check (absent at
+    ///         the original init, where the deployer was trusted on gauge wiring — load-bearing once
+    ///         a runtime migration can point at a fresh gauge, and it hardens init for free).
+    function applyVenue(VenueParams memory p) public {
+        Layout storage $ = _layout();
+        address usdc = $.usdc;
+        address mUsdc = $.mUsdc;
+
+        if (p.mCbBTC == address(0)) revert ZeroAddress();
+        if (p.mWeth == address(0)) revert ZeroAddress();
+        if (p.cbBTC == address(0)) revert ZeroAddress();
+        if (p.weth == address(0)) revert ZeroAddress();
+        if (p.pool == address(0)) revert ZeroAddress();
+        if (p.gauge == address(0)) revert ZeroAddress();
+        if (p.cbBTCFeed == address(0)) revert ZeroAddress();
+        if (p.wethFeed == address(0)) revert ZeroAddress();
+
+        // ── SHAPE DERIVATION — the ONE line that selects the pool shape (see `_initialize`) ──
+        bool legBIsAsset_ = p.cbBTC == usdc;
+
+        // Venue identity: the pool must BE the declared leg pair at the declared spacing, and each
+        // Moonwell borrow market must wrap its declared leg. Ordering is DERIVED here, never assumed.
+        if (ICLPool(p.pool).tickSpacing() != p.tickSpacing) revert VenueMismatch();
+        address t0 = ICLPool(p.pool).token0();
+        bool wethIsToken0_ = t0 == p.weth;
+        if (!wethIsToken0_ && t0 != p.cbBTC) revert VenueMismatch();
+        if (ICLPool(p.pool).token1() != (wethIsToken0_ ? p.cbBTC : p.weth)) revert VenueMismatch();
+        if (IMoonwellMarket(p.mCbBTC).underlying() != p.cbBTC) revert VenueMismatch();
+        if (IMoonwellMarket(p.mWeth).underlying() != p.weth) revert VenueMismatch();
+        // Symmetric with the two borrow legs: the collateral market must wrap the unit of account.
+        if (IMoonwellMarket(mUsdc).underlying() != usdc) revert VenueMismatch();
+        // The leg↔USDC swap pools are separate venues from the LP pool — probe them so a typo'd
+        // spacing can't route every swap at a nonexistent pool on a live levered book.
+        address clFactory = ICLPool(p.pool).factory();
+        if (legBIsAsset_) {
+            // ── ASSET-MODE: the three leg-B slots that only make sense for a BORROWED leg ──
+            // (see the numbered rationale in `_initialize`'s original block)
+            if (p.mCbBTC != mUsdc) revert VenueMismatch();
+            if (p.cbBTCSwapTickSpacing != 0) revert VenueMismatch();
+            if (p.cbBTCFeed != $.usdcFeed) revert VenueMismatch();
+        } else {
+            if (p.cbBTCSwapTickSpacing <= 0) revert VenueMismatch();
+            if (ICLFactory(clFactory).getPool(usdc, p.cbBTC, p.cbBTCSwapTickSpacing) == address(0)) {
+                revert VenueMismatch();
+            }
+        }
+        // Leg A is a real borrowed leg in BOTH shapes, so its swap venue is checked unconditionally.
+        if (p.wethSwapTickSpacing <= 0) revert VenueMismatch();
+        if (ICLFactory(clFactory).getPool(usdc, p.weth, p.wethSwapTickSpacing) == address(0)) {
+            revert VenueMismatch();
+        }
+
+        // Gauge↔pool binding (the ADDED check): a gauge that is not the pool's gauge would strand
+        // the staked NFT (`gauge.withdraw` on a gauge that never held it) or burn every reward.
+        if (ICLGauge(p.gauge).pool() != p.pool) revert VenueMismatch();
+
+        // Reject legs that break an accounting invariant (see `_initialize`'s original block).
+        address rewardTok = ICLGauge(p.gauge).rewardToken();
+        if (p.weth == usdc || p.weth == rewardTok || p.cbBTC == rewardTok) {
+            revert UnsupportedLeg();
+        }
+        // `compoundImpl`'s oracle floor hardcodes an 18dp reward token against an 8dp feed.
+        if (IERC20Metadata(rewardTok).decimals() != 18) revert UnexpectedFeedDecimals();
+
+        // Leg decimals drive every token↔USDC conversion — read them, never assume.
+        uint8 cbDec = IERC20Metadata(p.cbBTC).decimals();
+        uint8 wethDec = IERC20Metadata(p.weth).decimals();
+        if (cbDec < 2 || cbDec > 18 || wethDec < 2 || wethDec > 18) revert LegDecimalsOutOfRange();
+
+        // Rerange width band: on the tickSpacing grid, floor spans ≥ two spacings, ceiling inside
+        // the tick domain (see `_initialize`'s original block for the int24-wrap rationale).
+        if (p.tickSpacing <= 0) revert WidthOutOfBounds();
+        uint24 spacing = uint24(p.tickSpacing);
+        if (p.minWidth % spacing != 0 || p.maxWidth % spacing != 0) revert WidthOutOfBounds();
+        if (uint256(p.minWidth) < 2 * uint256(spacing)) revert WidthOutOfBounds();
+        if (p.minWidth > p.maxWidth) revert WidthOutOfBounds();
+        if (uint256(p.maxWidth) > 2 * uint256(uint24(TickMath.MAX_TICK))) revert WidthOutOfBounds();
+        if (p.width % spacing != 0 || p.width < p.minWidth || p.width > p.maxWidth) revert WidthOutOfBounds();
+
+        // Risk invariants against the LIVE collateral factor (re-read here — fresher than init's).
+        uint16 cfBps = _readCollateralFactor($.comptroller, mUsdc);
+        if (p.targetLtvBps > p.maxLtvBps) revert TargetLtvExceedsMax();
+        if (p.minHealthBps < 10500) revert MinHealthTooLow();
+        if (p.maxLtvBps >= cfBps) revert MaxLtvExceedsCF();
+        // L4: the permissionless-deleverage trigger LTV must sit strictly above maxLtvBps.
+        if (uint256(p.minHealthBps) * uint256(p.maxLtvBps) >= 1e8) revert MinHealthMaxLtvConflict();
+
+        // ── Persist the venue subset (every field a pool/pair change touches, nothing else) ──
+        $.mCbBTC = p.mCbBTC;
+        $.mWeth = p.mWeth;
+        $.cbBTC = p.cbBTC;
+        $.weth = p.weth;
+        $.pool = p.pool;
+        $.gauge = p.gauge;
+        $.cbBTCFeed = p.cbBTCFeed;
+        $.wethFeed = p.wethFeed;
+        $.tickSpacing = p.tickSpacing;
+        $.cbBTCSwapTickSpacing = p.cbBTCSwapTickSpacing;
+        $.wethSwapTickSpacing = p.wethSwapTickSpacing;
+        $.wethDeliversNative = p.wethDeliversNative;
+        $.width = p.width;
+        $.minWidth = p.minWidth;
+        $.maxWidth = p.maxWidth;
+        $.targetLtvBps = p.targetLtvBps;
+        $.maxLtvBps = p.maxLtvBps;
+        $.minHealthBps = p.minHealthBps;
+        $.usdcCollateralFactorBps = cfBps;
+        $.cbBTCDecimals = cbDec;
+        $.wethDecimals = wethDec;
+        $.wethIsToken0 = wethIsToken0_;
+        $.legBIsAsset = legBIsAsset_;
+    }
+
+    /// @dev USDC collateral factor (bps) from `Comptroller.markets(mUsdc)` — verbatim the strategy's
+    ///      original `_readCollateralFactor` (moved here with the venue block; init was its only caller).
+    function _readCollateralFactor(address comptroller_, address mUsdc_) private view returns (uint16 cfBps) {
+        (bool ok, bytes memory ret) = comptroller_.staticcall(abi.encodeWithSignature("markets(address)", mUsdc_));
+        if (!ok || ret.length < 64) revert ComptrollerCallFailed();
+        uint256 cfMantissa;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cfMantissa := mload(add(ret, 0x40))
+        }
+        cfBps = uint16(cfMantissa / 1e14); // 0.88e18 / 1e14 = 8800
+        if (cfBps == 0) revert ComptrollerCallFailed();
+    }
+}

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -2,12 +2,15 @@
 pragma solidity 0.8.28;
 
 import {LeveragedAeroManager} from "./LeveragedAeroManager.sol";
+import {LeveragedAeroValuation} from "./LeveragedAeroValuation.sol";
+import {IAggregatorV3} from "./sherwood/interfaces/IAggregatorV3.sol";
 import {IMoonwellMarket} from "./sherwood/interfaces/IMoonwellMarket.sol";
 import {ICLFactory, ICLGauge, ICLPool} from "./sherwood/interfaces/ISlipstream.sol";
 import {TickMath} from "./sherwood/libraries/TickMath.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title LeveragedAeroVenue
 /// @notice Venue-migration companion to `LeveragedAerodromeCLStrategy` (delegatecalled, like
@@ -47,6 +50,9 @@ library LeveragedAeroVenue {
     error VenueNotStaged(); // migrate without a staged hash, or params that do not match it
     error BookNotFlat(); // migrate while a CL position, hedged basis, or leg debt is still live
     error PositionAlreadyOpen(); // redeploy on a book that already has a CL position (use deployIdle)
+    error ZeroMinOut(); // flatten with a reward balance to sell but no caller floor
+    error BelowOracleFloor(); // flatten's reward-swap fill < the AERO/USD oracle floor (L9)
+    error InsufficientIdleAfterFlatten(uint256 idle, uint256 minIdle); // caller's aggregate unwind floor
 
     // ── Events (emitted from the strategy's address via delegatecall) ──
     /// @notice A destination venue hash was staged (or cleared, when `venueHash == 0`) by the vault owner.
@@ -60,8 +66,14 @@ library LeveragedAeroVenue {
     ///         Field semantics are LEG SLOTS exactly as in `InitParams` (names historical): `weth*`
     ///         is leg A (the natively-wrappable, always-borrowed slot), `cbBTC*` is leg B (the slot
     ///         that may be the unit of account — that IS asset-mode). The non-migratable core (usdc,
-    ///         mUsdc, comptroller, npm, swapRouter, usdcFeed, sequencerFeed, aeroUsdFeed, oracle/calm
-    ///         params, maxSlippageBps, fee params) is read from live storage, never from here.
+    ///         mUsdc, comptroller, npm, swapRouter, usdcFeed, sequencerFeed, oracle/calm params,
+    ///         maxSlippageBps, fee params) is read from live storage, never from here.
+    ///
+    ///         `aeroUsdFeed` IS part of the venue, deliberately. The gauge is migratable, so
+    ///         `gauge.rewardToken()` can change; a feed pinned to its init value would let a migration
+    ///         silently price reward token X with AERO's price — mis-scaling the L9 harvest floor (too
+    ///         low disables the sandwich guard, too high bricks every `compound`). Carrying it in the
+    ///         SAME owner-committed hash as the gauge is what keeps the pair attested together.
     struct VenueParams {
         address mCbBTC; // Moonwell market for leg B (must be mUsdc in asset-mode)
         address mWeth; // Moonwell market for leg A
@@ -71,6 +83,7 @@ library LeveragedAeroVenue {
         address gauge; // Gauge for the pool (AERO rewards); must report `pool()` == pool
         address cbBTCFeed; // leg B/USD aggregator (must be the USDC/USD feed in asset-mode)
         address wethFeed; // leg A/USD aggregator
+        address aeroUsdFeed; // gauge-reward/USD aggregator (8dp) — floors the reward swap (L9)
         int24 tickSpacing; // LP pool tickSpacing (asserted against `pool.tickSpacing()`)
         int24 cbBTCSwapTickSpacing; // leg B↔USDC swap-pool tickSpacing (0 in asset-mode)
         int24 wethSwapTickSpacing; // leg A↔USDC swap-pool tickSpacing
@@ -193,15 +206,55 @@ library LeveragedAeroVenue {
     /// @dev Slippage on the unwind swaps is Chainlink-floored inside `settleImpl` via
     ///      `maxSlippageBps` (same guard as a real settle); a down oracle fail-closes the flatten.
     ///      Idempotent on an already-flat book (the unwind and repays are no-ops).
-    function flattenImpl() public {
-        LeveragedAeroManager.settleImpl();
+    function flattenImpl(uint256 minRewardUsdcOut, uint256 minIdleUsdcOut) public {
         Layout storage $ = _layout();
+        // CALM GATE FIRST — never unwind at a manipulated tick. `settleImpl` has none of its own: it
+        // was written for the TERMINAL, owner-driven `settle()`, and `_unwindLiquidity`'s
+        // `amount0Min`/`amount1Min` are derived from the same `slot0()` it burns at, so they bind
+        // nothing against a shoved pool. `flatten` is proposer-callable and REPEATABLE (redeploy →
+        // flatten → …), which is exactly the shape `rerangeImpl` gates against; match it.
+        LeveragedAeroValuation.calmGate($.pool, $.twapWindow, $.calmDeviationTicks);
+        LeveragedAeroManager.settleImpl();
+        // Sell the reward tranche the unwind's `gauge.withdraw` just auto-claimed. WITHOUT this the
+        // book keeps a balance that is invisible to `nav()` (the `tokenId == 0` branch prices idle
+        // USDC only), unsellable (`compound` early-returns on a flat book) and un-rescuable
+        // (`rescueToVault` denies the reward token while Executed) — so every deposit and redeem in
+        // the flat window would price against an understated NAV.
+        _sellRewardBalance(minRewardUsdcOut);
         // Same pathological-case belt as `_settle`: repays drive the bases to 0 through `_repay`'s
         // clamp except when residual debt could not be covered at all — zero them explicitly so a
         // flat book never carries a stale hedge basis into the next venue.
         $.hedgedDebtA = 0;
         $.hedgedDebtB = 0;
-        emit Flattened(IERC20($.usdc).balanceOf(address(this)));
+        // Caller's aggregate floor on the WHOLE unwind (LP exit + leg sweeps + reward sale). The
+        // per-swap oracle floors bound each leg at `maxSlippageBps`, which init permits as wide as
+        // 10%; this is the proposer's own bound on the realised total, and the reason `flatten` is no
+        // longer the one value-moving entry point on this contract with no caller-supplied guard.
+        uint256 idle = IERC20($.usdc).balanceOf(address(this));
+        if (idle < minIdleUsdcOut) revert InsufficientIdleAfterFlatten(idle, minIdleUsdcOut);
+        emit Flattened(idle);
+    }
+
+    /// @dev Sell the gauge-reward balance to USDC, floored exactly as `compoundImpl`'s harvest is:
+    ///      `max(caller minOut, oracle floor)`, where the floor comes from a hardened 8dp read of the
+    ///      venue's `aeroUsdFeed` haircut by `maxSlippageBps`, post-checked against the MEASURED fill
+    ///      so a dishonest router cannot widen the bound. A stale feed fail-closes the flatten, which
+    ///      is the same posture `compound` takes (defer rather than sell blind).
+    ///
+    ///      No-op when the book holds no reward token — that keeps `flatten` idempotent on an
+    ///      already-flat book, and is why `minRewardUsdcOut` is only required to be nonzero when there
+    ///      is actually something to sell.
+    function _sellRewardBalance(uint256 minRewardUsdcOut) private {
+        Layout storage $ = _layout();
+        address rewardTok = ICLGauge($.gauge).rewardToken();
+        uint256 bal = IERC20(rewardTok).balanceOf(address(this));
+        if (bal == 0) return;
+        if (minRewardUsdcOut == 0) revert ZeroMinOut();
+        uint256 floor = Math.mulDiv(
+                bal, LeveragedAeroValuation.readUsd8($.aeroUsdFeed, $.sequencerFeed, $.maxDelay, $.gracePeriod), 1e20
+            ) * (10000 - uint256($.maxSlippageBps)) / 10000;
+        uint256 usdcOut = LeveragedAeroValuation.swapAeroToUsdc(rewardTok, $.usdc, bal, minRewardUsdcOut);
+        if (usdcOut < floor) revert BelowOracleFloor();
     }
 
     /// @notice Execute the staged venue rewrite: verify `p` byte-matches the owner-staged hash,
@@ -266,6 +319,11 @@ library LeveragedAeroVenue {
         if (p.gauge == address(0)) revert ZeroAddress();
         if (p.cbBTCFeed == address(0)) revert ZeroAddress();
         if (p.wethFeed == address(0)) revert ZeroAddress();
+        if (p.aeroUsdFeed == address(0)) revert ZeroAddress();
+        // L9: the reward-token floor scales an 8dp price (`mulDiv(bal, price8, 1e20)`); a non-8dp
+        // aggregator would silently mis-scale it by orders of magnitude. Checked here (not at read
+        // time like the leg feeds) because the floor consumes the raw answer.
+        if (IAggregatorV3(p.aeroUsdFeed).decimals() != 8) revert UnexpectedFeedDecimals();
 
         // ── SHAPE DERIVATION — the ONE line that selects the pool shape (see `_initialize`) ──
         bool legBIsAsset_ = p.cbBTC == usdc;
@@ -346,6 +404,7 @@ library LeveragedAeroVenue {
         $.gauge = p.gauge;
         $.cbBTCFeed = p.cbBTCFeed;
         $.wethFeed = p.wethFeed;
+        $.aeroUsdFeed = p.aeroUsdFeed;
         $.tickSpacing = p.tickSpacing;
         $.cbBTCSwapTickSpacing = p.cbBTCSwapTickSpacing;
         $.wethSwapTickSpacing = p.wethSwapTickSpacing;

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -169,7 +169,7 @@ library LeveragedAeroVenue {
         // ── appended for the config-emergent pool shape (keep byte-identical) ──
         bool legBIsAsset; // DERIVED at init: leg-B slot == usdc → asset-as-a-leg shape (packs above)
         // ── appended for the borrow-interest hedge (keep byte-identical) ──
-        uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with the widths above)
+        uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with hedgedDebtB below)
         uint128 hedgedDebtB; // leg-B borrowed principal the LP hedges (0 in asset-mode: leg B never borrows)
         // ── LAST field: appended for the owner-staged venue migration (keep byte-identical) ──
         bytes32 stagedVenueHash; // keccak256(abi.encode(VenueParams)) staged by the vault owner; 0 == none
@@ -244,15 +244,27 @@ library LeveragedAeroVenue {
     ///      No-op when the book holds no reward token — that keeps `flatten` idempotent on an
     ///      already-flat book, and is why `minRewardUsdcOut` is only required to be nonzero when there
     ///      is actually something to sell.
+    ///
+    ///      DUST NO-OP (and the reason the floor is derived BEFORE the `ZeroMinOut` belt): a balance
+    ///      worth less than one micro-USD prices to a ZERO oracle floor, and the router fills it at 0
+    ///      USDC. Without this branch every argument reverts — `0` on `ZeroMinOut`, anything nonzero on
+    ///      the router's own min-out check — so a 1e6-wei donation to a live book would brick `flatten`
+    ///      permanently: `compound` cannot clear it (it early-returns on a flat book and hits this same
+    ///      revert on a live one), `rescueToVault` denies the reward token while `Executed`, and
+    ///      `migrateVenue`'s flat-book gate then becomes unreachable, leaving terminal `settle()` as the
+    ///      only exit. Skipping is safe precisely where the floor rounds to 0: the mandatory-sale
+    ///      rationale is that an unsold balance is invisible to `nav()`, and a sub-micro-USD balance
+    ///      rounds out of a 6dp NAV by construction.
     function _sellRewardBalance(uint256 minRewardUsdcOut) private {
         Layout storage $ = _layout();
         address rewardTok = ICLGauge($.gauge).rewardToken();
         uint256 bal = IERC20(rewardTok).balanceOf(address(this));
         if (bal == 0) return;
-        if (minRewardUsdcOut == 0) revert ZeroMinOut();
         uint256 floor = Math.mulDiv(
             bal, LeveragedAeroValuation.readUsd8($.aeroUsdFeed, $.sequencerFeed, $.maxDelay, $.gracePeriod), 1e20
         ) * (10000 - uint256($.maxSlippageBps)) / 10000;
+        if (floor == 0) return; // dust: unsellable, and worth strictly less than one NAV unit
+        if (minRewardUsdcOut == 0) revert ZeroMinOut();
         uint256 usdcOut = LeveragedAeroValuation.swapAeroToUsdc(rewardTok, $.usdc, bal, minRewardUsdcOut);
         if (usdcOut < floor) revert BelowOracleFloor();
     }
@@ -290,10 +302,26 @@ library LeveragedAeroVenue {
     ///      fresh-mint ONLY — with a live position it would double-open, so it reverts
     ///      `PositionAlreadyOpen` and the caller routes to `deployIdle`. Slippage posture matches
     ///      the activation genesis: calm-gate up front plus the §8 two-sided `maxSlippageBps` floor
-    ///      inside the mint (no caller min-out, exactly like `execute`).
-    function redeployImpl() public {
-        if (_layout().tokenId != 0) revert PositionAlreadyOpen();
-        LeveragedAeroManager.executeImpl();
+    ///      inside the mint, PLUS the caller's `minLiquidity` — which `execute` does not take. The
+    ///      asymmetry is deliberate: `execute` runs once at activation on a seed-only book, whereas
+    ///      this re-enters the WHOLE book repeatedly against live depositors, and the in-mint mins are
+    ///      derived from the same `slot0()` the mint executes at (self-referential, the exact
+    ///      criticism `flattenImpl`'s own comment makes of `settleImpl`'s unwind mins).
+    ///
+    ///      CONSUMES ANY STAGED HASH. A `flatten → redeploy` round trip is the documented ROLLBACK of
+    ///      an aborted migration, and leaving the destination hash armed afterwards would let the
+    ///      proposer fire an owner authorization months later into conditions nobody re-evaluated —
+    ///      the same replay the migrate path closes by clearing on consume. Re-staging is one owner
+    ///      call, so the cost of being wrong here is asymmetric in the safe direction.
+    /// @param minLiquidity Minimum CL liquidity the fresh mint must produce (slippage guard).
+    function redeployImpl(uint256 minLiquidity) public {
+        Layout storage $ = _layout();
+        if ($.tokenId != 0) revert PositionAlreadyOpen();
+        if ($.stagedVenueHash != bytes32(0)) {
+            $.stagedVenueHash = bytes32(0);
+            emit VenueStaged(bytes32(0));
+        }
+        LeveragedAeroManager.executeImpl(minLiquidity);
     }
 
     // ── Shared venue validation + store (init AND migrate) ──
@@ -324,6 +352,13 @@ library LeveragedAeroVenue {
         // aggregator would silently mis-scale it by orders of magnitude. Checked here (not at read
         // time like the leg feeds) because the floor consumes the raw answer.
         if (IAggregatorV3(p.aeroUsdFeed).decimals() != 8) revert UnexpectedFeedDecimals();
+        // The LEG feeds, checked here for the same reason and not only at read time. `readUsd8` does
+        // reject a non-8dp answer (`FeedDecimalsMismatch`), so this is fail-closed either way — but it
+        // fails at the wrong MOMENT: an 18dp leg feed migrates cleanly and then bricks `redeploy` and
+        // every priced op on the new venue, recoverable only by re-staging. Rejecting a bad parameter
+        // set at validation time is strictly better than adopting it and discovering it later.
+        if (IAggregatorV3(p.wethFeed).decimals() != 8) revert UnexpectedFeedDecimals();
+        if (IAggregatorV3(p.cbBTCFeed).decimals() != 8) revert UnexpectedFeedDecimals();
 
         // ── SHAPE DERIVATION — the ONE line that selects the pool shape (see `_initialize`) ──
         bool legBIsAsset_ = p.cbBTC == usdc;
@@ -362,7 +397,29 @@ library LeveragedAeroVenue {
 
         // Gauge↔pool binding (the ADDED check): a gauge that is not the pool's gauge would strand
         // the staked NFT (`gauge.withdraw` on a gauge that never held it) or burn every reward.
+        //
+        // BOTH DIRECTIONS, and the second one is the load-bearing one. `gauge.pool()` is SELF-ATTESTED
+        // by the staged contract: a hostile gauge returns the real pool's address for free, passes this
+        // check, and then receives the freshly minted position NFT at `redeploy`. The pool's own
+        // `gauge()` is not forgeable the same way — on a real Slipstream pool it is written by the
+        // Aerodrome Voter at gauge creation, so requiring the pair to agree means an attacker must
+        // already control the pool, not merely the gauge. That is a strictly smaller residual, and it
+        // is the reciprocal check the vendored `ISlipstream.ICLPool` already declares.
         if (ICLGauge(p.gauge).pool() != p.pool) revert VenueMismatch();
+        if (ICLPool(p.pool).gauge() != p.gauge) revert VenueMismatch();
+
+        // TWAP AVAILABILITY. `calmGate` reads `pool.observe([twapWindow, 0])`, and a Slipstream pool
+        // whose oracle cardinality does not yet span `twapWindow` REVERTS that read. Every gated path
+        // on the destination — `redeploy`, `rerange`, and `flatten` itself — would then revert, i.e. a
+        // pool younger than the window is adoptable but neither usable nor exitable. Probe it here so
+        // that becomes a rejected stage instead of a stuck fund. `twapWindow` is non-migratable core,
+        // so the value probed is the one the gate will use.
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0] = $.twapWindow;
+        try ICLPool(p.pool).observe(secondsAgos) returns (int56[] memory, uint160[] memory) {}
+        catch {
+            revert VenueMismatch();
+        }
 
         // Reject legs that break an accounting invariant (see `_initialize`'s original block).
         address rewardTok = ICLGauge(p.gauge).rewardToken();
@@ -371,6 +428,13 @@ library LeveragedAeroVenue {
         }
         // `compoundImpl`'s oracle floor hardcodes an 18dp reward token against an 8dp feed.
         if (IERC20Metadata(rewardTok).decimals() != 18) revert UnexpectedFeedDecimals();
+        // The reward leg is a THIRD swap venue, distinct from the LP pool and the two leg↔USDC CL
+        // pools probed above, and `swapAeroToUsdc` hardcodes its route (Aerodrome v2, volatile).
+        // Probe it for the same reason: a gauge whose reward token has no v2/USDC pool passes every
+        // other check here and then reverts inside BOTH `compound` and `flatten` the moment a tranche
+        // accrues — and `flatten` is the migration's own precondition, so the fund would be stuck on a
+        // venue it cannot unwind. Rejecting at stage time turns that into a rejected parameter set.
+        if (LeveragedAeroValuation.aeroV2VolatilePool(rewardTok, usdc) == address(0)) revert VenueMismatch();
 
         // Leg decimals drive every token↔USDC conversion — read them, never assume.
         uint8 cbDec = IERC20Metadata(p.cbBTC).decimals();

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -178,6 +178,17 @@ library LeveragedAeroVenue {
     /// @dev keccak256(abi.encode(uint256(keccak256("leveraged.aero.cl.storage")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant STORAGE_SLOT = 0x405ae0b144079093e970849fdffdcb2a514e44968598c6c5c73444496e844900;
 
+    /// @dev The canonical Aerodrome Slipstream CLFactory on Base — the ONE registry allowed to vouch
+    ///      for a destination pool. Hardcoded rather than read from `pool.factory()` for the same
+    ///      reason `swapAeroToUsdc` hardcodes `AERO_V2_FACTORY`: a self-nominated registry vouches for
+    ///      nothing. Canonical immutable Base infra (`AERODROME_CL_FACTORY` in `addresses/8453.json`).
+    address private constant AERODROME_CL_FACTORY = 0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A;
+
+    /// @dev An 8dp reward-token price nothing could plausibly exceed ($10,000 against a ~$1 token),
+    ///      used ONLY to derive an oracle-free dust bound in `_sellRewardBalance`. Raising it makes
+    ///      that bound narrower (more conservative), never wider — the safe direction.
+    uint256 private constant REWARD_PRICE_CEILING_USD8 = 1e12;
+
     /// @dev ERC-7201 diamond-storage accessor (byte-identical across strategy + manager).
     function _layout() private pure returns (Layout storage $) {
         // solhint-disable-next-line no-inline-assembly
@@ -260,6 +271,21 @@ library LeveragedAeroVenue {
         address rewardTok = ICLGauge($.gauge).rewardToken();
         uint256 bal = IERC20(rewardTok).balanceOf(address(this));
         if (bal == 0) return;
+        // ORACLE-FREE DUST BAND, checked BEFORE the priced one below. The `floor == 0` skip is
+        // correct but sits AFTER `readUsd8`, so a dust donation still gates `flatten` on reward-feed
+        // staleness / sequencer grace for zero economic benefit — and `flatten` is `migrateVenue`'s
+        // own precondition, so a feed outage plus one wei of donated dust stalls a migration.
+        // `bal * price8 < 1e20` is what makes the floor round to 0; `REWARD_PRICE_CEILING_USD8`
+        // substitutes a price so absurd (`$10,000` against a ~$1 token) that no live read could
+        // exceed it, which makes this branch strictly narrower than the priced one — it can only
+        // skip balances the priced check would also have skipped.
+        //
+        // PARTIAL BY CONSTRUCTION, deliberately: this covers only the band that is dust at the
+        // CEILING price, so the priced `floor == 0` skip below still carries the rest of the band and
+        // still runs after the oracle. Closing the remainder needs the actual price, i.e. a
+        // non-reverting `tryReadUsd8` variant — a rewrite of a safety-critical oracle path, which is
+        // not worth it for a sub-micro-USD balance.
+        if (bal < 1e20 / REWARD_PRICE_CEILING_USD8) return;
         uint256 floor = Math.mulDiv(
             bal, LeveragedAeroValuation.readUsd8($.aeroUsdFeed, $.sequencerFeed, $.maxDelay, $.gracePeriod), 1e20
         ) * (10000 - uint256($.maxSlippageBps)) / 10000;
@@ -374,9 +400,20 @@ library LeveragedAeroVenue {
         if (IMoonwellMarket(p.mWeth).underlying() != p.weth) revert VenueMismatch();
         // Symmetric with the two borrow legs: the collateral market must wrap the unit of account.
         if (IMoonwellMarket(mUsdc).underlying() != usdc) revert VenueMismatch();
-        // The leg↔USDC swap pools are separate venues from the LP pool — probe them so a typo'd
-        // spacing can't route every swap at a nonexistent pool on a live levered book.
-        address clFactory = ICLPool(p.pool).factory();
+        // CANONICAL FACTORY BINDING. The pool no longer gets to nominate the registry that vouches
+        // for it. `pool.factory()` is SELF-ATTESTED — exactly the seam the `gauge.pool()` reciprocal
+        // below closes for the gauge — so a hostile pool paired with a hostile "factory" satisfies
+        // every probe below for free: the factory answers with whatever the attacker wants for the
+        // two leg↔USDC lookups, and nothing else here re-derives the LP pool's provenance. Pinning
+        // the real Slipstream CLFactory and requiring it to REGISTER `p.pool` at the declared pair +
+        // spacing means the attacker must control the canonical factory, not merely deploy a pool.
+        // Mirrors the treatment `swapAeroToUsdc`'s reward route already gets (hardcoded
+        // `AERO_V2_FACTORY`), removing the asymmetry between the two.
+        if (ICLPool(p.pool).factory() != AERODROME_CL_FACTORY) revert VenueMismatch();
+        if (ICLFactory(AERODROME_CL_FACTORY).getPool(p.weth, p.cbBTC, p.tickSpacing) != p.pool) {
+            revert VenueMismatch();
+        }
+        address clFactory = AERODROME_CL_FACTORY;
         if (legBIsAsset_) {
             // ── ASSET-MODE: the three leg-B slots that only make sense for a BORROWED leg ──
             // (see the numbered rationale in `_initialize`'s original block)
@@ -412,8 +449,13 @@ library LeveragedAeroVenue {
         // whose oracle cardinality does not yet span `twapWindow` REVERTS that read. Every gated path
         // on the destination — `redeploy`, `rerange`, and `flatten` itself — would then revert, i.e. a
         // pool younger than the window is adoptable but neither usable nor exitable. Probe it here so
-        // that becomes a rejected stage instead of a stuck fund. `twapWindow` is non-migratable core,
-        // so the value probed is the one the gate will use.
+        // that becomes a rejected MIGRATE instead of a stuck fund. `twapWindow` is non-migratable
+        // core, so the value probed is the one the gate will use.
+        //
+        // WHEN, precisely: `stageVenue` stores a hash and validates NOTHING — every check in this
+        // function runs at `migrateVenue`, on a book the proposer has already flattened. So a bad
+        // parameter set is caught after the flatten, not before it. Say so plainly: an operator who
+        // reads "rejected at stage time" will flatten first and then eat the revert.
         uint32[] memory secondsAgos = new uint32[](2);
         secondsAgos[0] = $.twapWindow;
         try ICLPool(p.pool).observe(secondsAgos) returns (int56[] memory, uint160[] memory) {}
@@ -433,7 +475,8 @@ library LeveragedAeroVenue {
         // Probe it for the same reason: a gauge whose reward token has no v2/USDC pool passes every
         // other check here and then reverts inside BOTH `compound` and `flatten` the moment a tranche
         // accrues — and `flatten` is the migration's own precondition, so the fund would be stuck on a
-        // venue it cannot unwind. Rejecting at stage time turns that into a rejected parameter set.
+        // venue it cannot unwind. Rejecting at MIGRATE time turns that into a rejected parameter set
+        // (see the timing note on the observe probe above — nothing is validated at stage time).
         if (LeveragedAeroValuation.aeroV2VolatilePool(rewardTok, usdc) == address(0)) revert VenueMismatch();
 
         // Leg decimals drive every token↔USDC conversion — read them, never assume.

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -251,8 +251,8 @@ library LeveragedAeroVenue {
         if (bal == 0) return;
         if (minRewardUsdcOut == 0) revert ZeroMinOut();
         uint256 floor = Math.mulDiv(
-                bal, LeveragedAeroValuation.readUsd8($.aeroUsdFeed, $.sequencerFeed, $.maxDelay, $.gracePeriod), 1e20
-            ) * (10000 - uint256($.maxSlippageBps)) / 10000;
+            bal, LeveragedAeroValuation.readUsd8($.aeroUsdFeed, $.sequencerFeed, $.maxDelay, $.gracePeriod), 1e20
+        ) * (10000 - uint256($.maxSlippageBps)) / 10000;
         uint256 usdcOut = LeveragedAeroValuation.swapAeroToUsdc(rewardTok, $.usdc, bal, minRewardUsdcOut);
         if (usdcOut < floor) revert BelowOracleFloor();
     }

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -93,6 +93,10 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     error WidthOutOfBounds(); // rerange width off the tickSpacing grid or outside [minWidth, maxWidth]
     error ZeroShares(); // deposit would mint 0 shares (dust assets against a large book) — pay-for-nothing
     error NotVaultOwner(); // stageVenue caller is not the vault's owner (the venue-selection authority)
+    // A lever-down that would repay the ENTIRE debt is rejected — it would orphan the staked position
+    // NFT. Declared once in the manager (same selector); re-declared here so it is on the strategy's
+    // public ABI for the rebalancer, exactly as `InsufficientIdleForLeverUp` is. Use `flatten()`.
+    error FullUnwindNotSupported();
 
     // ── Constants ──
     /// @dev Position `kind` tag for the PriceRouter adapter registry.

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -497,18 +497,25 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         $.mUsdc = p.mUsdc;
         $.usdcFeed = p.usdcFeed;
         $.comptroller = p.comptroller;
+        // FIFTH live-storage read, and it must be written HERE, not with the other oracle params
+        // below: `applyVenue`'s TWAP-availability probe calls `pool.observe([$.twapWindow, 0])`, so
+        // with the write left downstream the init-time probe ran as `observe([0, 0])` — which every
+        // pool answers, making the probe vacuous at init and live only at migrate. Its own bound
+        // check therefore has to move up with it, ahead of the sibling bounds below.
+        if (p.twapWindow == 0 || p.twapWindow > 1 days) revert OracleParamOutOfRange();
+        $.twapWindow = p.twapWindow;
         LeveragedAeroVenue.applyVenue(_venueParamsOf(p));
 
         // L3 (+L5): bound the oracle / calm-gate params so a misconfig can't silently disable a guard.
         // Bounds admit the confirmed config yet block degenerate values:
         //   maxDelay           ∈ (0, 7 days] — a huge value disables staleness detection
         //   gracePeriod        ∈ [0, 1 days] — sequencer-restart grace
-        //   twapWindow         ∈ (0, 1 days] — 0 disables the TWAP / calm-gate
+        //   twapWindow         ∈ (0, 1 days] — 0 disables the TWAP / calm-gate (checked ABOVE, with
+        //                                      its store, so `applyVenue`'s observe probe is live)
         //   calmDeviationTicks ∈ (0, 5000]   — a huge value disables the calm-gate
         //   maxSlippageBps     ∈ (0, 1000]   — 0 or huge disables swap-slippage protection (10% cap)
         if (p.maxDelay == 0 || p.maxDelay > 7 days) revert OracleParamOutOfRange();
         if (p.gracePeriod > 1 days) revert OracleParamOutOfRange();
-        if (p.twapWindow == 0 || p.twapWindow > 1 days) revert OracleParamOutOfRange();
         if (p.calmDeviationTicks == 0 || p.calmDeviationTicks > 5000) revert OracleParamOutOfRange();
         if (p.maxSlippageBps == 0 || p.maxSlippageBps > 1000) revert OracleParamOutOfRange();
         if ((p.managementFeeBps != 0 || p.performanceFeeBps != 0) && p.feeRecipient == address(0)) {
@@ -527,7 +534,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         $.maxDelay = p.maxDelay;
         $.gracePeriod = p.gracePeriod;
         $.calmDeviationTicks = p.calmDeviationTicks;
-        $.twapWindow = p.twapWindow;
+        // `$.twapWindow` was stored ahead of `applyVenue` — see the note there.
         $.maxSlippageBps = p.maxSlippageBps;
         $.managementFeeBps = p.managementFeeBps;
         $.performanceFeeBps = p.performanceFeeBps;

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -15,7 +15,6 @@ import {LeveragedAeroValuation} from "./LeveragedAeroValuation.sol";
 import {LeveragedAeroVenue} from "./LeveragedAeroVenue.sol";
 import {BaseStrategy} from "./sherwood/BaseStrategy.sol";
 import {FeeConstants} from "./sherwood/FeeConstants.sol";
-import {IAggregatorV3} from "./sherwood/interfaces/IAggregatorV3.sol";
 import {Position} from "./sherwood/interfaces/IPriceRouter.sol";
 import {IProtocolConfig} from "./sherwood/interfaces/IProtocolConfig.sol";
 import {ICLGauge, INonfungiblePositionManager} from "./sherwood/interfaces/ISlipstream.sol";
@@ -460,11 +459,9 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         if (p.wethFeed == address(0)) revert ZeroAddress();
         if (p.usdcFeed == address(0)) revert ZeroAddress();
         if (p.sequencerFeed == address(0)) revert ZeroAddress();
-        if (p.aeroUsdFeed == address(0)) revert ZeroAddress();
-        // L9: the AERO/USD floor scales an 8dp price (mulDiv by 1e20); a non-8dp aggregator would
-        // silently mis-scale the floor. Assert it here (the other feeds check dec at read time via
-        // _readUsd8; this one is checked once at init since the manager reads it raw for the floor).
-        if (IAggregatorV3(p.aeroUsdFeed).decimals() != 8) revert UnexpectedFeedDecimals();
+        // `aeroUsdFeed` (zero-check + the 8dp L9 assertion) is validated inside
+        // `LeveragedAeroVenue.applyVenue` — it moved into the migratable venue subset so a gauge
+        // change and its reward-price feed are always attested together.
 
         // L7: the strategy's unit of account MUST be the vault's ERC-4626 asset, and the
         // SHARES_VIRTUAL_OFFSET (1e6) hardcodes a 6-decimal asset — reject any other wiring.
@@ -509,7 +506,6 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         $.npm = p.npm;
         $.swapRouter = p.swapRouter;
         $.sequencerFeed = p.sequencerFeed;
-        $.aeroUsdFeed = p.aeroUsdFeed;
         $.maxDelay = p.maxDelay;
         $.gracePeriod = p.gracePeriod;
         $.calmDeviationTicks = p.calmDeviationTicks;
@@ -543,6 +539,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         v.gauge = p.gauge;
         v.cbBTCFeed = p.cbBTCFeed;
         v.wethFeed = p.wethFeed;
+        v.aeroUsdFeed = p.aeroUsdFeed;
         v.tickSpacing = p.tickSpacing;
         v.cbBTCSwapTickSpacing = p.cbBTCSwapTickSpacing;
         v.wethSwapTickSpacing = p.wethSwapTickSpacing;
@@ -1339,11 +1336,24 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///         residual legs to USDC, Chainlink-floored slippage via `maxSlippageBps`) but does NOT
     ///         settle: no state transition, no push-to-vault, no protocol-fee discharge. Deposits
     ///         and redeems keep working against the flat book (NAV == idle USDC, oracle-free); the
-    ///         proposer re-enters via `deployIdle` — into the current venue, or into a new one after
+    ///         proposer re-enters via `redeploy` — into the current venue, or into a new one after
     ///         `migrateVenue`. Idempotent on an already-flat book.
-    function flatten() external onlyProposer nonReentrant {
+    ///
+    ///         GUARDS (both added because `flatten` is repeatable, unlike the terminal `settle` whose
+    ///         unwind body it reuses): the pool is CALM-GATED before the burn — `settleImpl` has no
+    ///         gate of its own and `_unwindLiquidity`'s mins are derived from the same `slot0()` it
+    ///         burns at, so they bind nothing against a shoved tick — and the reward tranche the
+    ///         unwind auto-claims is SOLD here, so the flat-book `nav()` (idle USDC only) is again the
+    ///         whole book rather than understating it for the length of the flat window.
+    /// @param minRewardUsdcOut Minimum USDC out of the gauge-reward sale. Required nonzero only when
+    ///                         a reward balance is actually present; the L9 oracle floor applies on
+    ///                         top, so the effective bound is `max(this, floor)`.
+    /// @param minIdleUsdcOut   Aggregate floor on the strategy's idle USDC once the unwind completes
+    ///                         — the proposer's own bound on the realised total, over and above the
+    ///                         per-swap `maxSlippageBps` floors.
+    function flatten(uint256 minRewardUsdcOut, uint256 minIdleUsdcOut) external onlyProposer nonReentrant {
         if (_state != State.Executed) revert NotExecuted();
-        LeveragedAeroVenue.flattenImpl();
+        LeveragedAeroVenue.flattenImpl(minRewardUsdcOut, minIdleUsdcOut);
     }
 
     /// @notice Execute the owner-staged venue rewrite. PROPOSER ONLY, and only when `p` byte-matches

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -12,17 +12,16 @@ import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/Reentrancy
 import {LeveragedAeroFees} from "./LeveragedAeroFees.sol";
 import {LeveragedAeroManager} from "./LeveragedAeroManager.sol";
 import {LeveragedAeroValuation} from "./LeveragedAeroValuation.sol";
+import {LeveragedAeroVenue} from "./LeveragedAeroVenue.sol";
 import {BaseStrategy} from "./sherwood/BaseStrategy.sol";
 import {FeeConstants} from "./sherwood/FeeConstants.sol";
 import {IAggregatorV3} from "./sherwood/interfaces/IAggregatorV3.sol";
-import {IMoonwellMarket} from "./sherwood/interfaces/IMoonwellMarket.sol";
 import {Position} from "./sherwood/interfaces/IPriceRouter.sol";
 import {IProtocolConfig} from "./sherwood/interfaces/IProtocolConfig.sol";
-import {ICLFactory, ICLGauge, ICLPool, INonfungiblePositionManager} from "./sherwood/interfaces/ISlipstream.sol";
+import {ICLGauge, INonfungiblePositionManager} from "./sherwood/interfaces/ISlipstream.sol";
 import {IStrategy} from "./sherwood/interfaces/IStrategy.sol";
 import {ISyndicateFactory} from "./sherwood/interfaces/ISyndicateFactory.sol";
 import {ISyndicateVault} from "./sherwood/interfaces/ISyndicateVault.sol";
-import {TickMath} from "./sherwood/libraries/TickMath.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title LeveragedAerodromeCLStrategy
@@ -93,6 +92,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     error InsufficientIdleForLeverUp(uint256 needed, uint256 available);
     error WidthOutOfBounds(); // rerange width off the tickSpacing grid or outside [minWidth, maxWidth]
     error ZeroShares(); // deposit would mint 0 shares (dust assets against a large book) — pay-for-nothing
+    error NotVaultOwner(); // stageVenue caller is not the vault's owner (the venue-selection authority)
 
     // ── Constants ──
     /// @dev Position `kind` tag for the PriceRouter adapter registry.
@@ -263,9 +263,11 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         uint24 maxWidth; // upper bound for a proposer-supplied rerange width
         // ── appended for the config-emergent pool shape (keep byte-identical) ──
         bool legBIsAsset; // DERIVED at init: leg-B slot == usdc → asset-as-a-leg shape (packs above)
-        // ── LAST fields: appended for the borrow-interest hedge (keep byte-identical) ──
+        // ── appended for the borrow-interest hedge (keep byte-identical) ──
         uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with the widths above)
         uint128 hedgedDebtB; // leg-B borrowed principal the LP hedges (0 in asset-mode: leg B never borrows)
+        // ── LAST field: appended for the owner-staged venue migration (keep byte-identical) ──
+        bytes32 stagedVenueHash; // keccak256(abi.encode(VenueParams)) staged by the vault owner; 0 == none
     }
 
     /// @dev keccak256(abi.encode(uint256(keccak256("leveraged.aero.cl.storage")) - 1)) & ~bytes32(uint256(0xff))
@@ -331,6 +333,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         bool legBIsAsset;
         uint128 hedgedDebtA;
         uint128 hedgedDebtB;
+        bytes32 stagedVenueHash;
     }
 
     /// @notice Full strategy storage layout (single accessor for tests / off-chain reads), minus the
@@ -387,6 +390,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         v.legBIsAsset = $.legBIsAsset;
         v.hedgedDebtA = $.hedgedDebtA;
         v.hedgedDebtB = $.hedgedDebtB;
+        v.stagedVenueHash = $.stagedVenueHash;
     }
 
     /// @notice The borrowed PRINCIPAL each leg's LP side currently hedges, and therefore the
@@ -463,108 +467,19 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         if (p.usdc != IERC4626(vault()).asset()) revert AssetMismatch();
         if (IERC20Metadata(p.usdc).decimals() != 6) revert UnexpectedAssetDecimals();
 
-        // ── SHAPE DERIVATION — the ONE line that selects the pool shape ──
-        //
-        // There is NO mode flag in `InitParams`: the shape is EMERGENT FROM CONFIG. The leg-B slot
-        // being the unit of account IS the asset-as-a-leg configuration (e.g. a cbBTC/USDC pool, where
-        // part of the deposit is supplied as collateral, only leg A is borrowed, and the borrowed leg
-        // is LP'd against the REMAINING USDC). Anything else is the original two-borrowed-legs shape.
-        //
-        // THE ASYMMETRY IS DELIBERATE: only LEG B may be the asset. Leg A must always be a real
-        // volatile borrowed leg — it carries the `wethDeliversNative` wrap path and is the SINGLE
-        // borrow in asset-mode — so `weth == usdc` stays rejected outright below.
-        bool legBIsAsset_ = p.cbBTC == p.usdc;
+        // ── VENUE BLOCK — extracted verbatim to `LeveragedAeroVenue.applyVenue` so the owner-staged
+        // venue migration (`migrateVenue`) re-runs the EXACT same validation. Everything from the
+        // shape derivation through the CF/LTV invariants — plus one ADDED `gauge.pool() == pool`
+        // binding check — lives there now; check order is preserved so the same input reverts with
+        // the same error. The lib reads the non-migratable core (usdc / mUsdc / usdcFeed /
+        // comptroller) from live storage, which is why those four are stored FIRST below.
+        Layout storage $ = _layout();
+        $.usdc = p.usdc;
+        $.mUsdc = p.mUsdc;
+        $.usdcFeed = p.usdcFeed;
+        $.comptroller = p.comptroller;
+        LeveragedAeroVenue.applyVenue(_venueParamsOf(p));
 
-        // Venue identity: the pool must BE the declared leg pair at the declared spacing, and each
-        // Moonwell borrow market must wrap its declared leg. Ordering is DERIVED here, never assumed
-        // (the manager maps every (legB, legA) pair onto (amount0, amount1) through `wethIsToken0`).
-        // The pair check below doubles as the asset-mode pool-token-set check: with `cbBTC == usdc` it
-        // requires exactly `{legA, usdc}`, and rejects a degenerate `(usdc, usdc)` pool.
-        if (ICLPool(p.pool).tickSpacing() != p.tickSpacing) revert VenueMismatch();
-        address t0 = ICLPool(p.pool).token0();
-        bool wethIsToken0_ = t0 == p.weth;
-        if (!wethIsToken0_ && t0 != p.cbBTC) revert VenueMismatch();
-        if (ICLPool(p.pool).token1() != (wethIsToken0_ ? p.cbBTC : p.weth)) revert VenueMismatch();
-        if (IMoonwellMarket(p.mCbBTC).underlying() != p.cbBTC) revert VenueMismatch();
-        if (IMoonwellMarket(p.mWeth).underlying() != p.weth) revert VenueMismatch();
-        // Symmetric with the two borrow legs: the collateral market must wrap the unit of account,
-        // or every `_supplyCollateral` / `_redeemCollateral` would move a token the NAV never prices.
-        if (IMoonwellMarket(p.mUsdc).underlying() != p.usdc) revert VenueMismatch();
-        // The leg↔USDC swap pools are separate venues from the LP pool — their spacings are inputs,
-        // so they get the same treatment as the LP pool: positive, and an EXISTING pool at that
-        // spacing. Unprobed, a typo'd spacing routes every swap at a nonexistent pool and bricks
-        // settle / deleverage / shortfall-cover on a live levered book.
-        address clFactory = ICLPool(p.pool).factory();
-        if (legBIsAsset_) {
-            // ── ASSET-MODE: the three leg-B slots that only make sense for a BORROWED leg ──
-            //
-            // 1. Market: leg B is never borrowed here, so its market slot must be the COLLATERAL market
-            //    (already asserted to wrap `cbBTC == usdc` just above). Pinning it is what makes every
-            //    `borrowBalanceStored($.mCbBTC)` read in the manager/valuation structurally 0 — nothing
-            //    ever calls `borrow()` on mUSDC — so the debt / health / repay / shortfall paths need no
-            //    asset-mode branch at all and can never disagree with each other.
-            if (p.mCbBTC != p.mUsdc) revert VenueMismatch();
-            // 2. Swap spacing: DECLARED UNUSED (must be 0). There is no USDC/USDC pool to probe, and a
-            //    nonzero value would advertise a leg-B↔USDC route that must never be taken (the manager
-            //    makes every such swap an early-return identity instead).
-            if (p.cbBTCSwapTickSpacing != 0) revert VenueMismatch();
-            // 3. Feed: leg B prices at FACE. Pinning its feed to the USDC/USD feed makes
-            //    `_tokenToUsdc(x, 6, pUsdc, pUsdc) == x` identically, so face-valuing leg B needs no
-            //    special case anywhere. Left pointing at a volatile aggregator it would price idle USDC
-            //    at that token's price — a silent NAV blow-up on the deposit path.
-            if (p.cbBTCFeed != p.usdcFeed) revert VenueMismatch();
-        } else {
-            if (p.cbBTCSwapTickSpacing <= 0) revert VenueMismatch();
-            if (ICLFactory(clFactory).getPool(p.usdc, p.cbBTC, p.cbBTCSwapTickSpacing) == address(0)) {
-                revert VenueMismatch();
-            }
-        }
-        // Leg A is a real borrowed leg in BOTH shapes, so its swap venue is checked unconditionally.
-        if (p.wethSwapTickSpacing <= 0) revert VenueMismatch();
-        if (ICLFactory(clFactory).getPool(p.usdc, p.weth, p.wethSwapTickSpacing) == address(0)) {
-            revert VenueMismatch();
-        }
-
-        // Reject legs that break an accounting invariant. LEG A may never be the unit of account (it is
-        // USDC's counterparty in both shapes and owns the native-wrap path) nor the gauge reward token.
-        // LEG B may be the unit of account — that IS asset-mode, validated above — but never the reward
-        // token, which `compound()` sells wholesale (and would otherwise liquidate an LP leg).
-        address rewardTok = ICLGauge(p.gauge).rewardToken();
-        if (p.weth == p.usdc || p.weth == rewardTok || p.cbBTC == rewardTok) {
-            revert UnsupportedLeg();
-        }
-        // `compoundImpl`'s oracle floor hardcodes `mulDiv(aeroBal, price8, 1e20)` — i.e. an 18dp
-        // reward token against an 8dp feed. A reward token of any other denomination would mis-scale
-        // that floor by orders of magnitude, so pin it here (reusing the feed-decimals error).
-        if (IERC20Metadata(rewardTok).decimals() != 18) revert UnexpectedFeedDecimals();
-
-        // Leg decimals drive every token↔USDC conversion — read them instead of assuming 8/18. The
-        // [2, 18] band keeps `10 ** dec` well inside uint256 and rejects degenerate 0/1dp tokens.
-        uint8 cbDec = IERC20Metadata(p.cbBTC).decimals();
-        uint8 wethDec = IERC20Metadata(p.weth).decimals();
-        if (cbDec < 2 || cbDec > 18 || wethDec < 2 || wethDec > 18) revert LegDecimalsOutOfRange();
-
-        // Rerange width band: every width (init + per-cycle) must sit on the tickSpacing grid, and
-        // the floor must span at least two spacings so an aligned range is never empty.
-        if (p.tickSpacing <= 0) revert WidthOutOfBounds();
-        uint24 spacing = uint24(p.tickSpacing);
-        if (p.minWidth % spacing != 0 || p.maxWidth % spacing != 0) revert WidthOutOfBounds();
-        if (uint256(p.minWidth) < 2 * uint256(spacing)) revert WidthOutOfBounds();
-        if (p.minWidth > p.maxWidth) revert WidthOutOfBounds();
-        // Ceiling on the band: `_computeTickRange` spans `width/2` ticks each side of the pool tick,
-        // so a width beyond the full tick domain can only ever produce out-of-domain bounds (and, at
-        // the uint24 extreme, an int24 wrap in the `currentTick ± span` arithmetic).
-        if (uint256(p.maxWidth) > 2 * uint256(uint24(TickMath.MAX_TICK))) revert WidthOutOfBounds();
-        _checkWidth(p.width, p.tickSpacing, p.minWidth, p.maxWidth);
-
-        uint16 cfBps = _readCollateralFactor(p.comptroller, p.mUsdc);
-        if (p.targetLtvBps > p.maxLtvBps) revert TargetLtvExceedsMax();
-        if (p.minHealthBps < 10500) revert MinHealthTooLow();
-        if (p.maxLtvBps >= cfBps) revert MaxLtvExceedsCF();
-        // L4: permissionless deleverage triggers at LTV = 1e8 / minHealthBps; that trigger LTV MUST
-        // sit strictly above maxLtvBps, else there is an in-band range anyone can grief-deleverage.
-        // Cross-multiplied (overflow-free): require minHealthBps * maxLtvBps < 1e8.
-        if (uint256(p.minHealthBps) * uint256(p.maxLtvBps) >= 1e8) revert MinHealthMaxLtvConflict();
         // L3 (+L5): bound the oracle / calm-gate params so a misconfig can't silently disable a guard.
         // Bounds admit the confirmed config yet block degenerate values:
         //   maxDelay           ∈ (0, 7 days] — a huge value disables staleness detection
@@ -584,47 +499,22 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         if (p.performanceFeeBps > FeeConstants.MAX_PERFORMANCE_FEE_BPS) revert PerformanceFeeTooHigh();
         if (p.managementFeeBps > MAX_MANAGEMENT_FEE_BPS) revert ManagementFeeTooHigh();
 
-        Layout storage $ = _layout();
-        $.usdc = p.usdc;
-        $.mUsdc = p.mUsdc;
-        $.mCbBTC = p.mCbBTC;
-        $.mWeth = p.mWeth;
-        $.comptroller = p.comptroller;
-        $.cbBTC = p.cbBTC;
-        $.weth = p.weth;
-        $.pool = p.pool;
+        // Non-migratable core stores (the venue subset — legs, markets, pool, gauge, feeds,
+        // spacings, widths, LTV band, derived decimals/ordering/shape — was persisted inside
+        // `applyVenue` above; usdc / mUsdc / usdcFeed / comptroller were stored ahead of it).
         $.npm = p.npm;
-        $.gauge = p.gauge;
         $.swapRouter = p.swapRouter;
-        $.cbBTCFeed = p.cbBTCFeed;
-        $.wethFeed = p.wethFeed;
-        $.usdcFeed = p.usdcFeed;
         $.sequencerFeed = p.sequencerFeed;
         $.aeroUsdFeed = p.aeroUsdFeed;
         $.maxDelay = p.maxDelay;
         $.gracePeriod = p.gracePeriod;
         $.calmDeviationTicks = p.calmDeviationTicks;
         $.twapWindow = p.twapWindow;
-        $.tickSpacing = p.tickSpacing;
-        $.targetLtvBps = p.targetLtvBps;
-        $.maxLtvBps = p.maxLtvBps;
-        $.minHealthBps = p.minHealthBps;
         $.maxSlippageBps = p.maxSlippageBps;
-        $.usdcCollateralFactorBps = cfBps;
         $.managementFeeBps = p.managementFeeBps;
         $.performanceFeeBps = p.performanceFeeBps;
         $.feeRecipient = p.feeRecipient;
         $.lastFeeAccrualTimestamp = block.timestamp;
-        $.cbBTCDecimals = cbDec;
-        $.wethDecimals = wethDec;
-        $.wethIsToken0 = wethIsToken0_;
-        $.wethDeliversNative = p.wethDeliversNative;
-        $.cbBTCSwapTickSpacing = p.cbBTCSwapTickSpacing;
-        $.wethSwapTickSpacing = p.wethSwapTickSpacing;
-        $.width = p.width;
-        $.minWidth = p.minWidth;
-        $.maxWidth = p.maxWidth;
-        $.legBIsAsset = legBIsAsset_;
         // tokenId / posTickLower / posTickUpper / hwmPerShare default to 0 (set in _execute / on first deposit).
     }
 
@@ -637,18 +527,28 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         if (width_ < minWidth_ || width_ > maxWidth_) revert WidthOutOfBounds();
     }
 
-    /// @dev USDC collateral factor (bps) from `Comptroller.markets(mUsdc)`. ABI is
-    ///      `(bool isListed, uint256 collateralFactorMantissa, ...)`; read the 2nd word (1e18-scaled).
-    function _readCollateralFactor(address comptroller_, address mUsdc_) private view returns (uint16 cfBps) {
-        (bool ok, bytes memory ret) = comptroller_.staticcall(abi.encodeWithSignature("markets(address)", mUsdc_));
-        if (!ok || ret.length < 64) revert ComptrollerCallFailed();
-        uint256 cfMantissa;
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            cfMantissa := mload(add(ret, 0x40))
-        }
-        cfBps = uint16(cfMantissa / 1e14); // 0.88e18 / 1e14 = 8800
-        if (cfBps == 0) revert ComptrollerCallFailed();
+    /// @dev The venue subset of `InitParams`, marshalled for `LeveragedAeroVenue.applyVenue` (one
+    ///      shared validation + store path for init and `migrateVenue`). Field-by-field so the Yul
+    ///      IR streams memory copies instead of holding a wide struct-literal live.
+    function _venueParamsOf(InitParams memory p) private pure returns (LeveragedAeroVenue.VenueParams memory v) {
+        v.mCbBTC = p.mCbBTC;
+        v.mWeth = p.mWeth;
+        v.cbBTC = p.cbBTC;
+        v.weth = p.weth;
+        v.pool = p.pool;
+        v.gauge = p.gauge;
+        v.cbBTCFeed = p.cbBTCFeed;
+        v.wethFeed = p.wethFeed;
+        v.tickSpacing = p.tickSpacing;
+        v.cbBTCSwapTickSpacing = p.cbBTCSwapTickSpacing;
+        v.wethSwapTickSpacing = p.wethSwapTickSpacing;
+        v.wethDeliversNative = p.wethDeliversNative;
+        v.width = p.width;
+        v.minWidth = p.minWidth;
+        v.maxWidth = p.maxWidth;
+        v.targetLtvBps = p.targetLtvBps;
+        v.maxLtvBps = p.maxLtvBps;
+        v.minHealthBps = p.minHealthBps;
     }
 
     // ── NAV ──
@@ -1412,6 +1312,60 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
                 || token == $.mCbBTC || token == $.mWeth || (token == aero && _state != State.Settled)
         ) revert CannotRescuePositionToken();
         _pushAllToVault(token);
+    }
+
+    // ── Owner-staged venue migration (see LeveragedAeroVenue for the impls) ──
+
+    /// @notice Commit the destination venue for an in-place pool/pair migration, as
+    ///         `keccak256(abi.encode(LeveragedAeroVenue.VenueParams))`; `bytes32(0)` clears. VAULT
+    ///         OWNER ONLY — this is the venue-selection authority (the same trust root as
+    ///         `rescueToVault`'s owner leg and the vault's fee config), so the hot proposer key can
+    ///         never choose where the fund's liquidity goes. Staging is inert: nothing about the
+    ///         live venue, the position, or share pricing changes until the proposer executes
+    ///         `migrateVenue` with the byte-exact params. Re-staging replaces the previous hash.
+    /// @param venueHash keccak256 of the ABI-encoded `VenueParams` to authorize (0 = clear).
+    function stageVenue(bytes32 venueHash) external {
+        if (msg.sender != Ownable(vault()).owner()) revert NotVaultOwner();
+        LeveragedAeroVenue.stageImpl(venueHash);
+    }
+
+    /// @notice Unwind the WHOLE book to idle USDC while staying `Executed` — the migration's first
+    ///         leg, and a general proposer de-risk lever. Runs `settleImpl`'s exact unwind (exit
+    ///         gauge + CL, repay both legs self-funding any shortfall, redeem all collateral, sweep
+    ///         residual legs to USDC, Chainlink-floored slippage via `maxSlippageBps`) but does NOT
+    ///         settle: no state transition, no push-to-vault, no protocol-fee discharge. Deposits
+    ///         and redeems keep working against the flat book (NAV == idle USDC, oracle-free); the
+    ///         proposer re-enters via `deployIdle` — into the current venue, or into a new one after
+    ///         `migrateVenue`. Idempotent on an already-flat book.
+    function flatten() external onlyProposer nonReentrant {
+        if (_state != State.Executed) revert NotExecuted();
+        LeveragedAeroVenue.flattenImpl();
+    }
+
+    /// @notice Execute the owner-staged venue rewrite. PROPOSER ONLY, and only when `p` byte-matches
+    ///         the staged hash AND the book is flat (no CL position, no hedged basis, no live debt
+    ///         on either current leg market — flatten first). Re-runs the full init-grade venue
+    ///         validation against `p` (venue identity, swap-pool probes, gauge↔pool binding, leg /
+    ///         feed decimals, width band, CF/LTV/health invariants, shape re-derivation), rewrites
+    ///         the venue subset of storage, and consumes the staged hash. Share-ledger continuity is
+    ///         structural: on a flat book NAV is the idle USDC balance, which no venue field
+    ///         touches, so the vault, share balances, HWM, and pending redeem requests are
+    ///         unaffected. Old-leg dust becomes rescuable via `rescueToVault` (its deny-list reads
+    ///         the LIVE legs).
+    /// @param p The full destination venue config; must hash to the staged commitment.
+    function migrateVenue(LeveragedAeroVenue.VenueParams calldata p) external onlyProposer nonReentrant {
+        if (_state != State.Executed) revert NotExecuted();
+        LeveragedAeroVenue.migrateImpl(p);
+    }
+
+    /// @notice Open a FRESH position from a flat `Executed` book, deploying the entire idle USDC
+    ///         balance — the re-entry after a `flatten` (with or without an intervening
+    ///         `migrateVenue`). Runs `executeImpl`'s exact genesis sequence via
+    ///         `LeveragedAeroVenue.redeployImpl`; reverts `PositionAlreadyOpen` when a position is
+    ///         live (top-ups go through `deployIdle`, which conversely cannot mint from flat).
+    function redeploy() external onlyProposer nonReentrant {
+        if (_state != State.Executed) revert NotExecuted();
+        LeveragedAeroVenue.redeployImpl();
     }
 
     /// @dev No tunable params.

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -96,6 +96,24 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     // NFT. Declared once in the manager (same selector); re-declared here so it is on the strategy's
     // public ABI for the rebalancer, exactly as `InsufficientIdleForLeverUp` is. Use `flatten()`.
     error FullUnwindNotSupported();
+    // The migration surface, for the same reason as `FullUnwindNotSupported` above and applied to the
+    // whole set rather than one case: `LeveragedAeroVenue` is DELEGATECALLED, so these revert from THIS
+    // address and are indistinguishable from raw bytes to anyone holding only the strategy ABI —
+    // indexers, the rebalancer (which the operator docs tell to branch on `PositionAlreadyOpen`), and
+    // every `vm.expectRevert` written against the strategy. Selectors match the library's by name and
+    // arity; re-declaring costs zero runtime bytes. The rest of the library's set (`VenueMismatch`,
+    // `UnsupportedLeg`, the width/LTV/health family, `ZeroAddress` via `BaseStrategy`) is already above.
+    error VenueNotStaged(); // migrate without a staged hash, or params that do not match it
+    error BookNotFlat(); // migrate while a CL position, hedged basis, or leg debt is still live
+    error PositionAlreadyOpen(); // redeploy on a book that already has a position (use deployIdle)
+    error ZeroMinOut(); // flatten with a reward balance to sell but no caller floor
+    error BelowOracleFloor(); // a reward-sale fill landed under the AERO/USD oracle floor (L9)
+    error InsufficientIdleAfterFlatten(uint256 idle, uint256 minIdle); // caller's aggregate unwind floor
+
+    // ── Venue-migration events (emitted from this address via delegatecall; see above) ──
+    event VenueStaged(bytes32 venueHash);
+    event Flattened(uint256 idleUsdc);
+    event VenueMigrated(address indexed oldPool, address indexed newPool);
 
     // ── Constants ──
     /// @dev Position `kind` tag for the PriceRouter adapter registry.
@@ -267,7 +285,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         // ── appended for the config-emergent pool shape (keep byte-identical) ──
         bool legBIsAsset; // DERIVED at init: leg-B slot == usdc → asset-as-a-leg shape (packs above)
         // ── appended for the borrow-interest hedge (keep byte-identical) ──
-        uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with the widths above)
+        uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with hedgedDebtB below)
         uint128 hedgedDebtB; // leg-B borrowed principal the LP hedges (0 in asset-mode: leg B never borrows)
         // ── LAST field: appended for the owner-staged venue migration (keep byte-identical) ──
         bytes32 stagedVenueHash; // keccak256(abi.encode(VenueParams)) staged by the vault owner; 0 == none
@@ -630,7 +648,11 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///         sequence lives in `LeveragedAeroManager.executeImpl()` (delegatecalled, so
     ///         `address(this)` / `_layout()` resolve to this clone).
     function _execute() internal override {
-        LeveragedAeroManager.executeImpl();
+        // `minLiquidity == 0`: activation is a once-per-lifetime, owner-driven open on a book holding
+        // only the seed — no depositor state exists for a bad fill to dilute, and the base contract's
+        // activation signature carries no slippage argument. The §8 two-sided `maxSlippageBps` mins
+        // inside the mint still apply. `redeploy` is the repeatable variant and DOES take a floor.
+        LeveragedAeroManager.executeImpl(0);
         // Belt-and-suspenders: keep the fee-accrual clock running even if a clone bypassed
         // _initialize (guards against a ~54-year dt on the first crystallize).
         if (_layout().lastFeeAccrualTimestamp == 0) _layout().lastFeeAccrualTimestamp = block.timestamp;
@@ -1377,9 +1399,16 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///         `migrateVenue`). Runs `executeImpl`'s exact genesis sequence via
     ///         `LeveragedAeroVenue.redeployImpl`; reverts `PositionAlreadyOpen` when a position is
     ///         live (top-ups go through `deployIdle`, which conversely cannot mint from flat).
-    function redeploy() external onlyProposer nonReentrant {
+    ///
+    ///         CLEARS ANY STAGED VENUE HASH — re-entering the current venue is the documented rollback
+    ///         of an aborted migration, and an authorization that survived it could be fired later
+    ///         into unevaluated conditions. Re-stage (owner) if the migration is still intended.
+    /// @param minLiquidity Minimum CL liquidity the fresh mint must produce. Required here and not on
+    ///                     `execute` because this path is repeatable and runs against live depositors;
+    ///                     the mint's own §8 mins come off the same `slot0()` it executes at.
+    function redeploy(uint256 minLiquidity) external onlyProposer nonReentrant {
         if (_state != State.Executed) revert NotExecuted();
-        LeveragedAeroVenue.redeployImpl();
+        LeveragedAeroVenue.redeployImpl(minLiquidity);
     }
 
     /// @dev No tunable params.

--- a/src/leveraged-aero/sherwood/interfaces/ISlipstream.sol
+++ b/src/leveraged-aero/sherwood/interfaces/ISlipstream.sol
@@ -187,6 +187,9 @@ interface ICLGauge {
     /// @notice The ERC-20 token distributed as gauge rewards (AERO on Base).
     function rewardToken() external view returns (address);
 
+    /// @notice The Slipstream CL pool this gauge is bound to (used by the venue gauge↔pool binding check).
+    function pool() external view returns (address);
+
     /// @notice Rewards currently claimable by `account` for the staked position `tokenId`.
     /// @dev Read by `LeveragedAerodromeCLStrategy.compound` to tell a GENUINE no-op (nothing to harvest)
     ///      apart from a real harvest BEFORE it crystallises fees — a poll must have no side effects.

--- a/test/Multicall.integration.t.sol
+++ b/test/Multicall.integration.t.sol
@@ -97,7 +97,22 @@ contract MulticallIntegrationTest is BaseTest {
     // Events
     event MulticallExecuted(address indexed initiator, uint256 callsCount);
 
+    /// @dev PINNED Base fork. Previously this suite inherited the CLI `--fork-url base` at `latest`,
+    ///      and `updatePosition` → Moonwell's timestamp-based `accrueInterest` reverts
+    ///      `could not calculate block delta` whenever the live head's state is momentarily
+    ///      inconsistent with a market's last-accrued timestamp — a nondeterministic flake with no
+    ///      relation to the code under test. Pinning removes the drift (repo policy: fork tests MUST
+    ///      pin). The `make strategy-multicall` target drops `--fork-url base` so this self-fork is the
+    ///      only one; the `vm.fee(0)` / `vm.txGasPrice(0)` pair is the op-revm Isthmus operator-fee
+    ///      workaround the LPV2 integration suites already use. All referenced contracts
+    ///      (cbBTC_STRATEGY_FACTORY, STRATEGY_MULTICALL, MAMO_STRATEGY_REGISTRY, the Moonwell markets)
+    ///      have code at this block.
+    uint256 internal constant PINNED_BLOCK = 49_600_000;
+
     function setUp() public override {
+        vm.createSelectFork(vm.envString("BASE_RPC_URL"), PINNED_BLOCK);
+        vm.txGasPrice(0);
+        vm.fee(0);
         // workaround to make test contract work with mappings
         vm.makePersistent(DEFAULT_TEST_CONTRACT);
         super.setUp();

--- a/test/leveraged-aero/LayoutParity.t.sol
+++ b/test/leveraged-aero/LayoutParity.t.sol
@@ -4,11 +4,12 @@ pragma solidity ^0.8.28;
 import {Test} from "@forge-std/Test.sol";
 
 /// @title LayoutParity
-/// @notice Guards the CORRUPTION-CRITICAL invariant that `LeveragedAerodromeCLStrategy.sol`
-///         and `LeveragedAeroManager.sol` share an identical diamond-storage triplet:
-///         the `RedeemRequest` struct, the `Layout` struct (field types/order/names),
-///         and the `STORAGE_SLOT` literal `0x405ae0b1...`. The manager is delegatecalled
-///         by the strategy, so any drift silently corrupts storage.
+/// @notice Guards the CORRUPTION-CRITICAL invariant that `LeveragedAerodromeCLStrategy.sol`,
+///         `LeveragedAeroManager.sol` AND `LeveragedAeroVenue.sol` share an identical
+///         diamond-storage triplet: the `RedeemRequest` struct, the `Layout` struct (field
+///         types/order/names), and the `STORAGE_SLOT` literal `0x405ae0b1...`. Both libraries are
+///         delegatecalled by the strategy, so any drift silently corrupts storage. The script
+///         diffs manager AND venue against the strategy reference copy (empty == parity).
 /// @dev Uses FFI to extract each block from the on-disk sources and diff them. Run with:
 ///        forge test --match-path 'test/leveraged-aero/*' --ffi -vv
 ///      Line comments are stripped before comparison, so the check tolerates the one

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -11,7 +11,13 @@ import {MockCLGauge} from "../mocks/MockCLGauge.sol";
 import {MockCLFactory, MockCLPool} from "../mocks/MockCLPool.sol";
 import {MockComptroller} from "../mocks/MockMoonwellMarket.sol";
 import {MockToken} from "../mocks/MockToken.sol";
-import {MockChainlinkFeed, MockClSwapRouter, MockLendingMarket, MockNpm} from "./LeveragedAeroVenuesHarness.sol";
+import {
+    MockAeroV2Factory,
+    MockChainlinkFeed,
+    MockClSwapRouter,
+    MockLendingMarket,
+    MockNpm
+} from "./LeveragedAeroVenuesHarness.sol";
 
 import {Test} from "@forge-std/Test.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
@@ -80,6 +86,10 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
     /// @dev Leg-A price (8dp) implied by the pool's sqrtP, for THIS fixture's ordering (legA = token1).
     uint256 internal legAPrice8;
 
+    /// @dev Aerodrome v2 PoolFactory, hardcoded in `LeveragedAeroValuation` and probed by venue
+    ///      validation to prove the reward token has a USDC route. Etched below (no code otherwise).
+    address internal constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
+
     function setUp() public {
         vm.warp(1_800_000_000); // a sane clock for feed freshness / sequencer grace
 
@@ -100,10 +110,17 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
 
         gauge = new MockCLGauge(address(aero));
         gauge.setPool(address(pool));
+        pool.setGauge(address(gauge));
+        // The reward-route probe in venue validation reads a HARDCODED v2 factory address;
+        // place code there so the AERO/USDC route resolves in this fork-free suite.
+        vm.etch(AERO_V2_FACTORY, address(new MockAeroV2Factory(address(aero), address(usdc), address(0xA2F))).code);
         comptroller = new MockComptroller();
         mUsdc = new MockLendingMarket(address(usdc));
         mLegA = new MockLendingMarket(address(legA));
         npm = new MockNpm(pool);
+        // Real ERC-721 custody: a staked position is OWNED by the gauge, so any liquidity call
+        // that forgets to unstake first reverts here exactly as it would on chain.
+        gauge.setNpm(address(npm));
         router = new MockClSwapRouter();
 
         sequencerFeed = new MockChainlinkFeed(0, 8, 1, block.timestamp - 2 hours); // 0 == sequencer up

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -99,6 +99,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         legAPrice8 = _legAPriceFromSqrtP(sqrtP);
 
         gauge = new MockCLGauge(address(aero));
+        gauge.setPool(address(pool));
         comptroller = new MockComptroller();
         mUsdc = new MockLendingMarket(address(usdc));
         mLegA = new MockLendingMarket(address(legA));

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -90,6 +90,12 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
     ///      validation to prove the reward token has a USDC route. Etched below (no code otherwise).
     address internal constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
 
+    /// @dev `LeveragedAeroVenue.applyVenue` pins the canonical Slipstream CLFactory rather than
+    ///      trusting `pool.factory()`, so a fork-free test has to place the registry HERE. Etch is
+    ///      safe despite `MockCLFactory` being storage-based: only the code is copied, and every
+    ///      `setPool` below writes to the etched address's own storage.
+    address internal constant AERODROME_CL_FACTORY = 0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A;
+
     function setUp() public {
         vm.warp(1_800_000_000); // a sane clock for feed freshness / sequencer grace
 
@@ -102,8 +108,10 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         uint160 sqrtP = TickMath.getSqrtRatioAtTick(TICK);
         pool.setSqrtPriceX96(sqrtP);
         pool.setTick(TICK); // also pins the TWAP tick → calm-gate passes
-        clFactory = new MockCLFactory();
-        pool.setFactory(address(clFactory));
+        clFactory = MockCLFactory(AERODROME_CL_FACTORY);
+        vm.etch(AERODROME_CL_FACTORY, address(new MockCLFactory()).code);
+        pool.setFactory(AERODROME_CL_FACTORY);
+        clFactory.setPool(address(legA), address(usdc), SPACING, address(pool));
         clFactory.setPool(address(usdc), address(legA), LEG_A_SWAP_SPACING, makeAddr("legASwapPool"));
 
         legAPrice8 = _legAPriceFromSqrtP(sqrtP);

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -665,6 +665,39 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         assertGe(healthAfter, 12_000, "health restored above the minimum");
     }
 
+    /// @dev THE CLAMP, in the collateral≈0 tail it exists for. `deleverageImpl` targets
+    ///      `targetDebt = collateral × 1e4 / targetHealth`; once collateral is dust that floors to 0, so
+    ///      the requested `repayUsd == debtBefore` and `_leverDown`'s orphaned-NFT guard
+    ///      (`repayUsd >= debtUsd → FullUnwindNotSupported`) would fire — turning the PERMISSIONLESS
+    ///      health valve OFF in exactly the distressed state it exists for. The clamp
+    ///      (`repayUsd = debtBefore - 1`) keeps `num < den` so ≥1 liquidity and the re-stake survive.
+    ///
+    ///      Construction: after execute, set the mUSDC exchange rate to `1e18 / mBal + 1`, which drives
+    ///      the collateral read to EXACTLY 1 unit — `collateral = mBal × rate / 1e18 ∈ [1e18, 1e18+mBal)`
+    ///      / 1e18 = 1. That is the only collateral value (with 0) for which `targetDebt` floors to 0
+    ///      while health can still strictly improve. Against the clamp deletion this reverts
+    ///      `FullUnwindNotSupported`.
+    function testDeleverageClampKeepsTheValveAliveWhenCollateralIsDust() public {
+        _execute(SEED);
+        uint256 mBal = mUsdc.balanceOf(address(strategy));
+        mUsdc.setExchangeRateStored(1e18 / mBal + 1); // collateral read → exactly 1 unit
+
+        (uint256 collateralBefore, uint256 debtBefore) = _collateralAndDebt();
+        assertEq(collateralBefore, 1, "collateral driven to the 1-unit dust tail (targetDebt floors to 0)");
+        assertGt(debtBefore, 0, "debt still live");
+        assertEq((collateralBefore * 10_000) / debtBefore, 0, "health is zero, the valve must engage");
+
+        uint256 tokenIdBefore = strategy.layout().tokenId;
+        vm.prank(makeAddr("keeper"));
+        strategy.deleverage(0); // clamp path; without it, FullUnwindNotSupported
+
+        assertLt(mLegA.borrowBalance(address(strategy)), debtBefore, "debt was repaid down");
+        assertEq(strategy.layout().tokenId, tokenIdBefore, "position survived, not fully unwound/orphaned");
+        assertTrue(
+            gauge.stakedContains(address(strategy), strategy.layout().tokenId), "the >=1-liquidity re-stake fired"
+        );
+    }
+
     // ==================== THE CRUX INVARIANT ====================
 
     /**

--- a/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
@@ -13,6 +13,7 @@ import {MockCLFactory, MockCLPool} from "../mocks/MockCLPool.sol";
 import {MockComptroller} from "../mocks/MockMoonwellMarket.sol";
 import {MockToken} from "../mocks/MockToken.sol";
 import {
+    MockAeroV2Factory,
     MockAeroV2Router,
     MockChainlinkFeed,
     MockClSwapRouter,
@@ -105,6 +106,10 @@ contract LeveragedAeroCompoundHedgeUnitTest is Test {
     /// @dev Leg-A price (8dp) implied by the pool's `sqrtP` for this fixture's ordering (legA = token1).
     uint256 internal legAPrice8;
 
+    /// @dev Aerodrome v2 PoolFactory, hardcoded in `LeveragedAeroValuation` and probed by venue
+    ///      validation to prove the reward token has a USDC route. Etched below (no code otherwise).
+    address internal constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
+
     function setUp() public {
         vm.warp(1_800_000_000);
 
@@ -123,10 +128,17 @@ contract LeveragedAeroCompoundHedgeUnitTest is Test {
 
         gauge = new MockCLGauge(address(aero));
         gauge.setPool(address(pool));
+        pool.setGauge(address(gauge));
+        // The reward-route probe in venue validation reads a HARDCODED v2 factory address;
+        // place code there so the AERO/USDC route resolves in this fork-free suite.
+        vm.etch(AERO_V2_FACTORY, address(new MockAeroV2Factory(address(aero), address(usdc), address(0xA2F))).code);
         comptroller = new MockComptroller();
         mUsdc = new MockLendingMarket(address(usdc));
         mLegA = new MockLendingMarket(address(legA));
         npm = new MockNpm(pool);
+        // Real ERC-721 custody: a staked position is OWNED by the gauge, so any liquidity call
+        // that forgets to unstake first reverts here exactly as it would on chain.
+        gauge.setNpm(address(npm));
         router = new MockClSwapRouter();
 
         sequencerFeed = new MockChainlinkFeed(0, 8, 1, block.timestamp - 2 hours);

--- a/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
@@ -680,6 +680,41 @@ contract LeveragedAeroCompoundHedgeUnitTest is Test {
         assertGt(_collateralUsdc(), collateralBefore, "the stray balance was harvested and redeployed");
     }
 
+    /// @dev DUST NO-OP, the compound-side twin of `flatten`'s `_sellRewardBalance` skip. A reward
+    ///      balance worth under one micro-USD prices to a ZERO oracle floor, and the router fills it
+    ///      at 0 USDC — so the nonzero `minUsdcOut` compound is FORCED to demand (the `ZeroMinOut`
+    ///      belt rejects 0) makes the AERO→USDC swap revert on the router's own min-out check. Without
+    ///      the `floor == 0` early return, a single dust donation to the gauge bricks every subsequent
+    ///      `compound`. `1e6` wei AERO × `$1` (1e8) / 1e20 == 0 (6dp), so it lands in the dust band.
+    function testCompoundNoOpsOnADustRewardInsteadOfBricking() public {
+        _armBook();
+        _clearRewards();
+        aero.mint(address(strategy), 1e6); // sub-micro-USD: floor rounds to 0
+
+        uint256 collateralBefore = _collateralUsdc();
+        // A nonzero minUsdcOut is mandatory (ZeroMinOut belt); the dust skip must fire BEFORE the swap.
+        _compound(1);
+
+        assertEq(aero.balanceOf(address(strategy)), 1e6, "dust left in place, not force-sold at a loss");
+        assertEq(_collateralUsdc(), collateralBefore, "no redeploy: the harvest cleanly no-oped");
+    }
+
+    /// @dev The skip must NOT widen the guard for a real tranche: the smallest balance whose HAIRCUT
+    ///      floor is nonzero still swaps and redeploys. The threshold is the post-`maxSlippageBps`
+    ///      floor, not the raw one — at `1e12` the raw floor is 1 unit and the 100bps haircut rounds
+    ///      it back to 0 (still skipped); `2e12` gives raw 2, haircut floor 1, the first that sells.
+    function testCompoundStillHarvestsTheSmallestNonDustBalance() public {
+        _armBook();
+        _clearRewards();
+        aero.mint(address(strategy), 2e12);
+
+        uint256 collateralBefore = _collateralUsdc();
+        _compound(1);
+
+        assertEq(aero.balanceOf(address(strategy)), 0, "above-dust balance is sold, not skipped");
+        assertGt(_collateralUsdc(), collateralBefore, "the tranche was harvested and redeployed");
+    }
+
     // ==================== 3. FEE TIMING (findings 3 + 4) ====================
 
     /**

--- a/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
@@ -122,6 +122,7 @@ contract LeveragedAeroCompoundHedgeUnitTest is Test {
         legAPrice8 = _legAPriceFromSqrtP(pool.sqrtPriceX96());
 
         gauge = new MockCLGauge(address(aero));
+        gauge.setPool(address(pool));
         comptroller = new MockComptroller();
         mUsdc = new MockLendingMarket(address(usdc));
         mLegA = new MockLendingMarket(address(legA));

--- a/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
@@ -110,6 +110,12 @@ contract LeveragedAeroCompoundHedgeUnitTest is Test {
     ///      validation to prove the reward token has a USDC route. Etched below (no code otherwise).
     address internal constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
 
+    /// @dev `LeveragedAeroVenue.applyVenue` pins the canonical Slipstream CLFactory rather than
+    ///      trusting `pool.factory()`, so a fork-free test has to place the registry HERE. Etch is
+    ///      safe despite `MockCLFactory` being storage-based: only the code is copied, and every
+    ///      `setPool` below writes to the etched address's own storage.
+    address internal constant AERODROME_CL_FACTORY = 0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A;
+
     function setUp() public {
         vm.warp(1_800_000_000);
 
@@ -120,8 +126,10 @@ contract LeveragedAeroCompoundHedgeUnitTest is Test {
         pool = new MockCLPool(address(usdc), address(legA), SPACING);
         pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK));
         pool.setTick(TICK);
-        clFactory = new MockCLFactory();
-        pool.setFactory(address(clFactory));
+        clFactory = MockCLFactory(AERODROME_CL_FACTORY);
+        vm.etch(AERODROME_CL_FACTORY, address(new MockCLFactory()).code);
+        pool.setFactory(AERODROME_CL_FACTORY);
+        clFactory.setPool(address(legA), address(usdc), SPACING, address(pool));
         clFactory.setPool(address(usdc), address(legA), LEG_A_SWAP_SPACING, makeAddr("legASwapPool"));
 
         legAPrice8 = _legAPriceFromSqrtP(pool.sqrtPriceX96());

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -77,6 +77,12 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     ///      validation to prove the reward token has a USDC route. Etched below (no code otherwise).
     address internal constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
 
+    /// @dev `LeveragedAeroVenue.applyVenue` pins the canonical Slipstream CLFactory rather than
+    ///      trusting `pool.factory()`, so a fork-free test has to place the registry HERE. Etch is
+    ///      safe despite `MockCLFactory` being storage-based: only the code is copied, and every
+    ///      `setPool` below writes to the etched address's own storage.
+    address internal constant AERODROME_CL_FACTORY = 0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A;
+
     function setUp() public {
         usdc = new MockToken("USD Coin", "USDC", 6);
         legA = new MockToken("Leg A", "LEGA", 18);
@@ -88,8 +94,10 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
 
         // Default ordering: leg B is token0, leg A is token1 (i.e. `wethIsToken0 == false`).
         pool = new MockCLPool(address(legB), address(legA), SPACING);
-        clFactory = new MockCLFactory();
-        pool.setFactory(address(clFactory));
+        clFactory = MockCLFactory(AERODROME_CL_FACTORY);
+        vm.etch(AERODROME_CL_FACTORY, address(new MockCLFactory()).code);
+        pool.setFactory(AERODROME_CL_FACTORY);
+        clFactory.setPool(address(legA), address(legB), SPACING, address(pool));
         // Both leg<->USDC swap venues exist at their configured spacings (init probes for them).
         _registerSwapPools(address(legB), address(legA));
 
@@ -171,6 +179,14 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         clFactory.setPool(address(usdc), legA_, LEG_A_SWAP_SPACING, makeAddr("legASwapPool"));
     }
 
+    /// @dev Re-register the LP pool in the canonical factory at its CURRENT pair + spacing.
+    ///      `applyVenue` requires `CLFactory.getPool(pair, spacing) == pool`, so any test that
+    ///      rewires `pool`'s tokens must re-register it or it stops being an adoptable venue and
+    ///      every later guard becomes unreachable behind `VenueMismatch`.
+    function _registerLpPool() internal {
+        clFactory.setPool(pool.token0(), pool.token1(), pool.tickSpacing(), address(pool));
+    }
+
     /// @dev Rewire the pool pair + both borrow markets + both swap venues so `legB_`/`legA_` clear
     ///      the venue-identity guards; lets a test reach a LATER guard (leg identity, decimals) with
     ///      a swapped leg.
@@ -179,6 +195,10 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         mLegB.setUnderlying(legB_);
         mLegA.setUnderlying(legA_);
         _registerSwapPools(legB_, legA_);
+        // LAST: `_registerSwapPools` writes (usdc, legB_, LEG_B_SWAP_SPACING), which is the SAME
+        // factory key as the LP pool whenever that spacing equals SPACING. One key holds one pool,
+        // so the LP registration has to win — the swap probe only asserts non-zero.
+        _registerLpPool();
     }
 
     /// @dev `_baseParams()` with the `i`-th address member zeroed. An if-ladder rather than a loop
@@ -255,7 +275,8 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     }
 
     function testInitDerivesWethIsToken0True() public {
-        pool.setTokens(address(legA), address(legB)); // leg A first
+        pool.setTokens(address(legA), address(legB));
+        _registerLpPool(); // leg A first
         assertTrue(_init(_baseParams()).layout().wethIsToken0, "leg A sorts first");
     }
 
@@ -316,26 +337,108 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         s.initialize(address(oddVault), proposer, abi.encode(p));
     }
 
+    // ==================== GAUGE BINDING — ONE DIRECTION AT A TIME ====================
+
+    /// @dev UNMASKING. The gauge↔pool binding is two checks that share the `VenueMismatch` selector,
+    ///      and every existing fixture breaks BOTH at once — so deleting `gauge.pool() != pool` left
+    ///      the suite green, its partner absorbing the mutant. That is the same-selector masking the
+    ///      clause-by-clause work removed elsewhere. Here `pool.gauge()` is CORRECT and only the
+    ///      gauge lies, so this test can be killed by exactly one of the two clauses.
+    function testInitRejectsAGaugeThatMisreportsItsPool() public {
+        MockCLGauge liar = new MockCLGauge(address(aero));
+        liar.setPool(makeAddr("someOtherPool")); // the lie
+        pool.setGauge(address(liar)); // reciprocal AGREES, so it cannot fire
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.gauge = address(liar);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.VenueMismatch.selector);
+    }
+
+    /// @dev The mirror, isolating the other clause: the gauge tells the truth and the POOL names a
+    ///      different gauge. Only `pool.gauge() != gauge` can fire.
+    function testInitRejectsAPoolThatNamesADifferentGauge() public {
+        MockCLGauge honest = new MockCLGauge(address(aero));
+        honest.setPool(address(pool)); // truthful, so its clause passes
+        pool.setGauge(makeAddr("someOtherGauge")); // the lie
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.gauge = address(honest);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.VenueMismatch.selector);
+    }
+
+    // ==================== CANONICAL FACTORY BINDING ====================
+
+    /// @dev The seam this closes: `pool.factory()` is SELF-ATTESTED. Before the binding, a pool that
+    ///      named an attacker-controlled "factory" was adopted on that factory's say-so, and the two
+    ///      leg↔USDC probes then asked THAT contract whether the swap venues existed.
+    function testInitRejectsAPoolThatNominatesAForeignFactory() public {
+        MockCLFactory rogue = new MockCLFactory();
+        rogue.setPool(address(usdc), address(legB), LEG_B_SWAP_SPACING, makeAddr("rogueLegBPool"));
+        rogue.setPool(address(usdc), address(legA), LEG_A_SWAP_SPACING, makeAddr("rogueLegAPool"));
+        rogue.setPool(address(legB), address(legA), SPACING, address(pool));
+        // Fully self-consistent under its own registry — and rejected anyway.
+        pool.setFactory(address(rogue));
+        _expectInitRevert(_baseParams(), LeveragedAerodromeCLStrategy.VenueMismatch.selector);
+    }
+
+    /// @dev The other half: claiming the canonical factory is not enough, it must actually have
+    ///      registered this pool at the declared pair + spacing.
+    function testInitRejectsAPoolTheCanonicalFactoryDoesNotRegister() public {
+        clFactory.setPool(address(legB), address(legA), SPACING, address(0));
+        _expectInitRevert(_baseParams(), LeveragedAerodromeCLStrategy.VenueMismatch.selector);
+    }
+
+    /// @dev And it must be registered as THIS pool — a look-alike at the same key is not the venue.
+    function testInitRejectsAnImpostorAtTheRegisteredKey() public {
+        clFactory.setPool(address(legB), address(legA), SPACING, makeAddr("someOtherPool"));
+        _expectInitRevert(_baseParams(), LeveragedAerodromeCLStrategy.VenueMismatch.selector);
+    }
+
+    // ==================== TWAP AVAILABILITY (live at init) ====================
+
+    /// @dev REGRESSION for the vacuous-probe bug: `$.twapWindow` used to be written AFTER
+    ///      `applyVenue`, so the probe ran as `observe([0, 0])` — which every pool answers — and a
+    ///      pool younger than the window was adoptable at init, then bricked `execute`/`rerange`.
+    ///      With the store hoisted ahead of `applyVenue` the probe uses the REAL window, so this
+    ///      pool is rejected up front. Fails against the pre-fix ordering.
+    function testInitProbesTheTwapWindowAgainstTheRealHistory() public {
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        pool.setMaxObservationAge(p.twapWindow - 1); // history one second short of the window
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.VenueMismatch.selector);
+    }
+
+    /// @dev Boundary companion: history exactly spanning the window is adoptable, so the guard is
+    ///      rejecting on the window and not merely on the knob being set.
+    function testInitAcceptsAPoolWhoseHistoryExactlySpansTheWindow() public {
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        pool.setMaxObservationAge(p.twapWindow);
+        LeveragedAerodromeCLStrategy s = _clone();
+        s.initialize(address(vault), proposer, abi.encode(p));
+        assertEq(s.layout().twapWindow, p.twapWindow, "twapWindow stored");
+    }
+
     // ==================== VENUE IDENTITY GUARDS ====================
 
     function testInitRevertsOnPoolTickSpacingMismatch() public {
         pool.setTickSpacing(200);
+        _registerLpPool();
         _expectInitRevert(_baseParams(), LeveragedAerodromeCLStrategy.VenueMismatch.selector);
     }
 
     function testInitRevertsWhenPoolToken0IsForeign() public {
         pool.setTokens(address(aero), address(legA));
+        _registerLpPool();
         _expectInitRevert(_baseParams(), LeveragedAerodromeCLStrategy.VenueMismatch.selector);
     }
 
     function testInitRevertsWhenPoolToken1IsForeign() public {
         pool.setTokens(address(legB), address(aero));
+        _registerLpPool();
         _expectInitRevert(_baseParams(), LeveragedAerodromeCLStrategy.VenueMismatch.selector);
     }
 
     /// @dev Both pool tokens are legs but the SAME leg twice — the set compare must reject it.
     function testInitRevertsWhenPoolIsNotTheLegPair() public {
         pool.setTokens(address(legB), address(legB));
+        _registerLpPool();
         _expectInitRevert(_baseParams(), LeveragedAerodromeCLStrategy.VenueMismatch.selector);
     }
 
@@ -418,6 +521,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     ///      selects the pool token ordering so both `wethIsToken0` branches are reachable.
     function _assetModeParams(bool legAFirst) internal returns (LeveragedAerodromeCLStrategy.InitParams memory p) {
         pool.setTokens(legAFirst ? address(legA) : address(usdc), legAFirst ? address(usdc) : address(legA));
+        _registerLpPool();
         mLegA.setUnderlying(address(legA));
         clFactory.setPool(address(usdc), address(legA), LEG_A_SWAP_SPACING, makeAddr("legASwapPool"));
 
@@ -496,11 +600,13 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     ///      token — or the degenerate all-USDC pool — is rejected by the same pair check as before.
     function testInitRevertsWhenAssetModePoolIsNotTheLegAUsdcPair() public {
         LeveragedAerodromeCLStrategy.InitParams memory p = _assetModeParams(false);
-        pool.setTokens(address(usdc), address(legB)); // legB is a foreign token now, not a slot
+        pool.setTokens(address(usdc), address(legB));
+        _registerLpPool(); // legB is a foreign token now, not a slot
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.VenueMismatch.selector);
 
         p = _assetModeParams(false);
-        pool.setTokens(address(usdc), address(usdc)); // degenerate USDC/USDC
+        pool.setTokens(address(usdc), address(usdc));
+        _registerLpPool(); // degenerate USDC/USDC
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.VenueMismatch.selector);
     }
 
@@ -525,6 +631,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         mLegB.setUnderlying(address(legB));
         clFactory.setPool(address(usdc), address(legB), LEG_B_SWAP_SPACING, makeAddr("legBSwapPool"));
         clFactory.setPool(address(usdc), address(usdc), LEG_A_SWAP_SPACING, makeAddr("bogusSelfPool"));
+        _registerLpPool(); // after the swap pools — same key collision as `_wireLegs`
 
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.weth = address(usdc);
@@ -631,6 +738,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
 
     function testInitRevertsOnNonPositiveTickSpacing() public {
         pool.setTickSpacing(0);
+        _registerLpPool();
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.tickSpacing = 0;
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
@@ -640,6 +748,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     ///      the correct predicate (the pool is rewired so the identity guard passes first).
     function testInitRevertsOnNegativeTickSpacing() public {
         pool.setTickSpacing(-100);
+        _registerLpPool();
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.tickSpacing = -100;
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -10,6 +10,7 @@ import {MockCLFactory, MockCLPool} from "../mocks/MockCLPool.sol";
 import {MockComptroller, MockMoonwellMarket} from "../mocks/MockMoonwellMarket.sol";
 import {MockPriceFeed} from "../mocks/MockPriceFeed.sol";
 import {MockToken} from "../mocks/MockToken.sol";
+import {MockAeroV2Factory} from "./LeveragedAeroVenuesHarness.sol";
 
 import {Test, Vm} from "@forge-std/Test.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
@@ -72,6 +73,10 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     /// @dev `2 * TickMath.MAX_TICK` — the ceiling `_initialize` enforces on `maxWidth`.
     uint24 internal constant MAX_BAND_WIDTH = 1_774_544;
 
+    /// @dev Aerodrome v2 PoolFactory, hardcoded in `LeveragedAeroValuation` and probed by venue
+    ///      validation to prove the reward token has a USDC route. Etched below (no code otherwise).
+    address internal constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
+
     function setUp() public {
         usdc = new MockToken("USD Coin", "USDC", 6);
         legA = new MockToken("Leg A", "LEGA", 18);
@@ -90,6 +95,10 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
 
         gauge = new MockCLGauge(address(aero));
         gauge.setPool(address(pool));
+        pool.setGauge(address(gauge));
+        // The reward-route probe in venue validation reads a HARDCODED v2 factory address;
+        // place code there so the AERO/USDC route resolves in this fork-free suite.
+        vm.etch(AERO_V2_FACTORY, address(new MockAeroV2Factory(address(aero), address(usdc), address(0xA2F))).code);
         comptroller = new MockComptroller();
         mUsdc = new MockMoonwellMarket(address(usdc));
         mLegA = new MockMoonwellMarket(address(legA));
@@ -275,7 +284,11 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     function testInitRevertsOnNonEighteenDecimalRewardToken() public {
         MockToken sixDpReward = new MockToken("Reward", "RWD", 6);
         MockCLGauge oddGauge = new MockCLGauge(address(sixDpReward));
-        oddGauge.setPool(address(pool)); // bound correctly so the reward-decimals check is what fires
+        // Bind BOTH directions so the reward-decimals check is what fires: the gauge↔pool binding is
+        // reciprocal, and leaving `pool.gauge()` pointing at the default gauge would mask this guard
+        // behind a `VenueMismatch`.
+        oddGauge.setPool(address(pool));
+        pool.setGauge(address(oddGauge));
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.gauge = address(oddGauge);
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.UnexpectedFeedDecimals.selector);

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -89,6 +89,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         _registerSwapPools(address(legB), address(legA));
 
         gauge = new MockCLGauge(address(aero));
+        gauge.setPool(address(pool));
         comptroller = new MockComptroller();
         mUsdc = new MockMoonwellMarket(address(usdc));
         mLegA = new MockMoonwellMarket(address(legA));
@@ -274,6 +275,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     function testInitRevertsOnNonEighteenDecimalRewardToken() public {
         MockToken sixDpReward = new MockToken("Reward", "RWD", 6);
         MockCLGauge oddGauge = new MockCLGauge(address(sixDpReward));
+        oddGauge.setPool(address(pool)); // bound correctly so the reward-decimals check is what fires
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.gauge = address(oddGauge);
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.UnexpectedFeedDecimals.selector);

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -301,6 +301,18 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.UnexpectedFeedDecimals.selector);
     }
 
+    /// @dev The LEG feeds are pinned to 8dp at validation time too, not only at read time — a non-8dp
+    ///      aggregator mis-scales every token↔USDC conversion by orders of magnitude. `wethFeed` had a
+    ///      test; `cbBTCFeed` (the very next clause, same selector) did not, so a mutant deleting the
+    ///      `cbBTCFeed.decimals() != 8` line alone survived. Only `cbBTCFeed` is odd here (others 8dp),
+    ///      so this clause is what fires. Leg A stays 8dp so the earlier `wethFeed` clause passes.
+    function testInitRevertsOnNonEightDecimalCbBtcFeed() public {
+        MockPriceFeed odd = new MockPriceFeed(1e18, 18, block.timestamp);
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.cbBTCFeed = address(odd);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.UnexpectedFeedDecimals.selector);
+    }
+
     /// @dev The same floor hardcodes an 18dp reward token (`mulDiv(aeroBal, price8, 1e20)`).
     function testInitRevertsOnNonEighteenDecimalRewardToken() public {
         MockToken sixDpReward = new MockToken("Reward", "RWD", 6);

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -103,6 +103,7 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         clFactory.setPool(address(usdc), address(legA), LEG_A_SWAP_SPACING, makeAddr("legASwapPool"));
 
         gauge = new MockCLGauge(address(aero));
+        gauge.setPool(address(pool));
         comptroller = new MockComptroller();
         mUsdc = new MockLendingMarket(address(usdc));
         mLegB = new MockLendingMarket(address(legB));

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -92,6 +92,12 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
     ///      validation to prove the reward token has a USDC route. Etched below (no code otherwise).
     address internal constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
 
+    /// @dev `LeveragedAeroVenue.applyVenue` pins the canonical Slipstream CLFactory rather than
+    ///      trusting `pool.factory()`, so a fork-free test has to place the registry HERE. Etch is
+    ///      safe despite `MockCLFactory` being storage-based: only the code is copied, and every
+    ///      `setPool` below writes to the etched address's own storage.
+    address internal constant AERODROME_CL_FACTORY = 0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A;
+
     function setUp() public {
         vm.warp(1_800_000_000);
 
@@ -103,8 +109,10 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         pool = new MockCLPool(address(legB), address(legA), SPACING);
         pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK));
         pool.setTick(TICK);
-        clFactory = new MockCLFactory();
-        pool.setFactory(address(clFactory));
+        clFactory = MockCLFactory(AERODROME_CL_FACTORY);
+        vm.etch(AERODROME_CL_FACTORY, address(new MockCLFactory()).code);
+        pool.setFactory(AERODROME_CL_FACTORY);
+        clFactory.setPool(address(legA), address(legB), SPACING, address(pool));
         clFactory.setPool(address(usdc), address(legB), LEG_B_SWAP_SPACING, makeAddr("legBSwapPool"));
         clFactory.setPool(address(usdc), address(legA), LEG_A_SWAP_SPACING, makeAddr("legASwapPool"));
 

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -13,6 +13,7 @@ import {MockCLFactory, MockCLPool} from "../mocks/MockCLPool.sol";
 import {MockComptroller} from "../mocks/MockMoonwellMarket.sol";
 import {MockToken} from "../mocks/MockToken.sol";
 import {
+    MockAeroV2Factory,
     MockAeroV2Router,
     MockChainlinkFeed,
     MockClSwapRouter,
@@ -87,6 +88,10 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
     ///      two feed prices: raw = P_LEG_B·1e18 / (P_LEG_A·1e8) ≈ 3.33e13 ⇒ tick ≈ ln(raw)/ln(1.0001).
     int24 internal constant TICK = 311_100;
 
+    /// @dev Aerodrome v2 PoolFactory, hardcoded in `LeveragedAeroValuation` and probed by venue
+    ///      validation to prove the reward token has a USDC route. Etched below (no code otherwise).
+    address internal constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
+
     function setUp() public {
         vm.warp(1_800_000_000);
 
@@ -105,11 +110,18 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
 
         gauge = new MockCLGauge(address(aero));
         gauge.setPool(address(pool));
+        pool.setGauge(address(gauge));
+        // The reward-route probe in venue validation reads a HARDCODED v2 factory address;
+        // place code there so the AERO/USDC route resolves in this fork-free suite.
+        vm.etch(AERO_V2_FACTORY, address(new MockAeroV2Factory(address(aero), address(usdc), address(0xA2F))).code);
         comptroller = new MockComptroller();
         mUsdc = new MockLendingMarket(address(usdc));
         mLegB = new MockLendingMarket(address(legB));
         mLegA = new MockLendingMarket(address(legA));
         npm = new MockNpm(pool);
+        // Real ERC-721 custody: a staked position is OWNED by the gauge, so any liquidity call
+        // that forgets to unstake first reverts here exactly as it would on chain.
+        gauge.setNpm(address(npm));
         router = new MockClSwapRouter();
 
         sequencerFeed = new MockChainlinkFeed(0, 8, 1, block.timestamp - 2 hours);

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {LeveragedAeroVault} from "@contracts/LeveragedAeroVault.sol";
+import {LeveragedAeroManager} from "@contracts/leveraged-aero/LeveragedAeroManager.sol";
 import {LeveragedAeroValuation} from "@contracts/leveraged-aero/LeveragedAeroValuation.sol";
 import {LeveragedAerodromeCLStrategy} from "@contracts/leveraged-aero/LeveragedAerodromeCLStrategy.sol";
 import {LiquidityAmounts} from "@contracts/leveraged-aero/sherwood/libraries/LiquidityAmounts.sol";
@@ -304,6 +305,65 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         vm.prank(proposer);
         strategy.adjustLeverage(3000, 0, 0); // lever DOWN
         assertLt(mLegB.borrowBalance(address(strategy)), debtBUp, "lever DOWN repaid leg B");
+    }
+
+    // ==================== FULL LEVER-DOWN (the orphaned-NFT guard) ====================
+
+    /**
+     * @dev REGRESSION — a lever-down to zero debt must be REJECTED, not executed.
+     *
+     *      `_unwindLiquidity` unstakes unconditionally but re-stakes only while liquidity remains, and
+     *      `_leverDown` is the one 100%-unwind caller that neither clears `$.tokenId` nor mints a
+     *      replacement. Executing it therefore left a live `tokenId` pointing at an NFT the gauge no
+     *      longer held, and every later `gauge.withdraw` — settle, flatten, rerange, deployIdle,
+     *      compound, migrateVenue, redeploy, fulfillRedeem, emergencyRedeem — reverted forever.
+     *
+     *      Reverting is the fix rather than retiring the position: with the collateral still supplied,
+     *      clearing `tokenId` would send `nav()` down its flat-book branch, which counts ONLY idle USDC
+     *      and would erase the mUSDC collateral from NAV. A true full unwind has to redeem the
+     *      collateral too — that is what `flatten()` is for.
+     */
+    function testAdjustLeverageToZeroIsRejected() public {
+        _execute(SEED);
+        uint256 tokenIdBefore = strategy.layout().tokenId;
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAeroManager.FullUnwindNotSupported.selector);
+        strategy.adjustLeverage(0, 0, 0);
+
+        // Nothing moved, and the position is still staked — the whole point of the guard.
+        assertEq(strategy.layout().tokenId, tokenIdBefore, "position untouched");
+        assertTrue(gauge.stakedContains(address(strategy), tokenIdBefore), "NFT still staked");
+        assertGt(mLegB.borrowBalance(address(strategy)), 0, "leg B debt untouched");
+        assertGt(mLegA.borrowBalance(address(strategy)), 0, "leg A debt untouched");
+    }
+
+    /// @dev The guard is on the DEBT delta, not on the literal argument: a tiny non-zero target whose
+    ///      `targetDebt` floors to 0 against the live collateral reaches the same branch and must be
+    ///      rejected identically.
+    function testAdjustLeverageToADustTargetThatFloorsToZeroDebtIsRejected() public {
+        _execute(SEED);
+        // targetDebt = targetLtvBps * collateral / 10000; with collateral < 10000 (USDC 6dp) any
+        // targetLtvBps of 1 floors to 0. Shrink the collateral basis to reach that band.
+        mUsdc.setExchangeRateStored(1);
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAeroManager.FullUnwindNotSupported.selector);
+        strategy.adjustLeverage(1, 0, 0);
+    }
+
+    /// @dev The guard must NOT catch an ordinary lever-down: a partial repay leaves liquidity, so the
+    ///      re-stake fires and the invariant holds.
+    function testPartialLeverDownKeepsThePositionStaked() public {
+        _execute(SEED);
+        uint256 tokenId = strategy.layout().tokenId;
+
+        vm.prank(proposer);
+        strategy.adjustLeverage(3000, 0, 0);
+
+        assertEq(strategy.layout().tokenId, tokenId, "same position");
+        assertTrue(gauge.stakedContains(address(strategy), tokenId), "re-staked after a partial unwind");
+        assertGt(mLegB.borrowBalance(address(strategy)), 0, "debt reduced, not cleared");
     }
 
     // ==================== TARGET-LTV PERSISTENCE (two-borrowed-legs) ====================

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {LeveragedAeroVault} from "@contracts/LeveragedAeroVault.sol";
+import {LeveragedAeroValuation} from "@contracts/leveraged-aero/LeveragedAeroValuation.sol";
 import {LeveragedAeroVenue} from "@contracts/leveraged-aero/LeveragedAeroVenue.sol";
 import {LeveragedAerodromeCLStrategy} from "@contracts/leveraged-aero/LeveragedAerodromeCLStrategy.sol";
 import {BaseStrategy} from "@contracts/leveraged-aero/sherwood/BaseStrategy.sol";
@@ -11,7 +12,13 @@ import {MockCLGauge} from "../mocks/MockCLGauge.sol";
 import {MockCLFactory, MockCLPool} from "../mocks/MockCLPool.sol";
 import {MockComptroller} from "../mocks/MockMoonwellMarket.sol";
 import {MockToken} from "../mocks/MockToken.sol";
-import {MockChainlinkFeed, MockClSwapRouter, MockLendingMarket, MockNpm} from "./LeveragedAeroVenuesHarness.sol";
+import {
+    MockAeroV2Router,
+    MockChainlinkFeed,
+    MockClSwapRouter,
+    MockLendingMarket,
+    MockNpm
+} from "./LeveragedAeroVenuesHarness.sol";
 
 import {Test} from "@forge-std/Test.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
@@ -90,6 +97,11 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
     uint256 internal constant P_LEG_A = 3000e8; // $3k @ 18dp (legA AND legA2)
     int24 internal constant TICK = 311_100;
 
+    /// @dev The Aerodrome v2 router address `LeveragedAeroValuation.swapAeroToUsdc` hardcodes for the
+    ///      reward sale. `MockAeroV2Router` is etched there so `flatten`'s reward leg is exercised
+    ///      for real (immutables live in runtime bytecode, so the etched copy keeps its config).
+    address internal constant AERO_V2_ROUTER = 0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43;
+
     /// @dev Split into per-venue frames: one flat setUp of this size overflows the Yul stack
     ///      under via_ir (each helper keeps its locals in its own frame).
     function setUp() public {
@@ -162,6 +174,11 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
     }
 
     function fundVenues() external {
+        // Reward-sale venue: 1 AERO -> 1 USDC, matching the 1e8 aeroFeed mark.
+        MockAeroV2Router aeroRouterImpl = new MockAeroV2Router(address(aero), address(usdc), 1e6);
+        vm.etch(AERO_V2_ROUTER, address(aeroRouterImpl).code);
+        usdc.mint(AERO_V2_ROUTER, 100_000_000e6);
+
         usdc.mint(address(mUsdc), 100_000_000e6);
         legB.mint(address(mLegB), 1_000_000e8);
         legA.mint(address(mLegA), 1_000_000e18);
@@ -242,6 +259,7 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         v.gauge = address(gaugeB);
         v.cbBTCFeed = address(legB2Feed);
         v.wethFeed = address(legA2Feed);
+        v.aeroUsdFeed = address(aeroFeed);
         v.tickSpacing = SPACING_B;
         v.cbBTCSwapTickSpacing = LEG_B2_SWAP_SPACING;
         v.wethSwapTickSpacing = LEG_A2_SWAP_SPACING;
@@ -274,9 +292,12 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         strategy.execute();
     }
 
+    /// @dev `minRewardUsdcOut` is nonzero because several tests arm a gauge reward tranche; the L9
+    ///      oracle floor is the binding guard on top of it. `minIdleUsdcOut` is 0 here so the helper
+    ///      stays usable on an already-flat book; the dedicated tests below bound it explicitly.
     function _flatten() internal {
         vm.prank(proposer);
-        strategy.flatten();
+        strategy.flatten(1, 0);
     }
 
     function _stage(LeveragedAeroVenue.VenueParams memory v) internal {
@@ -323,7 +344,7 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         _execute(SEED);
         vm.expectRevert(BaseStrategy.NotProposer.selector);
         vm.prank(lp);
-        strategy.flatten();
+        strategy.flatten(1, 0);
     }
 
     function testFlattenIsIdempotentOnAFlatBook() public {
@@ -361,6 +382,101 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         vm.stopPrank();
         assertGt(out, 0, "flat-book redeem pays");
         assertEq(usdc.balanceOf(lp) - lpUsdcBefore, out, "payout delivered");
+    }
+
+    // ==================== flatten guards (audit findings 4 + 7) ====================
+
+    /**
+     * @dev REGRESSION (finding 4) — the unwind's `gauge.withdraw` auto-claims the pending reward
+     *      tranche, and `settleImpl` sweeps only the two LEG tokens. Left unsold, that balance is
+     *      invisible to `nav()` (the `tokenId == 0` branch prices idle USDC only), unsellable
+     *      (`compound` early-returns on a flat book) and un-rescuable (`rescueToVault` denies the
+     *      reward token while Executed) — so every deposit in the flat window buys a free claim on it.
+     *      `flatten` must convert it, leaving the flat NAV equal to the whole book.
+     */
+    function testFlattenSellsTheAutoClaimedRewardTranche() public {
+        _execute(SEED);
+        // Arm a reward tranche paid out by the gauge on unstake, and a router rate to sell it at.
+        uint256 tranche = 1000e18;
+        aero.mint(address(gauge), tranche);
+        gauge.setAeroToPayOnWithdraw(tranche);
+
+        _flatten();
+
+        assertEq(aero.balanceOf(address(strategy)), 0, "reward tranche sold, not stranded");
+        // The proceeds are in the flat-book NAV, which is exactly the idle USDC balance.
+        assertEq(strategy.nav(), usdc.balanceOf(address(strategy)), "flat NAV == idle USDC");
+        assertGt(strategy.nav(), (SEED * 98) / 100 + 900e6, "reward proceeds landed in NAV");
+    }
+
+    /// @dev The reward sale is floored by the L9 oracle read on top of the caller's bound: a router
+    ///      paying far under the AERO/USD mark must revert the whole flatten, not sell blind.
+    function testFlattenRevertsWhenTheRewardSaleIsBelowTheOracleFloor() public {
+        _execute(SEED);
+        aero.mint(address(gauge), 1000e18);
+        gauge.setAeroToPayOnWithdraw(1000e18);
+        // Re-etch a router paying 50% under the 1e8 feed mark (immutables => new instance + etch).
+        MockAeroV2Router cheap = new MockAeroV2Router(address(aero), address(usdc), 5e5);
+        vm.etch(AERO_V2_ROUTER, address(cheap).code);
+
+        vm.expectRevert(LeveragedAeroVenue.BelowOracleFloor.selector);
+        vm.prank(proposer);
+        strategy.flatten(1, 0);
+    }
+
+    /// @dev A reward balance with no caller floor is rejected (mirrors `compound`'s `ZeroMinOut`
+    ///      belt); with NO reward balance the same call is a clean no-op, which is what keeps
+    ///      `flatten` idempotent.
+    function testFlattenRewardFloorIsRequiredOnlyWhenThereIsAReward() public {
+        _execute(SEED);
+        aero.mint(address(gauge), 1000e18);
+        gauge.setAeroToPayOnWithdraw(1000e18);
+
+        vm.expectRevert(LeveragedAeroVenue.ZeroMinOut.selector);
+        vm.prank(proposer);
+        strategy.flatten(0, 0);
+
+        // No reward armed -> minRewardUsdcOut == 0 is fine.
+        gauge.setAeroToPayOnWithdraw(0);
+        vm.prank(proposer);
+        strategy.flatten(0, 0);
+        _assertFlat();
+    }
+
+    /**
+     * @dev REGRESSION (finding 7) — `settleImpl` carries no calm gate of its own, and
+     *      `_unwindLiquidity` derives its `amount0Min`/`amount1Min` from the same `slot0()` it burns
+     *      at, so those mins bind nothing against a shoved tick. `flatten` is proposer-callable and
+     *      repeatable (unlike the terminal `settle` whose body it reuses), so it must gate like
+     *      `rerange` does.
+     */
+    function testFlattenCalmGateBlocksAShovedTick() public {
+        _execute(SEED);
+        pool.setTick(TICK + 5000); // well past calmDeviationTicks = 100
+        pool.setTwapTick(TICK);
+        pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK + 5000));
+
+        vm.expectRevert(LeveragedAeroValuation.CalmGateBreached.selector);
+        vm.prank(proposer);
+        strategy.flatten(1, 0);
+
+        // The gate fired before the burn — the position is untouched and still staked.
+        assertGt(strategy.layout().tokenId, 0, "position untouched");
+        assertTrue(gauge.stakedContains(address(strategy), strategy.layout().tokenId), "still staked");
+    }
+
+    /// @dev REGRESSION (finding 7) — the caller's aggregate floor on the realised unwind. The
+    ///      per-swap oracle floors only bound each leg at `maxSlippageBps` (init permits up to 10%);
+    ///      this is the proposer's own bound on the total.
+    function testFlattenHonoursTheCallerIdleFloor() public {
+        _execute(SEED);
+        uint256 unreachable = SEED * 2;
+
+        // Selector-only: the realised idle depends on the unwind's slippage, and asserting the exact
+        // figure here would pin an unrelated number rather than the guard.
+        vm.expectPartialRevert(LeveragedAeroVenue.InsufficientIdleAfterFlatten.selector);
+        vm.prank(proposer);
+        strategy.flatten(1, unreachable);
     }
 
     // ==================== staging ====================
@@ -479,6 +595,41 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         LeveragedAeroVenue.VenueParams memory v = _venueBParams();
         v.cbBTCSwapTickSpacing = 300; // no legB2/USDC pool registered at this spacing
         _expectMigrateRevert(v, LeveragedAeroVenue.VenueMismatch.selector);
+    }
+
+    /**
+     * @dev REGRESSION (finding 8) — the gauge is migratable, so `gauge.rewardToken()` can change. If
+     *      the feed that prices that token stayed pinned to its init value, a migration would price
+     *      reward token X with AERO's price and mis-scale the L9 harvest floor. The feed therefore
+     *      lives in `VenueParams` and is validated + rewritten with the gauge.
+     */
+    function testMigrateRewritesTheRewardFeedWithTheGauge() public {
+        _execute(SEED);
+        _flatten();
+        MockChainlinkFeed newRewardFeed = new MockChainlinkFeed(2e8, 8, 1, block.timestamp);
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.aeroUsdFeed = address(newRewardFeed);
+        _stage(v);
+        _migrate(v);
+        assertEq(strategy.layout().aeroUsdFeed, address(newRewardFeed), "reward feed migrated with the gauge");
+    }
+
+    /// @dev The L9 scaling assumption (`mulDiv(bal, price8, 1e20)`) is asserted on the staged feed,
+    ///      exactly as it was at init.
+    function testMigrateRejectsANonEightDecimalRewardFeed() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.aeroUsdFeed = address(new MockChainlinkFeed(1e18, 18, 1, block.timestamp));
+        _expectMigrateRevert(v, LeveragedAeroVenue.UnexpectedFeedDecimals.selector);
+    }
+
+    function testMigrateRejectsAZeroRewardFeed() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.aeroUsdFeed = address(0);
+        _expectMigrateRevert(v, LeveragedAeroVenue.ZeroAddress.selector);
     }
 
     function testMigrateRejectsAnOffGridWidth() public {

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -13,6 +13,7 @@ import {MockCLFactory, MockCLPool} from "../mocks/MockCLPool.sol";
 import {MockComptroller} from "../mocks/MockMoonwellMarket.sol";
 import {MockToken} from "../mocks/MockToken.sol";
 import {
+    MockAeroV2Factory,
     MockAeroV2Router,
     MockChainlinkFeed,
     MockClSwapRouter,
@@ -104,6 +105,10 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
 
     /// @dev Split into per-venue frames: one flat setUp of this size overflows the Yul stack
     ///      under via_ir (each helper keeps its locals in its own frame).
+    /// @dev Aerodrome v2 PoolFactory, hardcoded in `LeveragedAeroValuation` and probed by venue
+    ///      validation to prove the reward token has a USDC route. Etched below (no code otherwise).
+    address internal constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
+
     function setUp() public {
         vm.warp(1_800_000_000);
         // EXTERNAL self-calls, not internal helpers: via_ir re-inlines single-call-site internal
@@ -140,11 +145,18 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         clFactory.setPool(address(usdc), address(legA), LEG_A_SWAP_SPACING, makeAddr("legASwapPool"));
         gauge = new MockCLGauge(address(aero));
         gauge.setPool(address(pool));
+        pool.setGauge(address(gauge));
+        // The reward-route probe in venue validation reads a HARDCODED v2 factory address;
+        // place code there so the AERO/USDC route resolves in this fork-free suite.
+        vm.etch(AERO_V2_FACTORY, address(new MockAeroV2Factory(address(aero), address(usdc), address(0xA2F))).code);
         mLegB = new MockLendingMarket(address(legB));
         mLegA = new MockLendingMarket(address(legA));
         legBFeed = new MockChainlinkFeed(int256(P_LEG_B), 8, 1, block.timestamp);
         legAFeed = new MockChainlinkFeed(int256(P_LEG_A), 8, 1, block.timestamp);
         npm = new MockNpm(pool);
+        // Real ERC-721 custody: a staked position is OWNED by the gauge, so any liquidity call
+        // that forgets to unstake first reverts here exactly as it would on chain.
+        gauge.setNpm(address(npm));
     }
 
     /// @dev Cross-pair destination: same prices/tick as venue A, different spacing.
@@ -159,6 +171,8 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         clFactory.setPool(address(usdc), address(legA2), LEG_A2_SWAP_SPACING, makeAddr("legA2SwapPool"));
         gaugeB = new MockCLGauge(address(aero));
         gaugeB.setPool(address(poolB));
+        poolB.setGauge(address(gaugeB));
+        gaugeB.setNpm(address(npm));
         mLegB2 = new MockLendingMarket(address(legB2));
         mLegA2 = new MockLendingMarket(address(legA2));
         legB2Feed = new MockChainlinkFeed(int256(P_LEG_B), 8, 1, block.timestamp);
@@ -171,6 +185,8 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         poolC.setFactory(address(clFactory));
         gaugeC = new MockCLGauge(address(aero));
         gaugeC.setPool(address(poolC));
+        poolC.setGauge(address(gaugeC));
+        gaugeC.setNpm(address(npm));
     }
 
     function fundVenues() external {
@@ -333,7 +349,10 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
 
         _assertFlat();
         uint256 idle = usdc.balanceOf(address(strategy));
-        assertGt(idle, (SEED * 98) / 100, "essentially the whole book realized as idle USDC");
+        // TIGHT on purpose: this fixture's swap mocks fill at exact oracle parity, so a lossless
+        // unwind is the CORRECT expectation and the only permitted gap is integer rounding. A 2%
+        // band here would let a real conservation bug through unnoticed.
+        assertApproxEqRel(idle, SEED, 0.0001e18, "whole book realized as idle USDC (lossless fixture)");
         assertEq(strategy.nav(), idle, "flat NAV == idle USDC (oracle-free)");
         // Still Executed: the proposer-gated venue ops remain reachable (settle would brick them).
         vm.prank(proposer);
@@ -441,6 +460,51 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         vm.prank(proposer);
         strategy.flatten(0, 0);
         _assertFlat();
+    }
+
+    /**
+     * @dev REGRESSION (dust-donation deadlock) — a reward balance worth under one micro-USD prices to
+     *      a ZERO oracle floor and the router fills it at 0 USDC, so BOTH arguments used to be
+     *      unsatisfiable: `0` hit `ZeroMinOut` and anything nonzero hit the router's own min-out
+     *      check. Since nothing else can clear a reward balance on a live `Executed` book — `compound`
+     *      early-returns once flat and reverts identically while live, and `rescueToVault` denies the
+     *      reward token until `Settled` — a 1e6-wei donation permanently blocked `flatten`, and with it
+     *      `migrateVenue`'s flat-book precondition. The sale is now skipped exactly where the floor
+     *      rounds to 0, which is exactly where an unsold balance cannot move a 6dp NAV.
+     */
+    function testFlattenSurvivesARewardDustDonation() public {
+        _execute(SEED);
+        aero.mint(address(strategy), 1e6); // sub-micro-USD at the 1e8 (== $1) feed mark
+
+        vm.prank(proposer);
+        strategy.flatten(1, 0);
+
+        _assertFlat();
+        assertEq(aero.balanceOf(address(strategy)), 1e6, "dust left in place, not force-sold");
+        assertEq(strategy.nav(), usdc.balanceOf(address(strategy)), "flat NAV still == idle USDC");
+        // And the migration it used to block now completes.
+        _stage(_venueBParams());
+        _migrate(_venueBParams());
+        assertEq(strategy.layout().pool, address(poolB), "migration no longer blocked by dust");
+    }
+
+    /// @dev The dust skip must NOT widen the guard for a real tranche: a balance whose oracle floor is
+    ///      nonzero still has to clear both the caller's floor and the L9 post-check.
+    function testFlattenStillSellsABalanceJustAboveTheDustThreshold() public {
+        _execute(SEED);
+        // 1e15 wei AERO × 1e8 / 1e20 == 1000 (6dp), and the `maxSlippageBps` haircut still leaves a
+        // NONZERO floor — which is what separates "dust" from "small". (The threshold is the haircut
+        // one, not the raw one: at 1e12 the raw floor is 1 unit and the haircut rounds it to 0.)
+        aero.mint(address(gauge), 1e15);
+        gauge.setAeroToPayOnWithdraw(1e15);
+
+        vm.expectRevert(LeveragedAeroVenue.ZeroMinOut.selector);
+        vm.prank(proposer);
+        strategy.flatten(0, 0);
+
+        vm.prank(proposer);
+        strategy.flatten(1, 0);
+        assertEq(aero.balanceOf(address(strategy)), 0, "above-dust balance is still sold");
     }
 
     /**
@@ -589,6 +653,47 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         _expectMigrateRevert(v, LeveragedAeroVenue.VenueMismatch.selector);
     }
 
+    /// @dev The gauge↔pool binding is checked in BOTH directions. `gauge.pool()` is self-attested by
+    ///      the staged contract, so a hostile gauge returns the real pool for free; only the pool's own
+    ///      `gauge()` (Voter-written on a real Slipstream pool) makes the pair non-forgeable.
+    function testMigrateRejectsAGaugeThePoolDoesNotClaim() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        MockCLGauge impostor = new MockCLGauge(address(aero));
+        impostor.setPool(address(poolB)); // passes the self-attested direction...
+        // ...but poolB.gauge() still points at the real gaugeB.
+        v.gauge = address(impostor);
+        _expectMigrateRevert(v, LeveragedAeroVenue.VenueMismatch.selector);
+    }
+
+    /// @dev The reward leg is a THIRD swap venue (Aerodrome v2, volatile, hardcoded route). Without a
+    ///      probe, a gauge whose reward token has no v2/USDC pool passes every other check and then
+    ///      reverts inside BOTH `compound` and `flatten` once a tranche accrues — permanently, since
+    ///      `flatten` is also the precondition for migrating away.
+    function testMigrateRejectsARewardTokenWithNoUsdcRoute() public {
+        _execute(SEED);
+        _flatten();
+        MockToken orphanReward = new MockToken("Orphan", "ORPH", 18); // no pool in the v2 factory mock
+        MockCLGauge orphanGauge = new MockCLGauge(address(orphanReward));
+        orphanGauge.setPool(address(poolB));
+        poolB.setGauge(address(orphanGauge));
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.gauge = address(orphanGauge);
+        _expectMigrateRevert(v, LeveragedAeroVenue.VenueMismatch.selector);
+    }
+
+    /// @dev Leg feeds are validated at STAGE time, not only at read time. `readUsd8` does fail closed
+    ///      on a non-8dp answer, but it fails after the venue is already adopted — bricking `redeploy`
+    ///      on a fund that has no way back except re-staging.
+    function testMigrateRejectsANonEightDecimalLegFeed() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.wethFeed = address(new MockChainlinkFeed(int256(1e18), 18, 1, block.timestamp));
+        _expectMigrateRevert(v, LeveragedAeroVenue.UnexpectedFeedDecimals.selector);
+    }
+
     function testMigrateRejectsAMissingLegSwapPool() public {
         _execute(SEED);
         _flatten();
@@ -719,6 +824,57 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         assertEq(l.cbBTCFeed, address(usdcFeed), "leg B feed pinned to USDC/USD");
         assertEq(l.cbBTCSwapTickSpacing, 0, "leg B swap spacing declared unused");
         assertFalse(l.wethIsToken0, "usdc is token0 in poolC");
+        // CROSS-DECIMAL: venue A's leg B is 8dp, venue C's is USDC at 6dp. The stored decimals drive
+        // every token↔USDC conversion, so a migration that failed to rewrite them would mis-scale the
+        // whole book by 100x while every other assertion above still passed.
+        assertEq(l.cbBTCDecimals, 6, "leg B decimals re-read at migrate (8dp -> 6dp)");
+        assertEq(l.wethDecimals, 18, "leg A decimals re-read at migrate");
+    }
+
+    /**
+     * @dev The scenario the reward feed lives in `VenueParams` FOR: a destination gauge that rewards a
+     *      DIFFERENT token. Pinning the feed at init would price that token with AERO's mark and
+     *      mis-scale the L9 harvest floor. Nothing exercised it end-to-end — both fixture gauges reward
+     *      AERO — so this drives the full sequence and then sells a real tranche of the new token
+     *      against the new feed.
+     */
+    function testMigrationToAGaugeWithADifferentRewardTokenHarvestsAgainstTheNewFeed() public {
+        _execute(SEED);
+        _flatten();
+
+        MockToken newReward = new MockToken("Reward2", "RWD2", 18);
+        MockChainlinkFeed newRewardFeed = new MockChainlinkFeed(2e8, 8, 1, block.timestamp); // $2
+        MockCLGauge gaugeB2 = new MockCLGauge(address(newReward));
+        gaugeB2.setPool(address(poolB));
+        poolB.setGauge(address(gaugeB2));
+        // The route probe and the sale both key off the destination's reward token now.
+        vm.etch(AERO_V2_FACTORY, address(new MockAeroV2Factory(address(newReward), address(usdc), address(0xA2F))).code);
+
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.gauge = address(gaugeB2);
+        v.aeroUsdFeed = address(newRewardFeed);
+        _stage(v);
+        _migrate(v);
+        assertEq(strategy.layout().aeroUsdFeed, address(newRewardFeed), "feed migrated with the gauge");
+
+        npm.setPool(poolB);
+        vm.prank(proposer);
+        strategy.redeploy(0);
+
+        // Arm a tranche of the NEW reward token and a router that fills it at the new feed's $2 mark.
+        uint256 tranche = 1000e18;
+        newReward.mint(address(gaugeB2), tranche);
+        gaugeB2.setAeroToPayOnWithdraw(tranche);
+        MockAeroV2Router r = new MockAeroV2Router(address(newReward), address(usdc), 2e6);
+        vm.etch(AERO_V2_ROUTER, address(r).code);
+        usdc.mint(AERO_V2_ROUTER, 100_000_000e6);
+
+        vm.prank(proposer);
+        strategy.flatten(1, 0);
+
+        assertEq(newReward.balanceOf(address(strategy)), 0, "new reward token sold, not stranded");
+        assertEq(aero.balanceOf(address(strategy)), 0, "old reward token not involved");
+        assertEq(strategy.nav(), usdc.balanceOf(address(strategy)), "flat NAV == idle USDC");
     }
 
     // ==================== redeploy ====================
@@ -733,7 +889,7 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         uint256 idle = usdc.balanceOf(address(strategy));
 
         vm.prank(proposer);
-        strategy.redeploy();
+        strategy.redeploy(0);
 
         assertGt(strategy.layout().tokenId, 0, "fresh position minted");
         assertEq(gaugeB.depositCallCount(), 1, "staked in the NEW gauge");
@@ -751,7 +907,7 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         _execute(SEED);
         vm.expectRevert(LeveragedAeroVenue.PositionAlreadyOpen.selector);
         vm.prank(proposer);
-        strategy.redeploy();
+        strategy.redeploy(0);
     }
 
     function testRedeployRevertsForNonProposer() public {
@@ -759,7 +915,153 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         _flatten();
         vm.expectRevert(BaseStrategy.NotProposer.selector);
         vm.prank(lp);
-        strategy.redeploy();
+        strategy.redeploy(0);
+    }
+
+    /// @dev `redeploy` is the ONE repeatable value-moving proposer op, and the mint's own §8 mins come
+    ///      off the same `slot0()` the mint executes at — self-referential. The caller's floor is the
+    ///      only bound that is not derived from the price being bounded.
+    function testRedeployHonoursTheCallerLiquidityFloor() public {
+        _execute(SEED);
+        _flatten();
+
+        vm.expectRevert(LeveragedAerodromeCLStrategy.InsufficientLiquidity.selector);
+        vm.prank(proposer);
+        strategy.redeploy(type(uint128).max);
+
+        assertEq(strategy.layout().tokenId, 0, "nothing opened when the floor is unmet");
+
+        // A reachable floor still opens the position.
+        vm.prank(proposer);
+        strategy.redeploy(1);
+        assertGt(strategy.layout().tokenId, 0, "position opened under a satisfiable floor");
+    }
+
+    /// @dev ROLLBACK (B → A): `flatten → redeploy` re-enters the ORIGINAL venue with nothing changed,
+    ///      and the staged destination hash must NOT survive it. Leaving it armed would let the
+    ///      proposer fire an owner authorization months later into conditions nobody re-evaluated —
+    ///      the replay the migrate path already closes by consuming on use.
+    function testRedeployRollsBackToTheOldVenueAndClearsTheStagedHash() public {
+        _execute(SEED);
+        _flatten();
+        _stage(_venueBParams());
+        assertTrue(strategy.layout().stagedVenueHash != bytes32(0), "hash armed");
+
+        vm.prank(proposer);
+        strategy.redeploy(0);
+
+        assertEq(strategy.layout().stagedVenueHash, bytes32(0), "staged hash cleared by the rollback");
+        assertEq(strategy.layout().pool, address(pool), "still on the ORIGINAL venue");
+        assertEq(strategy.layout().gauge, address(gauge), "still on the original gauge");
+        assertGt(strategy.layout().tokenId, 0, "position reopened on venue A");
+        assertEq(gauge.depositCallCount(), 2, "restaked in the OLD gauge (genesis + rollback)");
+        assertEq(gaugeB.depositCallCount(), 0, "venue B never touched");
+
+        // And the abandoned authorization can no longer be executed without a fresh stage.
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        vm.expectRevert(LeveragedAeroVenue.VenueNotStaged.selector);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+    }
+
+    /// @dev Same-venue round trip with no migration in between — the plain "unwind, wait, re-enter"
+    ///      operation, distinct from the rollback above in that nothing was ever staged.
+    function testFlattenThenRedeployRoundTripsOnTheSameVenue() public {
+        _execute(SEED);
+        uint256 tokenIdBefore = strategy.layout().tokenId;
+        uint256 navBefore = strategy.nav();
+
+        _flatten();
+        _assertFlat();
+        vm.prank(proposer);
+        strategy.redeploy(0);
+
+        assertGt(strategy.layout().tokenId, 0, "reopened");
+        assertTrue(strategy.layout().tokenId != tokenIdBefore, "a FRESH position, not the old id");
+        assertEq(strategy.layout().pool, address(pool), "same venue throughout");
+        assertApproxEqRel(strategy.nav(), navBefore, 0.0001e18, "round trip is value-neutral (lossless fixture)");
+    }
+
+    // ==================== post-settle gating (mutation survivors) ====================
+
+    /// @dev ERC-7201 base slot, byte-identical to the three `STORAGE_SLOT` copies in `src`.
+    bytes32 internal constant LAYOUT_SLOT = 0x405ae0b144079093e970849fdffdcb2a514e44968598c6c5c73444496e844900;
+
+    /// @dev Poke `Layout.tokenId` directly. Needed because the flat-book gate is a conjunction whose
+    ///      clauses cannot all be driven through the public surface — a real book with a live `tokenId`
+    ///      also carries debt, so the leg-debt clause would mask this one (exactly what let the mutant
+    ///      survive). The read-back assert doubles as a check that the slot offset is still correct.
+    function _writeTokenId(uint256 id) internal {
+        vm.store(address(strategy), bytes32(uint256(LAYOUT_SLOT) + 18), bytes32(id));
+        assertEq(strategy.layout().tokenId, id, "tokenId slot offset drifted");
+    }
+
+    /// @dev Same, for the packed `hedgedDebtA | hedgedDebtB` slot.
+    function _writeHedgedDebt(uint128 a, uint128 b) internal {
+        vm.store(address(strategy), bytes32(uint256(LAYOUT_SLOT) + 27), bytes32((uint256(b) << 128) | uint256(a)));
+        (uint128 ra, uint128 rb) = strategy.hedgedDebt();
+        assertEq(ra, a, "hedgedDebtA slot offset drifted");
+        assertEq(rb, b, "hedgedDebtB slot offset drifted");
+    }
+
+    /// @dev All three new entry points gate on `Executed`. Nothing covered them post-`settle`, where
+    ///      `redeploy` in particular would re-open a levered position on a wound-down fund whose assets
+    ///      have already been pushed to the vault.
+    function testMigrationEntryPointsAreRejectedAfterSettle() public {
+        _execute(SEED);
+        vm.prank(address(vault));
+        strategy.settle();
+
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+
+        vm.expectRevert(BaseStrategy.NotExecuted.selector);
+        vm.prank(proposer);
+        strategy.flatten(1, 0);
+
+        vm.expectRevert(BaseStrategy.NotExecuted.selector);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+
+        vm.expectRevert(BaseStrategy.NotExecuted.selector);
+        vm.prank(proposer);
+        strategy.redeploy(0);
+    }
+
+    /// @dev The flat-book gate is a CONJUNCTION, and the mutation sweep found the first two clauses
+    ///      masked by the leg-debt clause firing with the same selector. Drive each in isolation.
+    function testMigrateFlatBookGateIsCheckedClauseByClause() public {
+        _execute(SEED);
+        _flatten();
+        _stage(_venueBParams());
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+
+        // (1) tokenId alone: no debt, no hedged basis, but a live position id.
+        _writeTokenId(1234);
+        vm.expectRevert(LeveragedAeroVenue.BookNotFlat.selector);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+        _writeTokenId(0);
+
+        // (2) hedged basis A alone.
+        _writeHedgedDebt(1, 0);
+        vm.expectRevert(LeveragedAeroVenue.BookNotFlat.selector);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+
+        // (3) hedged basis B alone.
+        _writeHedgedDebt(0, 1);
+        vm.expectRevert(LeveragedAeroVenue.BookNotFlat.selector);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+        _writeHedgedDebt(0, 0);
+
+        // (4) leg-B debt alone (the leg-A case is `testMigrateRevertsWhileLegDebtRemains`).
+        vm.prank(address(strategy));
+        mLegB.borrow(1e8);
+        vm.expectRevert(LeveragedAeroVenue.BookNotFlat.selector);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
     }
 
     // ==================== continuity across the full sequence ====================
@@ -779,7 +1081,7 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         _migrate(_venueBParams());
         npm.setPool(poolB);
         vm.prank(proposer);
-        strategy.redeploy();
+        strategy.redeploy(0);
 
         uint256 lpUsdcBefore = usdc.balanceOf(lp);
         vm.prank(proposer);

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -614,6 +614,44 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         strategy.flatten(1, unreachable);
     }
 
+    /// @dev REGRESSION for the `_settleRepayDebts` stale-index bug. That function decides full-repay
+    ///      (`type(uint256).max`) vs partial off a leg's debt read; the fix reads `borrowBalanceCurrent`
+    ///      (which ACCRUES) instead of the stale `borrowBalanceStored`. The bug window: a leg whose
+    ///      HELD balance covers the STORED debt but not the ACCRUED debt takes the `>= stored` full-repay
+    ///      branch, approves only the held balance, and Moonwell's `repayBorrow` then capitalises and
+    ///      pulls the larger ACCRUED debt — reverting the whole flatten, and with it `migrateVenue`'s
+    ///      flat-book precondition. Construction: arm PENDING interest (invisible to `borrowBalanceStored`)
+    ///      so accrued > stored, and mint a small cushion so each leg's held balance lands in
+    ///      `[stored, accrued)`. With the fix, flatten reads the accrued debt, repays what it holds, and
+    ///      `_settleShortfall` covers the remainder from collateral. Fails against the stored read.
+    function testFlattenSurvivesPendingInterestBetweenStoredAndAccruedDebt() public {
+        _execute(SEED);
+        uint256 storedA = mLegA.borrowBalance(address(strategy));
+        uint256 storedB = mLegB.borrowBalance(address(strategy));
+        assertGt(storedA, 0, "leg A borrowed");
+        assertGt(storedB, 0, "leg B borrowed");
+
+        // Arm 20% of PENDING (un-capitalised) interest on each borrow: stored stays put, accrued jumps.
+        mLegA.accruePendingBorrowInterest(address(strategy), storedA * 20 / 100);
+        mLegB.accruePendingBorrowInterest(address(strategy), storedB * 20 / 100);
+        assertEq(mLegA.borrowBalance(address(strategy)), storedA, "stored read is still the pre-accrual debt");
+        assertGt(mLegA.borrowBalanceAccrued(address(strategy)), storedA, "accrued read reveals the gap");
+
+        // Cushion each leg so the post-unwind held balance robustly clears STORED (genesis rounds the
+        // LP down by dust) while staying well under ACCRUED — i.e. squarely inside the bug window.
+        legA.mint(address(strategy), storedA * 3 / 100);
+        legB.mint(address(strategy), storedB * 3 / 100);
+
+        // With the fix this succeeds; against `borrowBalanceStored` the full-repay branch over-pulls
+        // the accrued debt past the held-balance approval and the unwind reverts.
+        vm.prank(proposer);
+        strategy.flatten(1, 0);
+
+        _assertFlat();
+        assertEq(mLegA.borrowBalance(address(strategy)), 0, "leg A debt fully cleared");
+        assertEq(mLegB.borrowBalance(address(strategy)), 0, "leg B debt fully cleared");
+    }
+
     // ==================== staging ====================
 
     function testStageVenueIsVaultOwnerOnly() public {
@@ -830,6 +868,50 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         assertEq(strategy.layout().cbBTC, before.cbBTC, "leg B is a real borrowed leg again");
         assertEq(strategy.layout().mCbBTC, before.mCbBTC, "leg B market restored");
         assertEq(strategy.layout().cbBTCSwapTickSpacing, before.cbBTCSwapTickSpacing, "leg B spacing restored");
+    }
+
+    /// @dev The leg-A DECIMALS half of the same gap. Venues A/B/C all carry an 18dp leg A, so the
+    ///      `wethDecimals` value never changes across any migration among them and a stale
+    ///      `$.wethDecimals = wethDec` write is invisible — the A↔B↔C round trips above pass even with
+    ///      that write deleted. Venue D is a two-leg destination whose leg A is 8dp, so the migration
+    ///      forces `wethDecimals` 18→8 and back, catching the stale write. Migrate-only (no redeploy),
+    ///      so venue D needs no tick/price — `applyVenue` reads no pool price.
+    function testMigrateRoundTripThroughAnEightDecimalLegARestoresTheDecimals() public {
+        _execute(SEED);
+        _flatten();
+
+        LeveragedAerodromeCLStrategy.LayoutView memory before = strategy.layout();
+        assertEq(before.wethDecimals, 18, "venue A leg A is 18dp");
+
+        // ── Venue D: fresh 8dp leg A, reusing venue B's 8dp leg B + collateral market. ──
+        MockToken legAD = new MockToken("Leg A 8dp", "LEGAD", 8);
+        MockLendingMarket mLegAD = new MockLendingMarket(address(legAD));
+        MockChainlinkFeed legADFeed = new MockChainlinkFeed(int256(P_LEG_A), 8, 1, block.timestamp);
+        MockCLPool poolD = new MockCLPool(address(legB2), address(legAD), SPACING);
+        poolD.setFactory(AERODROME_CL_FACTORY);
+        clFactory.setPool(address(legB2), address(legAD), SPACING, address(poolD));
+        clFactory.setPool(address(usdc), address(legAD), LEG_A_SWAP_SPACING, makeAddr("legADSwapPool"));
+        MockCLGauge gaugeD = new MockCLGauge(address(aero));
+        gaugeD.setPool(address(poolD));
+        poolD.setGauge(address(gaugeD));
+        gaugeD.setNpm(address(npm));
+
+        LeveragedAeroVenue.VenueParams memory d = _venueBParams();
+        d.mWeth = address(mLegAD);
+        d.weth = address(legAD);
+        d.wethFeed = address(legADFeed);
+        d.pool = address(poolD);
+        d.gauge = address(gaugeD);
+        d.tickSpacing = SPACING;
+        d.wethSwapTickSpacing = LEG_A_SWAP_SPACING;
+
+        _stage(d);
+        _migrate(d);
+        assertEq(strategy.layout().wethDecimals, 8, "leg A decimals re-derived to 8 on the way out");
+
+        _stage(_venueAParams());
+        _migrate(_venueAParams());
+        assertEq(strategy.layout().wethDecimals, before.wethDecimals, "leg A decimals restored to 18");
     }
 
     /// @dev The reward leg is a THIRD swap venue (Aerodrome v2, volatile, hardcoded route). Without a

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -1,0 +1,656 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {LeveragedAeroVault} from "@contracts/LeveragedAeroVault.sol";
+import {LeveragedAeroVenue} from "@contracts/leveraged-aero/LeveragedAeroVenue.sol";
+import {LeveragedAerodromeCLStrategy} from "@contracts/leveraged-aero/LeveragedAerodromeCLStrategy.sol";
+import {BaseStrategy} from "@contracts/leveraged-aero/sherwood/BaseStrategy.sol";
+import {TickMath} from "@contracts/leveraged-aero/sherwood/libraries/TickMath.sol";
+
+import {MockCLGauge} from "../mocks/MockCLGauge.sol";
+import {MockCLFactory, MockCLPool} from "../mocks/MockCLPool.sol";
+import {MockComptroller} from "../mocks/MockMoonwellMarket.sol";
+import {MockToken} from "../mocks/MockToken.sol";
+import {MockChainlinkFeed, MockClSwapRouter, MockLendingMarket, MockNpm} from "./LeveragedAeroVenuesHarness.sol";
+
+import {Test} from "@forge-std/Test.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
+/**
+ * @title Owner-staged venue migration — flatten / stage / migrate / redeploy
+ * @notice End-to-end coverage of the in-place pool/pair migration: the proposer flattens the book to
+ *         idle USDC (staying `Executed`), the VAULT OWNER stages a hash-committed destination venue,
+ *         the proposer executes the byte-exact rewrite on the flat book, and `redeploy` re-opens a
+ *         fresh position in the destination venue. Continuity invariants (NAV, share balances,
+ *         pending redeem requests, old-leg rescue) are asserted across the whole sequence.
+ *
+ * @dev Fixture: venue A is the TwoLegLifecycle fixture verbatim (legB 8dp / legA 18dp, both
+ *      borrowed, `wethIsToken0 == false`). Venue B is a genuinely distinct cross-pair venue
+ *      (fresh tokens/markets/feeds/pool/gauge) that deliberately reuses venue A's PRICES and TICK so
+ *      the post-migration lifecycle runs on the same known-good geometry. Venue C is an asset-mode
+ *      config (`cbBTC` slot == usdc) used to pin the shape re-derivation; migrate-only (validation
+ *      reads no pool price), so it needs no tick setup. Fees off.
+ */
+contract LeveragedAeroVenueMigrationUnitTest is Test {
+    address internal owner = makeAddr("owner");
+    address internal proposer = makeAddr("proposer");
+    address internal lp = makeAddr("lp");
+
+    // ── shared core ──
+    MockToken internal usdc;
+    MockToken internal aero;
+    MockCLFactory internal clFactory;
+    MockComptroller internal comptroller;
+    MockLendingMarket internal mUsdc;
+    MockNpm internal npm;
+    MockClSwapRouter internal router;
+    MockChainlinkFeed internal usdcFeed;
+    MockChainlinkFeed internal aeroFeed;
+    MockChainlinkFeed internal sequencerFeed;
+
+    // ── venue A (initial) ──
+    MockToken internal legB;
+    MockToken internal legA;
+    MockCLPool internal pool;
+    MockCLGauge internal gauge;
+    MockLendingMarket internal mLegB;
+    MockLendingMarket internal mLegA;
+    MockChainlinkFeed internal legBFeed;
+    MockChainlinkFeed internal legAFeed;
+
+    // ── venue B (cross-pair destination) ──
+    MockToken internal legB2;
+    MockToken internal legA2;
+    MockCLPool internal poolB;
+    MockCLGauge internal gaugeB;
+    MockLendingMarket internal mLegB2;
+    MockLendingMarket internal mLegA2;
+    MockChainlinkFeed internal legB2Feed;
+    MockChainlinkFeed internal legA2Feed;
+
+    // ── venue C (asset-mode destination: {usdc, legA2}) ──
+    MockCLPool internal poolC;
+    MockCLGauge internal gaugeC;
+
+    LeveragedAeroVault internal vault;
+    LeveragedAerodromeCLStrategy internal strategy;
+
+    int24 internal constant SPACING = 100;
+    int24 internal constant SPACING_B = 200; // venue B uses a different LP spacing on purpose
+    int24 internal constant LEG_B_SWAP_SPACING = 100;
+    int24 internal constant LEG_A_SWAP_SPACING = 200;
+    int24 internal constant LEG_B2_SWAP_SPACING = 100;
+    int24 internal constant LEG_A2_SWAP_SPACING = 200;
+    uint24 internal constant WIDTH = 4000;
+    uint16 internal constant TARGET_LTV_BPS = 5000;
+    uint256 internal constant P_USDC = 1e8;
+    uint256 internal constant SEED = 1_000_000e6;
+    /// @dev Venue B reuses venue A's prices/tick so the redeployed lifecycle runs known-good geometry.
+    uint256 internal constant P_LEG_B = 1e13; // $100k @ 8dp (legB AND legB2)
+    uint256 internal constant P_LEG_A = 3000e8; // $3k @ 18dp (legA AND legA2)
+    int24 internal constant TICK = 311_100;
+
+    /// @dev Split into per-venue frames: one flat setUp of this size overflows the Yul stack
+    ///      under via_ir (each helper keeps its locals in its own frame).
+    function setUp() public {
+        vm.warp(1_800_000_000);
+        // EXTERNAL self-calls, not internal helpers: via_ir re-inlines single-call-site internal
+        // functions straight back into setUp, recreating the overflowing frame. `this.` forces a
+        // real call frame per stage.
+        this.setUpCore();
+        this.setUpVenueA();
+        this.setUpVenueB();
+        this.setUpVenueC();
+        this.fundVenues();
+        this.deployStack();
+    }
+
+    function setUpCore() external {
+        usdc = new MockToken("USD Coin", "USDC", 6);
+        aero = new MockToken("Aerodrome", "AERO", 18);
+        clFactory = new MockCLFactory();
+        comptroller = new MockComptroller();
+        mUsdc = new MockLendingMarket(address(usdc));
+        router = new MockClSwapRouter();
+        sequencerFeed = new MockChainlinkFeed(0, 8, 1, block.timestamp - 2 hours);
+        usdcFeed = new MockChainlinkFeed(int256(P_USDC), 8, 1, block.timestamp);
+        aeroFeed = new MockChainlinkFeed(1e8, 8, 1, block.timestamp);
+    }
+
+    function setUpVenueA() external {
+        legB = new MockToken("Leg B", "LEGB", 8);
+        legA = new MockToken("Leg A", "LEGA", 18);
+        pool = new MockCLPool(address(legB), address(legA), SPACING);
+        pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK));
+        pool.setTick(TICK);
+        pool.setFactory(address(clFactory));
+        clFactory.setPool(address(usdc), address(legB), LEG_B_SWAP_SPACING, makeAddr("legBSwapPool"));
+        clFactory.setPool(address(usdc), address(legA), LEG_A_SWAP_SPACING, makeAddr("legASwapPool"));
+        gauge = new MockCLGauge(address(aero));
+        gauge.setPool(address(pool));
+        mLegB = new MockLendingMarket(address(legB));
+        mLegA = new MockLendingMarket(address(legA));
+        legBFeed = new MockChainlinkFeed(int256(P_LEG_B), 8, 1, block.timestamp);
+        legAFeed = new MockChainlinkFeed(int256(P_LEG_A), 8, 1, block.timestamp);
+        npm = new MockNpm(pool);
+    }
+
+    /// @dev Cross-pair destination: same prices/tick as venue A, different spacing.
+    function setUpVenueB() external {
+        legB2 = new MockToken("Leg B2", "LEGB2", 8);
+        legA2 = new MockToken("Leg A2", "LEGA2", 18);
+        poolB = new MockCLPool(address(legB2), address(legA2), SPACING_B);
+        poolB.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK));
+        poolB.setTick(TICK);
+        poolB.setFactory(address(clFactory));
+        clFactory.setPool(address(usdc), address(legB2), LEG_B2_SWAP_SPACING, makeAddr("legB2SwapPool"));
+        clFactory.setPool(address(usdc), address(legA2), LEG_A2_SWAP_SPACING, makeAddr("legA2SwapPool"));
+        gaugeB = new MockCLGauge(address(aero));
+        gaugeB.setPool(address(poolB));
+        mLegB2 = new MockLendingMarket(address(legB2));
+        mLegA2 = new MockLendingMarket(address(legA2));
+        legB2Feed = new MockChainlinkFeed(int256(P_LEG_B), 8, 1, block.timestamp);
+        legA2Feed = new MockChainlinkFeed(int256(P_LEG_A), 8, 1, block.timestamp);
+    }
+
+    /// @dev Asset-mode destination {usdc, legA2}: migrate-only, so no price/tick setup needed.
+    function setUpVenueC() external {
+        poolC = new MockCLPool(address(usdc), address(legA2), SPACING);
+        poolC.setFactory(address(clFactory));
+        gaugeC = new MockCLGauge(address(aero));
+        gaugeC.setPool(address(poolC));
+    }
+
+    function fundVenues() external {
+        usdc.mint(address(mUsdc), 100_000_000e6);
+        legB.mint(address(mLegB), 1_000_000e8);
+        legA.mint(address(mLegA), 1_000_000e18);
+        legB2.mint(address(mLegB2), 1_000_000e8);
+        legA2.mint(address(mLegA2), 1_000_000e18);
+        usdc.mint(address(router), 100_000_000e6);
+        legB.mint(address(router), 1_000_000e8);
+        legA.mint(address(router), 1_000_000e18);
+        legB2.mint(address(router), 1_000_000e8);
+        legA2.mint(address(router), 1_000_000e18);
+        router.setRate(address(legB), address(usdc), (P_LEG_B * 1e18) / (100 * 1e8));
+        router.setRate(address(usdc), address(legB), (100 * 1e8 * 1e18) / P_LEG_B);
+        router.setRate(address(legA), address(usdc), (P_LEG_A * 1e18) / (100 * 1e18));
+        router.setRate(address(usdc), address(legA), (100 * 1e18 * 1e18) / P_LEG_A);
+        router.setRate(address(legB2), address(usdc), (P_LEG_B * 1e18) / (100 * 1e8));
+        router.setRate(address(usdc), address(legB2), (100 * 1e8 * 1e18) / P_LEG_B);
+        router.setRate(address(legA2), address(usdc), (P_LEG_A * 1e18) / (100 * 1e18));
+        router.setRate(address(usdc), address(legA2), (100 * 1e18 * 1e18) / P_LEG_A);
+    }
+
+    function deployStack() external {
+        vault = new LeveragedAeroVault(address(usdc), owner, "Leveraged Aero Vault", "lvAERO");
+        strategy = LeveragedAerodromeCLStrategy(payable(Clones.clone(address(new LeveragedAerodromeCLStrategy()))));
+        strategy.initialize(address(vault), proposer, abi.encode(_paramsA()));
+
+        vm.startPrank(owner);
+        vault.setStrategy(address(strategy));
+        vault.setOpenDeposits(true);
+        vm.stopPrank();
+    }
+
+    // ==================== helpers ====================
+
+    function _paramsA() internal view returns (LeveragedAerodromeCLStrategy.InitParams memory p) {
+        p.usdc = address(usdc);
+        p.mUsdc = address(mUsdc);
+        p.mCbBTC = address(mLegB);
+        p.mWeth = address(mLegA);
+        p.comptroller = address(comptroller);
+        p.cbBTC = address(legB);
+        p.weth = address(legA);
+        p.pool = address(pool);
+        p.npm = address(npm);
+        p.gauge = address(gauge);
+        p.swapRouter = address(router);
+        p.cbBTCFeed = address(legBFeed);
+        p.wethFeed = address(legAFeed);
+        p.usdcFeed = address(usdcFeed);
+        p.sequencerFeed = address(sequencerFeed);
+        p.aeroUsdFeed = address(aeroFeed);
+        p.maxDelay = 1 hours;
+        p.gracePeriod = 1 hours;
+        p.calmDeviationTicks = 100;
+        p.twapWindow = 600;
+        p.tickSpacing = SPACING;
+        p.cbBTCSwapTickSpacing = LEG_B_SWAP_SPACING;
+        p.wethSwapTickSpacing = LEG_A_SWAP_SPACING;
+        p.wethDeliversNative = false;
+        p.width = WIDTH;
+        p.minWidth = 200;
+        p.maxWidth = 20_000;
+        p.targetLtvBps = TARGET_LTV_BPS;
+        p.maxLtvBps = 6500;
+        p.minHealthBps = 12_000;
+        p.maxSlippageBps = 100;
+        p.managementFeeBps = 0;
+        p.performanceFeeBps = 0;
+        p.feeRecipient = address(0);
+    }
+
+    /// @dev Venue B (cross-pair): fresh legs/markets/feeds/pool/gauge, spacing 200, width band on grid.
+    function _venueBParams() internal view returns (LeveragedAeroVenue.VenueParams memory v) {
+        v.mCbBTC = address(mLegB2);
+        v.mWeth = address(mLegA2);
+        v.cbBTC = address(legB2);
+        v.weth = address(legA2);
+        v.pool = address(poolB);
+        v.gauge = address(gaugeB);
+        v.cbBTCFeed = address(legB2Feed);
+        v.wethFeed = address(legA2Feed);
+        v.tickSpacing = SPACING_B;
+        v.cbBTCSwapTickSpacing = LEG_B2_SWAP_SPACING;
+        v.wethSwapTickSpacing = LEG_A2_SWAP_SPACING;
+        v.wethDeliversNative = false;
+        v.width = 4000;
+        v.minWidth = 400;
+        v.maxWidth = 20_000;
+        v.targetLtvBps = 4000;
+        v.maxLtvBps = 6000;
+        v.minHealthBps = 12_000;
+    }
+
+    /// @dev Venue C (asset-mode flip): leg-B slot IS usdc — market pinned to mUsdc, feed to usdcFeed,
+    ///      swap spacing 0, pool {usdc, legA2}.
+    function _venueCParams() internal view returns (LeveragedAeroVenue.VenueParams memory v) {
+        v = _venueBParams();
+        v.mCbBTC = address(mUsdc);
+        v.cbBTC = address(usdc);
+        v.pool = address(poolC);
+        v.gauge = address(gaugeC);
+        v.cbBTCFeed = address(usdcFeed);
+        v.tickSpacing = SPACING;
+        v.cbBTCSwapTickSpacing = 0;
+        v.minWidth = 200;
+    }
+
+    function _execute(uint256 amount) internal {
+        usdc.mint(address(strategy), amount);
+        vm.prank(address(vault));
+        strategy.execute();
+    }
+
+    function _flatten() internal {
+        vm.prank(proposer);
+        strategy.flatten();
+    }
+
+    function _stage(LeveragedAeroVenue.VenueParams memory v) internal {
+        bytes32 h = keccak256(abi.encode(v));
+        vm.prank(owner);
+        strategy.stageVenue(h);
+    }
+
+    function _migrate(LeveragedAeroVenue.VenueParams memory v) internal {
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+    }
+
+    function _assertFlat() internal view {
+        assertEq(strategy.layout().tokenId, 0, "no CL position");
+        (uint128 hA, uint128 hB) = strategy.hedgedDebt();
+        assertEq(hA, 0, "hedged basis A zero");
+        assertEq(hB, 0, "hedged basis B zero");
+        assertEq(mLegB.borrowBalance(address(strategy)), 0, "no leg-B debt");
+        assertEq(mLegA.borrowBalance(address(strategy)), 0, "no leg-A debt");
+        assertEq(mUsdc.balanceOf(address(strategy)), 0, "no collateral");
+    }
+
+    // ==================== flatten ====================
+
+    function testFlattenUnwindsWholeBookToIdleUsdcAndStaysExecuted() public {
+        _execute(SEED);
+        assertGt(strategy.layout().tokenId, 0, "book deployed");
+
+        vm.expectEmit(false, false, false, false, address(strategy));
+        emit LeveragedAeroVenue.Flattened(0); // amount unchecked (slippage-dependent)
+        _flatten();
+
+        _assertFlat();
+        uint256 idle = usdc.balanceOf(address(strategy));
+        assertGt(idle, (SEED * 98) / 100, "essentially the whole book realized as idle USDC");
+        assertEq(strategy.nav(), idle, "flat NAV == idle USDC (oracle-free)");
+        // Still Executed: the proposer-gated venue ops remain reachable (settle would brick them).
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, 0, 0); // flat-book no-op that requires State.Executed
+    }
+
+    function testFlattenRevertsForNonProposer() public {
+        _execute(SEED);
+        vm.expectRevert(BaseStrategy.NotProposer.selector);
+        vm.prank(lp);
+        strategy.flatten();
+    }
+
+    function testFlattenIsIdempotentOnAFlatBook() public {
+        _execute(SEED);
+        _flatten();
+        uint256 idleBefore = usdc.balanceOf(address(strategy));
+        _flatten(); // second flatten: unwind/repays are no-ops
+        assertEq(usdc.balanceOf(address(strategy)), idleBefore, "idle unchanged");
+        _assertFlat();
+    }
+
+    function testDepositAndRedeemWorkOnAFlatBook() public {
+        _execute(SEED);
+        // Seed a depositor while the book is live so supply > 0.
+        usdc.mint(lp, 200_000e6);
+        vm.startPrank(lp);
+        usdc.approve(address(strategy), 200_000e6);
+        uint256 shares = strategy.deposit(100_000e6, 0);
+        vm.stopPrank();
+
+        _flatten();
+
+        // Deposit prices against idle-USDC NAV.
+        uint256 navBefore = strategy.nav();
+        vm.prank(lp);
+        uint256 shares2 = strategy.deposit(100_000e6, 0);
+        assertGt(shares2, 0, "flat-book deposit mints");
+        assertEq(strategy.nav(), navBefore + 100_000e6, "NAV grew by exactly the deposit");
+
+        // Fast redeem funds entirely from idle (no collateral, no LTV gate).
+        uint256 lpUsdcBefore = usdc.balanceOf(lp);
+        vm.startPrank(lp);
+        vault.approve(address(strategy), shares);
+        uint256 out = strategy.redeem(shares, 0);
+        vm.stopPrank();
+        assertGt(out, 0, "flat-book redeem pays");
+        assertEq(usdc.balanceOf(lp) - lpUsdcBefore, out, "payout delivered");
+    }
+
+    // ==================== staging ====================
+
+    function testStageVenueIsVaultOwnerOnly() public {
+        bytes32 h = keccak256("venue");
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotVaultOwner.selector);
+        vm.prank(proposer);
+        strategy.stageVenue(h);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotVaultOwner.selector);
+        vm.prank(lp);
+        strategy.stageVenue(h);
+
+        vm.expectEmit(false, false, false, true, address(strategy));
+        emit LeveragedAeroVenue.VenueStaged(h);
+        vm.prank(owner);
+        strategy.stageVenue(h);
+        assertEq(strategy.layout().stagedVenueHash, h, "hash staged");
+
+        // Staging is inert: live venue untouched.
+        assertEq(strategy.layout().pool, address(pool), "live venue unchanged");
+
+        // Clear.
+        vm.prank(owner);
+        strategy.stageVenue(bytes32(0));
+        assertEq(strategy.layout().stagedVenueHash, bytes32(0), "hash cleared");
+    }
+
+    // ==================== migrate: gates ====================
+
+    function testMigrateRevertsWithoutAStagedHash() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        vm.expectRevert(LeveragedAeroVenue.VenueNotStaged.selector);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+    }
+
+    function testMigrateRevertsWhenParamsDoNotMatchTheStagedHash() public {
+        _execute(SEED);
+        _flatten();
+        _stage(_venueBParams());
+        LeveragedAeroVenue.VenueParams memory tampered = _venueBParams();
+        tampered.targetLtvBps = 5000; // one field off the committed config
+        vm.expectRevert(LeveragedAeroVenue.VenueNotStaged.selector);
+        vm.prank(proposer);
+        strategy.migrateVenue(tampered);
+    }
+
+    function testMigrateRevertsWhileThePositionIsLive() public {
+        _execute(SEED);
+        _stage(_venueBParams());
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        vm.expectRevert(LeveragedAeroVenue.BookNotFlat.selector);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+        assertEq(strategy.layout().pool, address(pool), "venue untouched");
+    }
+
+    function testMigrateRevertsWhileLegDebtRemains() public {
+        _execute(SEED);
+        _flatten();
+        // Manufacture residual debt on a flat book (donation-style borrow as the strategy).
+        vm.prank(address(strategy));
+        mLegA.borrow(1e18);
+        _stage(_venueBParams());
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        vm.expectRevert(LeveragedAeroVenue.BookNotFlat.selector);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+    }
+
+    function testMigrateRevertsForNonProposerIncludingOwner() public {
+        _execute(SEED);
+        _flatten();
+        _stage(_venueBParams());
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        vm.expectRevert(BaseStrategy.NotProposer.selector);
+        vm.prank(owner);
+        strategy.migrateVenue(v);
+    }
+
+    // ==================== migrate: destination validation ====================
+
+    function _expectMigrateRevert(LeveragedAeroVenue.VenueParams memory v, bytes4 err) internal {
+        _stage(v);
+        vm.expectRevert(err);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+        assertEq(strategy.layout().pool, address(pool), "venue untouched after rejected config");
+    }
+
+    function testMigrateRejectsAPoolThatIsNotTheDeclaredPair() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.cbBTC = address(legB); // old leg B — poolB's token set is {legB2, legA2}
+        v.mCbBTC = address(mLegB);
+        v.cbBTCFeed = address(legBFeed);
+        _expectMigrateRevert(v, LeveragedAeroVenue.VenueMismatch.selector);
+    }
+
+    function testMigrateRejectsAGaugeNotBoundToThePool() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        MockCLGauge unbound = new MockCLGauge(address(aero)); // pool() == address(0)
+        v.gauge = address(unbound);
+        _expectMigrateRevert(v, LeveragedAeroVenue.VenueMismatch.selector);
+    }
+
+    function testMigrateRejectsAMissingLegSwapPool() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.cbBTCSwapTickSpacing = 300; // no legB2/USDC pool registered at this spacing
+        _expectMigrateRevert(v, LeveragedAeroVenue.VenueMismatch.selector);
+    }
+
+    function testMigrateRejectsAnOffGridWidth() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.width = 4100; // off the 200 grid
+        _expectMigrateRevert(v, LeveragedAeroVenue.WidthOutOfBounds.selector);
+    }
+
+    function testMigrateRejectsTargetLtvAboveMax() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.targetLtvBps = 6100; // > maxLtvBps 6000
+        _expectMigrateRevert(v, LeveragedAeroVenue.TargetLtvExceedsMax.selector);
+    }
+
+    // ==================== migrate: happy paths ====================
+
+    function testMigratePreservesNavSharesAndHwm() public {
+        _execute(SEED);
+        usdc.mint(lp, 100_000e6);
+        vm.startPrank(lp);
+        usdc.approve(address(strategy), 100_000e6);
+        uint256 lpShares = strategy.deposit(100_000e6, 0);
+        vm.stopPrank();
+
+        _flatten();
+        _stage(_venueBParams());
+
+        uint256 navBefore = strategy.nav();
+        uint256 hwmBefore = strategy.layout().hwmPerShare;
+
+        vm.expectEmit(true, true, false, true, address(strategy));
+        emit LeveragedAeroVenue.VenueMigrated(address(pool), address(poolB));
+        _migrate(_venueBParams());
+
+        // NAV + share ledger continuity across the rewrite.
+        assertEq(strategy.nav(), navBefore, "NAV identical across the venue rewrite");
+        assertEq(vault.balanceOf(lp), lpShares, "share balances untouched");
+        assertEq(strategy.layout().hwmPerShare, hwmBefore, "HWM untouched");
+        assertEq(strategy.layout().stagedVenueHash, bytes32(0), "staged hash consumed");
+    }
+
+    function testMigrateRewritesTheWholeVenueSubset() public {
+        _execute(SEED);
+        _flatten();
+        _stage(_venueBParams());
+        _migrate(_venueBParams());
+        _assertVenueBApplied();
+    }
+
+    /// @dev Own frame (not inlined in the test) so the assert cascade's locals never share a stack
+    ///      with the migration-driving frame — via_ir stack-depth hygiene.
+    function _assertVenueBApplied() internal view {
+        LeveragedAerodromeCLStrategy.LayoutView memory l = strategy.layout();
+        assertEq(l.pool, address(poolB), "pool");
+        assertEq(l.gauge, address(gaugeB), "gauge");
+        assertEq(l.cbBTC, address(legB2), "leg B");
+        assertEq(l.weth, address(legA2), "leg A");
+        assertEq(l.mCbBTC, address(mLegB2), "market B");
+        assertEq(l.mWeth, address(mLegA2), "market A");
+        assertEq(l.cbBTCFeed, address(legB2Feed), "feed B");
+        assertEq(l.wethFeed, address(legA2Feed), "feed A");
+        assertEq(l.tickSpacing, SPACING_B, "spacing");
+        assertEq(l.cbBTCSwapTickSpacing, LEG_B2_SWAP_SPACING, "swap spacing B");
+        assertEq(l.wethSwapTickSpacing, LEG_A2_SWAP_SPACING, "swap spacing A");
+        assertEq(l.width, 4000, "width");
+        assertEq(l.minWidth, 400, "minWidth");
+        assertEq(l.maxWidth, 20_000, "maxWidth");
+        assertEq(l.targetLtvBps, 4000, "targetLtv");
+        assertEq(l.maxLtvBps, 6000, "maxLtv");
+        assertFalse(l.legBIsAsset, "still two-leg shape");
+    }
+
+    function testMigrateToAssetModeRederivesTheShape() public {
+        _execute(SEED);
+        _flatten();
+        _stage(_venueCParams());
+        _migrate(_venueCParams());
+
+        LeveragedAerodromeCLStrategy.LayoutView memory l = strategy.layout();
+        assertTrue(l.legBIsAsset, "asset-mode derived from config");
+        assertEq(l.cbBTC, address(usdc), "leg B slot is the unit of account");
+        assertEq(l.mCbBTC, address(mUsdc), "leg B market pinned to mUSDC");
+        assertEq(l.cbBTCFeed, address(usdcFeed), "leg B feed pinned to USDC/USD");
+        assertEq(l.cbBTCSwapTickSpacing, 0, "leg B swap spacing declared unused");
+        assertFalse(l.wethIsToken0, "usdc is token0 in poolC");
+    }
+
+    // ==================== redeploy ====================
+
+    function testRedeployOpensAFreshPositionInTheNewVenue() public {
+        _execute(SEED);
+        _flatten();
+        _stage(_venueBParams());
+        _migrate(_venueBParams());
+
+        npm.setPool(poolB); // the mock NPM reads geometry off one pool; re-point it at venue B
+        uint256 idle = usdc.balanceOf(address(strategy));
+
+        vm.prank(proposer);
+        strategy.redeploy();
+
+        assertGt(strategy.layout().tokenId, 0, "fresh position minted");
+        assertEq(gaugeB.depositCallCount(), 1, "staked in the NEW gauge");
+        assertEq(gauge.depositCallCount(), 1, "old gauge untouched since genesis");
+        // Whole idle deployed as collateral at the NEW venue's target LTV.
+        uint256 collateral = (mUsdc.balanceOf(address(strategy)) * mUsdc.exchangeRateStored()) / 1e18;
+        assertEq(collateral, idle, "entire idle became collateral");
+        assertGt(mLegB2.borrowBalance(address(strategy)), 0, "borrows in the new leg-B market");
+        assertGt(mLegA2.borrowBalance(address(strategy)), 0, "borrows in the new leg-A market");
+        assertEq(mLegB.borrowBalance(address(strategy)), 0, "no debt in the old markets");
+        assertEq(mLegA.borrowBalance(address(strategy)), 0, "no debt in the old markets");
+    }
+
+    function testRedeployRevertsWhileAPositionIsOpen() public {
+        _execute(SEED);
+        vm.expectRevert(LeveragedAeroVenue.PositionAlreadyOpen.selector);
+        vm.prank(proposer);
+        strategy.redeploy();
+    }
+
+    function testRedeployRevertsForNonProposer() public {
+        _execute(SEED);
+        _flatten();
+        vm.expectRevert(BaseStrategy.NotProposer.selector);
+        vm.prank(lp);
+        strategy.redeploy();
+    }
+
+    // ==================== continuity across the full sequence ====================
+
+    function testPendingRedeemRequestSurvivesTheFullMigration() public {
+        _execute(SEED);
+        usdc.mint(lp, 100_000e6);
+        vm.startPrank(lp);
+        usdc.approve(address(strategy), 100_000e6);
+        uint256 shares = strategy.deposit(100_000e6, 0);
+        vault.approve(address(strategy), shares);
+        uint256 id = strategy.requestRedeem(shares, 0);
+        vm.stopPrank();
+
+        _flatten();
+        _stage(_venueBParams());
+        _migrate(_venueBParams());
+        npm.setPool(poolB);
+        vm.prank(proposer);
+        strategy.redeploy();
+
+        uint256 lpUsdcBefore = usdc.balanceOf(lp);
+        vm.prank(proposer);
+        strategy.fulfillRedeem(id);
+        assertGt(usdc.balanceOf(lp) - lpUsdcBefore, 0, "request fulfilled post-migration for the same shares");
+        assertTrue(strategy.redeemRequest(id).settled, "request settled");
+    }
+
+    function testOldLegDustIsRescuableAfterCrossPairMigrationAndNewLegsAreNot() public {
+        _execute(SEED);
+        _flatten();
+        _stage(_venueBParams());
+        _migrate(_venueBParams());
+
+        legA.mint(address(strategy), 1e15); // old-leg unwind dust
+        uint256 vaultBefore = legA.balanceOf(address(vault));
+        vm.prank(owner);
+        strategy.rescueToVault(address(legA));
+        assertEq(legA.balanceOf(address(vault)) - vaultBefore, 1e15, "old leg swept to the vault");
+
+        vm.expectRevert(LeveragedAerodromeCLStrategy.CannotRescuePositionToken.selector);
+        vm.prank(owner);
+        strategy.rescueToVault(address(legA2)); // NEW leg is now a position token
+    }
+}

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -6,6 +6,7 @@ import {LeveragedAeroValuation} from "@contracts/leveraged-aero/LeveragedAeroVal
 import {LeveragedAeroVenue} from "@contracts/leveraged-aero/LeveragedAeroVenue.sol";
 import {LeveragedAerodromeCLStrategy} from "@contracts/leveraged-aero/LeveragedAerodromeCLStrategy.sol";
 import {BaseStrategy} from "@contracts/leveraged-aero/sherwood/BaseStrategy.sol";
+import {ChainlinkReader} from "@contracts/leveraged-aero/sherwood/libraries/ChainlinkReader.sol";
 import {TickMath} from "@contracts/leveraged-aero/sherwood/libraries/TickMath.sol";
 
 import {MockCLGauge} from "../mocks/MockCLGauge.sol";
@@ -109,6 +110,13 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
     ///      validation to prove the reward token has a USDC route. Etched below (no code otherwise).
     address internal constant AERO_V2_FACTORY = 0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
 
+    /// @dev `LeveragedAeroVenue.applyVenue` pins the canonical Slipstream CLFactory rather than
+    ///      trusting `pool.factory()`, so a fork-free test has to place the registry HERE, and every
+    ///      destination pool must be REGISTERED at its declared pair + spacing to be adoptable.
+    ///      Etch is safe despite `MockCLFactory` being storage-based: only the code is copied, and
+    ///      every `setPool` below writes to the etched address's own storage.
+    address internal constant AERODROME_CL_FACTORY = 0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A;
+
     function setUp() public {
         vm.warp(1_800_000_000);
         // EXTERNAL self-calls, not internal helpers: via_ir re-inlines single-call-site internal
@@ -125,7 +133,8 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
     function setUpCore() external {
         usdc = new MockToken("USD Coin", "USDC", 6);
         aero = new MockToken("Aerodrome", "AERO", 18);
-        clFactory = new MockCLFactory();
+        clFactory = MockCLFactory(AERODROME_CL_FACTORY);
+        vm.etch(AERODROME_CL_FACTORY, address(new MockCLFactory()).code);
         comptroller = new MockComptroller();
         mUsdc = new MockLendingMarket(address(usdc));
         router = new MockClSwapRouter();
@@ -140,7 +149,8 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         pool = new MockCLPool(address(legB), address(legA), SPACING);
         pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK));
         pool.setTick(TICK);
-        pool.setFactory(address(clFactory));
+        pool.setFactory(AERODROME_CL_FACTORY);
+        clFactory.setPool(address(legB), address(legA), SPACING, address(pool));
         clFactory.setPool(address(usdc), address(legB), LEG_B_SWAP_SPACING, makeAddr("legBSwapPool"));
         clFactory.setPool(address(usdc), address(legA), LEG_A_SWAP_SPACING, makeAddr("legASwapPool"));
         gauge = new MockCLGauge(address(aero));
@@ -166,7 +176,8 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         poolB = new MockCLPool(address(legB2), address(legA2), SPACING_B);
         poolB.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK));
         poolB.setTick(TICK);
-        poolB.setFactory(address(clFactory));
+        poolB.setFactory(AERODROME_CL_FACTORY);
+        clFactory.setPool(address(legB2), address(legA2), SPACING_B, address(poolB));
         clFactory.setPool(address(usdc), address(legB2), LEG_B2_SWAP_SPACING, makeAddr("legB2SwapPool"));
         clFactory.setPool(address(usdc), address(legA2), LEG_A2_SWAP_SPACING, makeAddr("legA2SwapPool"));
         gaugeB = new MockCLGauge(address(aero));
@@ -182,7 +193,8 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
     /// @dev Asset-mode destination {usdc, legA2}: migrate-only, so no price/tick setup needed.
     function setUpVenueC() external {
         poolC = new MockCLPool(address(usdc), address(legA2), SPACING);
-        poolC.setFactory(address(clFactory));
+        poolC.setFactory(AERODROME_CL_FACTORY);
+        clFactory.setPool(address(usdc), address(legA2), SPACING, address(poolC));
         gaugeC = new MockCLGauge(address(aero));
         gaugeC.setPool(address(poolC));
         poolC.setGauge(address(gaugeC));
@@ -263,6 +275,31 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         p.managementFeeBps = 0;
         p.performanceFeeBps = 0;
         p.feeRecipient = address(0);
+    }
+
+    /// @dev Venue A as a MIGRATION DESTINATION — the same venue `_baseParams()` initialises with,
+    ///      marshalled as `VenueParams` so a test can migrate BACK to it. Every field must match
+    ///      `_baseParams()`'s venue subset or the round trip is not a round trip.
+    function _venueAParams() internal view returns (LeveragedAeroVenue.VenueParams memory v) {
+        v.mCbBTC = address(mLegB);
+        v.mWeth = address(mLegA);
+        v.cbBTC = address(legB);
+        v.weth = address(legA);
+        v.pool = address(pool);
+        v.gauge = address(gauge);
+        v.cbBTCFeed = address(legBFeed);
+        v.wethFeed = address(legAFeed);
+        v.aeroUsdFeed = address(aeroFeed);
+        v.tickSpacing = SPACING;
+        v.cbBTCSwapTickSpacing = LEG_B_SWAP_SPACING;
+        v.wethSwapTickSpacing = LEG_A_SWAP_SPACING;
+        v.wethDeliversNative = false;
+        v.width = WIDTH;
+        v.minWidth = 200;
+        v.maxWidth = 20_000;
+        v.targetLtvBps = TARGET_LTV_BPS;
+        v.maxLtvBps = 6500;
+        v.minHealthBps = 12_000;
     }
 
     /// @dev Venue B (cross-pair): fresh legs/markets/feeds/pool/gauge, spacing 200, width band on grid.
@@ -488,6 +525,40 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         assertEq(strategy.layout().pool, address(poolB), "migration no longer blocked by dust");
     }
 
+    /// @dev The dust skip used to sit AFTER `readUsd8`, so dust still gated `flatten` on the reward
+    ///      feed being healthy — and `flatten` is `migrateVenue`'s own precondition, which made a
+    ///      feed outage plus one wei of donated dust enough to stall a migration for the duration of
+    ///      the outage, for zero economic benefit. The oracle-free band now short-circuits first.
+    function testFlattenIgnoresDustWithoutConsultingAStaleRewardFeed() public {
+        _execute(SEED);
+        aero.mint(address(strategy), 1e6);
+        aeroFeed.setUpdatedAt(block.timestamp - 2 hours); // past the 1 hour maxDelay
+
+        vm.prank(proposer);
+        strategy.flatten(1, 0);
+
+        _assertFlat();
+        assertEq(aero.balanceOf(address(strategy)), 1e6, "dust left in place");
+        // The migration the outage would otherwise have stalled still completes.
+        _stage(_venueBParams());
+        _migrate(_venueBParams());
+        assertEq(strategy.layout().pool, address(poolB), "migration not stalled by a stale feed");
+    }
+
+    /// @dev The narrow half of the same branch, and the reason it is safe: the oracle-free band is
+    ///      derived from a price CEILING, so anything above it still consults the feed and still
+    ///      fails closed when that feed is stale. The band can only ever be narrower than the priced
+    ///      `floor == 0` skip, never wider.
+    function testFlattenStillFailsClosedOnAStaleFeedAboveTheOracleFreeBand() public {
+        _execute(SEED);
+        aero.mint(address(strategy), 1e9); // > 1e20 / REWARD_PRICE_CEILING_USD8 (== 1e8)
+        aeroFeed.setUpdatedAt(block.timestamp - 2 hours);
+
+        vm.expectRevert(ChainlinkReader.StaleOracle.selector);
+        vm.prank(proposer);
+        strategy.flatten(1, 0);
+    }
+
     /// @dev The dust skip must NOT widen the guard for a real tranche: a balance whose oracle floor is
     ///      nonzero still has to clear both the caller's floor and the L9 post-check.
     function testFlattenStillSellsABalanceJustAboveTheDustThreshold() public {
@@ -665,6 +736,100 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         // ...but poolB.gauge() still points at the real gaugeB.
         v.gauge = address(impostor);
         _expectMigrateRevert(v, LeveragedAeroVenue.VenueMismatch.selector);
+    }
+
+    // ==================== CANONICAL FACTORY BINDING (migrate side) ====================
+
+    /// @dev The migrate-side half of the init binding: a destination pool is adoptable only if the
+    ///      CANONICAL Slipstream factory registers it. A pool that nominates its own registry — the
+    ///      self-attestation the binding removes — is rejected even when that registry vouches for
+    ///      it completely. This is the seam that mattered most at runtime: init is deployer-driven,
+    ///      whereas `migrateVenue` re-points a LIVE fund at a pool chosen months later.
+    function testMigrateRejectsADestinationPoolThatNominatesAForeignFactory() public {
+        _execute(SEED);
+        _flatten();
+        MockCLFactory rogue = new MockCLFactory();
+        rogue.setPool(address(usdc), address(legB2), LEG_B2_SWAP_SPACING, makeAddr("rogueB2Swap"));
+        rogue.setPool(address(usdc), address(legA2), LEG_A2_SWAP_SPACING, makeAddr("rogueA2Swap"));
+        rogue.setPool(address(legB2), address(legA2), SPACING_B, address(poolB));
+        poolB.setFactory(address(rogue));
+        _expectMigrateRevert(_venueBParams(), LeveragedAeroVenue.VenueMismatch.selector);
+    }
+
+    /// @dev And the registration itself is load-bearing, not just the factory address.
+    function testMigrateRejectsADestinationTheCanonicalFactoryDoesNotRegister() public {
+        _execute(SEED);
+        _flatten();
+        clFactory.setPool(address(legB2), address(legA2), SPACING_B, address(0));
+        _expectMigrateRevert(_venueBParams(), LeveragedAeroVenue.VenueMismatch.selector);
+    }
+
+    // ==================== ROUND TRIP ====================
+
+    /// @dev A→B→A. Every prior migration test moves the fund ONE way, so nothing ever migrated OUT of
+    ///      a venue with a different token ordering or shape — which is exactly why migrate-staleness
+    ///      mutants on the DERIVED fields survived: a stale `wethIsToken0` / `legBIsAsset` / leg
+    ///      decimals looks identical to a correct one until a second migration has to overwrite it.
+    ///      Venue B is deliberately a different pair AND a different spacing, so the return leg has to
+    ///      rewrite the derived set rather than leave it alone.
+    function testMigrateRoundTripRestoresEveryDerivedField() public {
+        _execute(SEED);
+        _flatten();
+
+        LeveragedAerodromeCLStrategy.LayoutView memory before = strategy.layout();
+        assertFalse(before.wethIsToken0, "venue A sorts leg B first");
+
+        // FLIP THE ORDERING on the destination. Without this the round trip is blind to the mutant
+        // it exists to catch: venues A and B both sort leg B into token0, so a DELETED
+        // `$.wethIsToken0` write is indistinguishable from a correct one and the mutant survives.
+        // Verified: with the flip, deleting that write fails this test.
+        poolB.setTokens(address(legA2), address(legB2));
+        clFactory.setPool(address(legA2), address(legB2), SPACING_B, address(poolB));
+
+        _stage(_venueBParams());
+        _migrate(_venueBParams());
+        assertEq(strategy.layout().pool, address(poolB), "outbound leg landed");
+        assertTrue(strategy.layout().wethIsToken0, "ordering flipped on the way out");
+
+        _stage(_venueAParams());
+        _migrate(_venueAParams());
+
+        LeveragedAerodromeCLStrategy.LayoutView memory afterTrip = strategy.layout();
+        assertEq(afterTrip.pool, before.pool, "pool restored");
+        assertEq(afterTrip.gauge, before.gauge, "gauge restored");
+        assertEq(afterTrip.cbBTC, before.cbBTC, "leg B restored");
+        assertEq(afterTrip.weth, before.weth, "leg A restored");
+        assertEq(afterTrip.mCbBTC, before.mCbBTC, "leg B market restored");
+        assertEq(afterTrip.mWeth, before.mWeth, "leg A market restored");
+        assertEq(afterTrip.tickSpacing, before.tickSpacing, "spacing restored");
+        // The DERIVED set — the fields a stale-write mutant leaves behind.
+        assertEq(afterTrip.wethIsToken0, before.wethIsToken0, "ordering re-derived");
+        assertEq(afterTrip.legBIsAsset, before.legBIsAsset, "shape re-derived");
+        assertEq(afterTrip.cbBTCDecimals, before.cbBTCDecimals, "leg B decimals re-derived");
+        assertEq(afterTrip.wethDecimals, before.wethDecimals, "leg A decimals re-derived");
+    }
+
+    /// @dev The shape half of the same gap: venue C is ASSET-MODE (`cbBTC == usdc`), so
+    ///      `legBIsAsset` must flip false→true on the way out and true→false on the way back. Only a
+    ///      migration OUT of asset mode can catch a stale write to it, and until now nothing migrated
+    ///      out of anything.
+    function testMigrateRoundTripThroughAssetModeRestoresTheShape() public {
+        _execute(SEED);
+        _flatten();
+
+        LeveragedAerodromeCLStrategy.LayoutView memory before = strategy.layout();
+        assertFalse(before.legBIsAsset, "venue A is the two-borrowed-legs shape");
+
+        _stage(_venueCParams());
+        _migrate(_venueCParams());
+        assertTrue(strategy.layout().legBIsAsset, "asset mode adopted");
+
+        _stage(_venueAParams());
+        _migrate(_venueAParams());
+        assertFalse(strategy.layout().legBIsAsset, "shape re-derived on the way back");
+        assertEq(strategy.layout().cbBTC, before.cbBTC, "leg B is a real borrowed leg again");
+        assertEq(strategy.layout().mCbBTC, before.mCbBTC, "leg B market restored");
+        assertEq(strategy.layout().cbBTCSwapTickSpacing, before.cbBTCSwapTickSpacing, "leg B spacing restored");
     }
 
     /// @dev The reward leg is a THIRD swap venue (Aerodrome v2, volatile, hardcoded route). Without a

--- a/test/leveraged-aero/LeveragedAeroVenuesHarness.sol
+++ b/test/leveraged-aero/LeveragedAeroVenuesHarness.sol
@@ -281,12 +281,23 @@ contract MockNpm {
     }
 
     mapping(uint256 => Pos) internal _pos;
+    /// @notice ERC-721 owner of each minted position.
+    /// @dev MODELLED ON PURPOSE. The previous stub had a no-op `approve` and no owner at all, so every
+    ///      liquidity call succeeded regardless of who held the NFT — which makes a
+    ///      touch-the-position-before-unstaking bug invisible to the suite and a revert on chain (the
+    ///      real NPM authorises `increaseLiquidity`/`decreaseLiquidity`/`collect` against the owner or
+    ///      an approved operator, and a staked NFT is owned by the GAUGE). Same fidelity-gap class as
+    ///      the `MockCLGauge._stakes` set.
+    mapping(uint256 => address) public ownerOf;
+    mapping(uint256 => address) public getApproved;
     uint256 public nextId = 1;
     /// @dev Settable (not immutable): the real NPM is pool-agnostic, so a venue-migration test
     ///      re-points the mock at the destination pool before driving `redeploy`.
     MockCLPool public pool;
 
     error MockNpmSlippage();
+    error MockNpmNotAuthorised();
+    error MockNpmNotOwner();
 
     constructor(MockCLPool pool_) {
         pool = pool_;
@@ -331,11 +342,31 @@ contract MockNpm {
             owed0: 0,
             owed1: 0
         });
+        ownerOf[tokenId] = mp.recipient;
+    }
+
+    /// @dev Authorised == owner or the single approved operator, mirroring the real NPM's
+    ///      `isAuthorizedForToken`.
+    modifier onlyAuthorised(uint256 tokenId) {
+        if (msg.sender != ownerOf[tokenId] && msg.sender != getApproved[tokenId]) revert MockNpmNotAuthorised();
+        _;
+    }
+
+    /// @notice ERC-721 transfer, as the gauge performs on stake/unstake.
+    function transferFrom(address from, address to, uint256 tokenId) public onlyAuthorised(tokenId) {
+        if (ownerOf[tokenId] != from) revert MockNpmNotOwner();
+        ownerOf[tokenId] = to;
+        getApproved[tokenId] = address(0);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId) external {
+        transferFrom(from, to, tokenId);
     }
 
     function increaseLiquidity(INonfungiblePositionManager.IncreaseLiquidityParams calldata ip)
         external
         payable
+        onlyAuthorised(ip.tokenId)
         returns (uint128 liquidity, uint256 amount0, uint256 amount1)
     {
         Pos storage p = _pos[ip.tokenId];
@@ -348,6 +379,7 @@ contract MockNpm {
     function decreaseLiquidity(INonfungiblePositionManager.DecreaseLiquidityParams calldata dp)
         external
         payable
+        onlyAuthorised(dp.tokenId)
         returns (uint256 amount0, uint256 amount1)
     {
         Pos storage p = _pos[dp.tokenId];
@@ -366,6 +398,7 @@ contract MockNpm {
     function collect(INonfungiblePositionManager.CollectParams calldata cp)
         external
         payable
+        onlyAuthorised(cp.tokenId)
         returns (uint256 amount0, uint256 amount1)
     {
         Pos storage p = _pos[cp.tokenId];
@@ -377,8 +410,12 @@ contract MockNpm {
         if (amount1 > 0) IERC20(p.token1).safeTransfer(cp.recipient, amount1);
     }
 
-    /// @dev ERC-721 approve — the manager calls this raw before staking; only success matters.
-    function approve(address, uint256) external {}
+    /// @dev ERC-721 approve — the manager calls this raw before staking. Records the operator (and
+    ///      rejects a non-owner) so the gauge's pull is authorised the way the real one is.
+    function approve(address to, uint256 tokenId) external {
+        if (msg.sender != ownerOf[tokenId]) revert MockNpmNotOwner();
+        getApproved[tokenId] = to;
+    }
 
     function _addFor(int24 tickLower, int24 tickUpper, uint256 desired0, uint256 desired1)
         internal
@@ -395,6 +432,31 @@ contract MockNpm {
     function _pull(address token0, address token1, uint256 amount0, uint256 amount1) internal {
         if (amount0 > 0) IERC20(token0).safeTransferFrom(msg.sender, address(this), amount0);
         if (amount1 > 0) IERC20(token1).safeTransferFrom(msg.sender, address(this), amount1);
+    }
+}
+
+/// @notice Aerodrome **v2 (AMM)** PoolFactory stand-in for venue validation's reward-route probe.
+/// @dev Same etch-at-a-hardcoded-address constraint as {MockAeroV2Router} below, and the same
+///      immutables-only rule for the same reason: `applyVenue` probes `AERO_V2_FACTORY.getPool(reward,
+///      usdc, false)` to prove the reward leg has a route BEFORE adopting a venue, and that address has
+///      no code in a fork-free test. Answers with `pool` for the configured volatile pair (either
+///      ordering, as the real factory sorts) and `address(0)` for everything else — so a test can model
+///      "reward token with no USDC route" by etching an instance configured for a different pair.
+contract MockAeroV2Factory {
+    address public immutable tokenA;
+    address public immutable tokenB;
+    address public immutable pool;
+
+    constructor(address tokenA_, address tokenB_, address pool_) {
+        tokenA = tokenA_;
+        tokenB = tokenB_;
+        pool = pool_;
+    }
+
+    function getPool(address a, address b, bool stable) external view returns (address) {
+        if (stable) return address(0);
+        if ((a == tokenA && b == tokenB) || (a == tokenB && b == tokenA)) return pool;
+        return address(0);
     }
 }
 

--- a/test/leveraged-aero/LeveragedAeroVenuesHarness.sol
+++ b/test/leveraged-aero/LeveragedAeroVenuesHarness.sol
@@ -282,11 +282,18 @@ contract MockNpm {
 
     mapping(uint256 => Pos) internal _pos;
     uint256 public nextId = 1;
-    MockCLPool public immutable pool;
+    /// @dev Settable (not immutable): the real NPM is pool-agnostic, so a venue-migration test
+    ///      re-points the mock at the destination pool before driving `redeploy`.
+    MockCLPool public pool;
 
     error MockNpmSlippage();
 
     constructor(MockCLPool pool_) {
+        pool = pool_;
+    }
+
+    /// @notice Re-point the geometry source at a different pool (venue-migration tests).
+    function setPool(MockCLPool pool_) external {
         pool = pool_;
     }
 

--- a/test/leveraged-aero/layout_parity.sh
+++ b/test/leveraged-aero/layout_parity.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 STRAT="$ROOT/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol"
 MGR="$ROOT/src/leveraged-aero/LeveragedAeroManager.sol"
+VENUE="$ROOT/src/leveraged-aero/LeveragedAeroVenue.sol"
 
 norm() { sed 's#//.*##; s/[[:space:]]*$//' | grep -v '^[[:space:]]*$' || true; }
 
@@ -33,4 +34,7 @@ extract() {
 
 kind="${1:?usage: layout_parity.sh <redeemrequest|layout|storageslot>}"
 
+# Three-way parity: strategy is the reference copy; the manager AND the venue library must both
+# match it (all three are delegatecall peers over the same ERC-7201 slot).
 diff <(extract "$STRAT" "$kind" | norm) <(extract "$MGR" "$kind" | norm) || true
+diff <(extract "$STRAT" "$kind" | norm) <(extract "$VENUE" "$kind" | norm) || true

--- a/test/mocks/MockCLGauge.sol
+++ b/test/mocks/MockCLGauge.sol
@@ -40,13 +40,27 @@ contract MockCLGauge {
         aeroToPayOnWithdraw = amount;
     }
 
+    /// @dev Per-depositor stake set, mirroring the real Slipstream `CLGauge._stakes`. Modelled on
+    ///      purpose: the previous stub let `withdraw` succeed on an NFT the gauge never held, which
+    ///      made an unstaked-but-still-referenced position indistinguishable from a staked one and
+    ///      hid a permanent-DoS class of bug from the whole suite.
+    mapping(address => mapping(uint256 => bool)) internal _staked;
+
+    error MockCLGaugeNotStaked();
+
     function deposit(uint256 tokenId) external {
         lastDepositedTokenId = tokenId;
         lastDepositor = msg.sender;
         depositCallCount++;
+        _staked[msg.sender][tokenId] = true;
     }
 
     function withdraw(uint256 tokenId) external {
+        // The real CLGauge reverts when the caller is not the staked depositor (it transfers the NFT
+        // out of the gauge's own custody). Enforced here so a test can observe the orphaned-NFT state.
+        if (!_staked[msg.sender][tokenId]) revert MockCLGaugeNotStaked();
+        _staked[msg.sender][tokenId] = false;
+
         lastWithdrawnTokenId = tokenId;
         lastWithdrawCaller = msg.sender;
         withdrawCallCount++;
@@ -95,7 +109,7 @@ contract MockCLGauge {
         return aeroToken;
     }
 
-    function stakedContains(address, uint256) external pure returns (bool) {
-        return false;
+    function stakedContains(address depositor, uint256 tokenId) external view returns (bool) {
+        return _staked[depositor][tokenId];
     }
 }

--- a/test/mocks/MockCLGauge.sol
+++ b/test/mocks/MockCLGauge.sol
@@ -4,6 +4,11 @@ pragma solidity 0.8.28;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+/// @dev The slice of the position manager this gauge needs for custody.
+interface IMockNpmCustody {
+    function transferFrom(address from, address to, uint256 tokenId) external;
+}
+
 /// @notice Minimal mock for ICLGauge used in unit tests.
 contract MockCLGauge {
     using SafeERC20 for IERC20;
@@ -12,6 +17,14 @@ contract MockCLGauge {
 
     // Pool this gauge is bound to (read by _validateAndStore's gauge->pool binding check).
     address public pool;
+
+    /// @notice The position manager to take real ERC-721 custody through. OPT-IN: when unset the gauge
+    ///         only tracks the stake set, preserving the behaviour older suites rely on.
+    /// @dev Wired by the leveraged-aero suites so a staked NFT is actually OWNED by the gauge, the way
+    ///      the real CLGauge holds it. Without custody, `MockNpm` would still authorise the strategy to
+    ///      touch a staked position — so a liquidity-touch-before-unstake bug passes the suite and
+    ///      reverts on chain.
+    address public npm;
 
     // Amount of AERO to pay out when withdraw() is called
     uint256 public aeroToPayOnWithdraw;
@@ -35,6 +48,11 @@ contract MockCLGauge {
         pool = pool_;
     }
 
+    /// @notice Enable real ERC-721 custody through `npm_` (see the `npm` field).
+    function setNpm(address npm_) external {
+        npm = npm_;
+    }
+
     /// @notice Configure how much AERO to transfer to msg.sender on withdraw.
     function setAeroToPayOnWithdraw(uint256 amount) external {
         aeroToPayOnWithdraw = amount;
@@ -53,6 +71,8 @@ contract MockCLGauge {
         lastDepositor = msg.sender;
         depositCallCount++;
         _staked[msg.sender][tokenId] = true;
+        // Real custody when wired: the gauge pulls the NFT using the approval the depositor just gave.
+        if (npm != address(0)) IMockNpmCustody(npm).transferFrom(msg.sender, address(this), tokenId);
     }
 
     function withdraw(uint256 tokenId) external {
@@ -64,6 +84,7 @@ contract MockCLGauge {
         lastWithdrawnTokenId = tokenId;
         lastWithdrawCaller = msg.sender;
         withdrawCallCount++;
+        if (npm != address(0)) IMockNpmCustody(npm).transferFrom(address(this), msg.sender, tokenId);
 
         // Simulate auto-claim: transfer AERO to caller (like Aerodrome does)
         if (aeroToPayOnWithdraw > 0) {

--- a/test/mocks/MockCLPool.sol
+++ b/test/mocks/MockCLPool.sol
@@ -70,6 +70,23 @@ contract MockCLPool {
         sqrtPriceX96 = sqrtPriceX96_;
     }
 
+    /// @notice Cap the oracle history `observe` can answer for, in seconds. `0` (the default) means
+    ///         unlimited — the pre-existing behaviour, so every existing fixture is unaffected.
+    /// @dev Models the ONE failure mode venue validation's TWAP-availability probe exists to catch:
+    ///      a real Slipstream pool whose observation cardinality does not yet span the requested
+    ///      window REVERTS `observe`, and without a knob here that probe cannot be exercised at all
+    ///      (it always succeeded, which is also why the vacuous `observe([0, 0])` at init went
+    ///      unnoticed). Set it to `window - 1` to model "pool younger than twapWindow".
+    function setMaxObservationAge(uint32 maxObservationAge_) external {
+        maxObservationAge = maxObservationAge_;
+    }
+
+    /// @notice Oldest observation `observe` will serve, in seconds ago. `0` == unlimited.
+    uint32 public maxObservationAge;
+
+    /// @notice Thrown when `observe` is asked for a window the mock's history does not span.
+    error MockCLPoolOldestObservation();
+
     // ── ICLPool ──
 
     function slot0() external view returns (uint160, int24, uint16, uint16, uint16, bool) {
@@ -86,6 +103,9 @@ contract MockCLPool {
         tickCumulatives = new int56[](secondsAgos.length);
         secondsPerLiquidityCumulativeX128s = new uint160[](secondsAgos.length);
         for (uint256 i; i < secondsAgos.length; ++i) {
+            if (maxObservationAge != 0 && secondsAgos[i] > maxObservationAge) {
+                revert MockCLPoolOldestObservation();
+            }
             // Cumulative measured backwards from now: -(secondsAgo) * twapTick.
             tickCumulatives[i] = -int56(int32(int256(uint256(secondsAgos[i])))) * int56(twapTick);
         }

--- a/test/mocks/MockCLPool.sol
+++ b/test/mocks/MockCLPool.sol
@@ -19,6 +19,13 @@ contract MockCLPool {
     ///         swap-pool existence probe (`pool.factory().getPool(usdc, leg, spacing)`).
     address public factory;
 
+    /// @notice The gauge this pool reports as its own. On a real Slipstream pool the Voter writes
+    ///         this at gauge creation, which is why venue validation requires it to AGREE with
+    ///         `gauge.pool()` — the self-attested direction alone is forgeable by a hostile gauge.
+    ///         Defaults to `address(0)` (ungauged), so a test must wire it explicitly, exactly as it
+    ///         must wire `gauge.setPool`.
+    address public gauge;
+
     uint160 public sqrtPriceX96 = 79228162514264337593543950336; // 1:1
     int24 public tick;
 
@@ -35,6 +42,10 @@ contract MockCLPool {
 
     function setFactory(address factory_) external {
         factory = factory_;
+    }
+
+    function setGauge(address gauge_) external {
+        gauge = gauge_;
     }
 
     function setTokens(address token0_, address token1_) external {
@@ -82,10 +93,6 @@ contract MockCLPool {
 
     function fee() external pure returns (uint24) {
         return 500;
-    }
-
-    function gauge() external pure returns (address) {
-        return address(0);
     }
 }
 


### PR DESCRIPTION
## What

Lets the fund move to a **different Slipstream pool — including a different token pair — in place**: same vault, same share token, same user accounts, **no user action and no funds leaving the strategy**.

Today the venue is pinned at `initialize` and the only exit is `settle`, which is terminal: it drains everything to the vault and every user must individually redeem and re-deposit into a fresh stack. Since all account exit hatches are `onlyOwner`, the backend cannot drive that at all.

```
1. multisig   stageVenue(keccak256(abi.encode(VenueParams)))   ← authorization
2. backend    flatten(minRewardUsdcOut, minIdleUsdcOut)        ← LP exit, loans repaid,
                                                                  USDC stays in the contract
3. backend    migrateVenue(params)                             ← config rewrite, moves no funds
4. backend    redeploy()                                       ← enters the new pool
```

Funds path: old pool → strategy contract (idle USDC) → new pool. **The rebalancer can never move funds out of the contract, and can only ever deploy into the venue the multisig signed** — it picks the timing, not the destination.

## Design

**Enforcement is share-ledger-safe by construction.** `migrateVenue` requires a flat book (no CL position, no hedged basis, no debt on either leg market), so NAV is exactly the idle USDC balance — which no venue field touches. Share balances, HWM and pending redeem requests are therefore provably untouched across the rewrite.

**A third library, `LeveragedAeroVenue.sol`.** The strategy and manager both sat within ~350 bytes of EIP-170, so neither could host new logic. Extracting the init venue block into the new library is what freed the strategy bytes the new entry points cost — it went from 24,228 → 22,419 B. `applyVenue` is now shared by `_initialize` and `migrateVenue`, so migration validation can never drift below init validation.

**One added check:** `gauge.pool() == pool`. Init previously trusted the deployer on gauge wiring; once a runtime migration can point at a fresh gauge that binding becomes load-bearing (wrong gauge = stranded staked NFT). `src/libraries/LPPositionLib.sol` already models this pattern.

**`redeploy()` was discovered mid-implementation.** No existing path re-opens a position from a flat book — `deployIdle` only `increaseLiquidity`s an existing tokenId (0 when flat) and `rerange` no-ops. `redeploy()` delegates to the Manager's existing `executeImpl`, so it costs zero new bytes in the at-cap Manager. Recorded as a revision to design decision D6.

## Audit fixes included

A 12-agent security review ran against this diff. **Four findings it raised are fixed here**; the pre-existing ones are tracked in #68.

| Fix | Commit | What |
|---|---|---|
| Orphaned position NFT — permanent DoS | `29237f6` | `adjustLeverage(0, …)` drove `_unwindLiquidity` down its full-removal branch, which skips the re-stake while `_leverDown` keeps `tokenId` — permanently bricking settle, flatten, rerange, deployIdle, compound, migrate, redeploy and **both async-redeem exits**. Also reachable permissionlessly via `deleverage`. Pre-existing, fixed here because it blocks the migration flow. |
| `flatten` stranded the reward tranche | `d1d1680` | `gauge.withdraw` auto-claims AERO that `settleImpl` never sells — invisible to `nav()`, unsellable (`compound` bails on a flat book), un-rescuable while `Executed`. Every deposit in the flat window bought a free claim on it. Now sold with `compound`'s L9 oracle floor. |
| `flatten` had no calm gate and no caller bound | `d1d1680` | `settleImpl` was written for the terminal owner-driven `settle`; `_unwindLiquidity`'s mins come from the same `slot0()` it burns at, so they bind nothing. Now calm-gated like `rerange`, with caller floors. |
| Reward feed pinned across migration | `d1d1680` | The gauge is migratable so `rewardToken()` can change, but `aeroUsdFeed` was not — a migration could price token X at AERO's price and mis-scale the harvest floor. The feed moved into `VenueParams` so gauge and feed are attested in one hash. |

**I did not use the audit's suggested fix for the first item.** It proposed clearing `tokenId` after a full unwind; with collateral still supplied that sends `nav()` down its flat-book branch, which counts only idle USDC — erasing the mUSDC collateral, the bulk of the fund, from NAV. The guard rejects the full lever-down instead and routes it through `flatten()`.

## Testing

628 unit tests pass. All contracts under EIP-170 (Manager 303 B margin, strategy 2,157 B, new Venue library 8,939 B).

**Every guard was mutant-tested** — removed individually with the matching test confirmed to fail. Two results worth noting:

- The orphaned-NFT bug was **reproduced on a mutant**: `tokenId` retained, `stakedContains` false, and `flatten`/`rerange`/`redeploy`/`settle` all reverting.
- The calm-gate mutant does not revert cleanly — it proceeds into the burn and dies on a token-balance error deep in the unwind, which is the manipulated-price unwind the finding described.

## Test-infrastructure fix worth reviewing

`MockCLGauge.withdraw` was an unconditional no-op and `stakedContains` returned a hardcoded `false`. **That is why 620 tests never caught a permanent-DoS bug** — an orphaned NFT was indistinguishable from a staked one. The mock now tracks stakes like the real `CLGauge`. No existing test broke, so nothing was relying on the sloppy behaviour.

Related: `MockMoonwellMarket.repayBorrow` is still a `pure` stub returning 0, which is why finding #1 in #68 is likewise invisible to the current suite.

## Scope boundaries

- **Not for already-deployed clones.** The strategy clone is immutable, so this must land before production deployment. Nothing leveraged-aero is on Base yet.
- **Vault `strategy` pointer stays set-once** — rotating it is explicitly forbidden by the vault's trust model and is untouched here.
- Cross-pair destinations are limited to assets with live borrowable Moonwell markets and Chainlink feeds on Base.

## Docs

`docs/integrations/LEVERAGED_AERO_REBALANCER.md` gains §G2: the 4-step runbook, the rollback path, and the multisig staging recipe.

Spec: `openspec/specs/venue-migration/spec.md` (6 requirements) — note that file lands via #69, which is stacked on this branch.

## Base branch

Targets `feat/leveraged-aero-vanilla-vault`, matching the existing stack (#66 → `sherlock_audit` → #58 → `main`). #69 is stacked on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
