### PR TITLE
feat: per-cycle rerange skew for the leveraged-aero strategy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,5 +93,9 @@ The two-call protocol-fee lookup the strategy inherits (`vault.factory()` → `.
 _Avoid_: factory (nothing is deployed by it), ProtocolConfig as a contract we ship
 
 **Width band**:
-The init-time `[minWidth, maxWidth]` bounds, on the `tickSpacing` grid, that every rerange width must satisfy — the genesis width included. Enforced by `_checkWidth`, rejected with `WidthOutOfBounds()`.
-_Avoid_: range (that is the resulting tickLower/tickUpper), tick spacing (the grid the band sits on)
+The init-time `[minWidth, maxWidth]` bounds, on the `tickSpacing` grid, that every rerange width must satisfy — the genesis width included. Enforced by `_checkWidth`, rejected with `OutOfBounds()`.
+_Avoid_: range (that is the resulting tickLower/tickUpper), tick spacing (the grid the band sits on), `WidthOutOfBounds()` (renamed — that name still belongs to `LPAutoBalancerV2`, a different contract)
+
+**Skew**:
+`skewBps` — the fraction of `width` placed BELOW the current tick, on the bps scale (`10000` = 1.00). `5000` = centered; `3500` = 35 % of the range below spot, 65 % above. `lowerSpan = width × skewBps / 10000`, `upperSpan = width − lowerSpan`, both bounds aligned DOWN to `tickSpacing`. Stored in `Layout` and exposed on `layout()` exactly like `width` — a flat-book `rerange` persists both, and the next genesis mint uses the stored pair. Validated with the width and rejected by the same `OutOfBounds()`: strictly inside `(0, 10000)`, and both spans at least one `tickSpacing`.
+_Avoid_: skew as a percentage or a ratio (it is bps), "offset"/"shift" (the range still brackets spot), centered range (only true at 5000)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,9 +93,17 @@ The two-call protocol-fee lookup the strategy inherits (`vault.factory()` → `.
 _Avoid_: factory (nothing is deployed by it), ProtocolConfig as a contract we ship
 
 **Width band**:
-The init-time `[minWidth, maxWidth]` bounds, on the `tickSpacing` grid, that every rerange width must satisfy — the genesis width included. Enforced by `_checkWidth`, rejected with `OutOfBounds()`.
+The init-time `[minWidth, maxWidth]` bounds, on the `tickSpacing` grid, that every rerange width must satisfy — the genesis width included. Enforced by `LeveragedAeroValuation.checkRange` (which validates width and skew together), rejected with `OutOfBounds()`.
 _Avoid_: range (that is the resulting tickLower/tickUpper), tick spacing (the grid the band sits on), `WidthOutOfBounds()` (renamed — that name still belongs to `LPAutoBalancerV2`, a different contract)
 
 **Skew**:
-`skewBps` — the fraction of `width` placed BELOW the current tick, on the bps scale (`10000` = 1.00). `5000` = centered; `3500` = 35 % of the range below spot, 65 % above. `lowerSpan = width × skewBps / 10000`, `upperSpan = width − lowerSpan`, both bounds aligned DOWN to `tickSpacing`. Stored in `Layout` and exposed on `layout()` exactly like `width` — a flat-book `rerange` persists both, and the next genesis mint uses the stored pair. Validated with the width and rejected by the same `OutOfBounds()`: strictly inside `(0, 10000)`, and both spans at least one `tickSpacing`.
+`skewBps` — the fraction of `width` placed BELOW the current tick, on the bps scale (`10000` = 1.00). `5000` = centered; `3500` = 35 % of the range below spot, 65 % above. `lowerSpan = width × skewBps / 10000`, `upperSpan = width − lowerSpan`, both bounds aligned DOWN to `tickSpacing` — which preserves the realised width exactly but always moves up to `tickSpacing − 1` ticks OUT of the upper span and INTO the lower one, never the reverse. Stored in `Layout` and exposed on `layout()` exactly like `width` — a flat-book `rerange` persists both, and the next genesis mint uses the stored pair. Validated with the width and rejected by the same `OutOfBounds()`: strictly inside `(0, 10000)`, inside the skew band, and both spans at least one `tickSpacing`. Quantization cliff: at `width == 2 × tickSpacing` every admissible skew aliases onto the same centred range, so meaningful skew needs `width ≥ 3 × tickSpacing`.
 _Avoid_: skew as a percentage or a ratio (it is bps), "offset"/"shift" (the range still brackets spot), centered range (only true at 5000)
+
+**Skew band**:
+The init-time `[minSkewBps, maxSkewBps]` bounds every `skewBps` must satisfy — the genesis skew included. The skew analogue of the width band: two `InitParams`/`Layout` fields sitting immediately after `skewBps`, checked at init AND on every `rerange`, rejected with the same `OutOfBounds()` (no new selector). Immutable per clone.
+_Avoid_: skew limits/skew caps (the term is band, matching **Width band**), treating it as a per-cycle argument (it is not — only `skewBps` is)
+
+**Borrow drag (skew ratchet)**:
+Two-borrowed-legs shape only: each genesis/`deployIdle`/`compound` borrow is split 50/50 by USD value regardless of the range, so a skewed range strands part of THAT borrow as idle — and since pre-existing idle leg balances are never re-offered, the stranded slice grows with every compound. Direction-independent (skew 2000 and 8000 strand the same ≈33.5 %), debt-funded (pays borrow interest, earns no LP fees), and delta-neutral (the idle token still hedges its own debt; `nav()` prices it).
+_Avoid_: hedge break / delta drift (net exposure is unchanged), standing remainder (understates it — it ratchets per borrow)

--- a/docs/LEVERAGED_AERO_CL_AUDIT.md
+++ b/docs/LEVERAGED_AERO_CL_AUDIT.md
@@ -28,6 +28,9 @@ Delta against the baseline:
 | Any-pool init + validation | Leg decimals read from the tokens at init and bounded `[2, 18]` (were `CBBTC_DECIMALS` / `WETH_DECIMALS` constants); pool token ordering derived from `pool.token0()` (`wethIsToken0`, mapped through `_tokens01` / `_amounts01`) instead of the manager's hardwired `token0 == WETH`; per-leg swap-pool `tickSpacing` inputs replace three hardcoded `int24(100)` literals; native-ETH borrow wrap made conditional (`wethDeliversNative`); init venue guards (pool `tickSpacing` + token-set match, Moonwell `underlying()` binding, reject USDC-as-leg and reward-token-as-leg) | `978e5af` |
 | Per-cycle rerange width | `rerange(uint24 width, uint256 minLiq0, uint256 minLiq1)` validated against an init-time `[minWidth, maxWidth]` band on the `tickSpacing` grid and persisted; `RANGE_TICK_SPACINGS` deleted; genesis mints at the init width; `WidthOutOfBounds()` = `0x1f9f54af` | `978e5af` |
 | Per-cycle rerange **skew** | `rerange` grew a second argument — `rerange(uint24 width_, uint16 skewBps_, uint256 minLiq0, uint256 minLiq1)`. `skewBps` is the fraction of `width` placed **below** the current tick (bps, `10000` = 1.00; `5000` = centered, the previous fixed behaviour and the genesis/ops default). `lowerSpan = width × skewBps / 10000`, `upperSpan = width − lowerSpan`, both bounds still aligned DOWN to `tickSpacing`. Stored in `Layout` and surfaced on `layout()` exactly like `width`, so a flat-book `rerange` persists both and the next genesis mint re-mints at the stored pair. `centeredTickRange` → `skewedTickRange(pool, tickSpacing, width, skewBps)`; `rerangeImpl` narrowed to `(minLiq0, minLiq1)` and reads both knobs from storage (the persists moved to the strategy). **`WidthOutOfBounds()` renamed `OutOfBounds()` = `0xb4120f14`** and reused for both knobs | *this change* |
+| Skew governance band + validation relocation | Two new fields, `minSkewBps` / `maxSkewBps`, **inserted** into `InitParams` and `Layout` immediately after `skewBps` (so `hedgedDebtA`/`hedgedDebtB` shift from `layout()` tuple positions 48/49 to 50/51). Validated once at init and re-checked on **every** `rerange`, raising the existing `OutOfBounds()` — no new selector. Width **and** skew validation moved out of the strategy's private `_checkWidth`/`_checkSkew` into `LeveragedAeroValuation.checkRange(width, skewBps, tickSpacing, minWidth, maxWidth, minSkewBps, maxSkewBps)`; behaviour is identical to the previous checks plus the band. Harness defaults `MIN_SKEW_BPS=1000` / `MAX_SKEW_BPS=9000` | *this change* |
+| Review remediation — asset-mode `rerangeImpl` idle draw | `rerangeImpl` **snapshots the leg-B balance before the unwind** and offers the mint only what the unwind itself collected. Previously it passed the whole leg-B slot balance as `amountDesired`, and in asset-mode that slot **is** USDC — so a rerange could pull stayers' idle USDC, including the redeemers' cover reserve, into the LP. Value-conserving but not the operator's intent, and it silently shrank the fast-redeem buffer. Now structurally impossible | *this change* |
+| Review remediation — need-sized `_rebalanceCover` | The lever-down / `deleverage` cover swap now sells **only the surplus required to cover the shortfall** and keeps the remainder, instead of selling the whole surplus leg balance. Shrinks the swapped notional (less realized slippage and venue fee on every lever-down) and leaves the unsold surplus as an idle leg balance that `nav()` prices and that still hedges its own debt | *this change* |
 | Comment hygiene | Three comment-only hunks in the strategy retiring stale Sherwood rationale (`selfManagesFees`, `_protocolConfig`, `rescueToVault`); new docstring on the manager's trimmed `_config()` | `ea822be`, `978e5af` |
 
 > **Selector break in the skew row, called out deliberately.** The width row above records
@@ -38,13 +41,30 @@ Delta against the baseline:
 > pre-launch, and neither is upgrade-safe to do later; re-derive rather than copy
 > (`cast sig 'OutOfBounds()'`, `cast sig 'rerange(uint24,uint16,uint256,uint256)'`).
 
-> **Known, accepted consequence of skew — two-borrowed-legs shape only.** The genesis / `deployIdle`
-> borrow is range-blind (`_borrowHalfEach` splits 50/50 by USD value), so a **skewed** range is not 50/50
-> by value and the book carries a persistent idle remainder of one borrowed token. This is **not** a hedge
-> break (the idle borrowed token 1:1 hedges its own debt, and `nav()` prices it) and **not** an LTV/health
-> change — it is capital-utilisation drag: less of the book earns LP fees. Mitigated operationally
-> (init `skewBps = 5000`, apply skew via `rerange`, size the skew against the drag). Making the borrow
-> range-aware is a possible follow-up and is **out of scope** here.
+> **Known, accepted consequence of skew — two-borrowed-legs shape only. Restated after review: it is a
+> per-borrow RATCHET, not a standing balance.** Every borrow site (genesis, `deployIdle`, `compound`) is
+> range-blind — `_borrowHalfEach` splits 50/50 by USD value — and each mint is offered only the amounts
+> borrowed **in that cycle**; pre-existing idle leg balances are never swept back in. So a skewed range
+> strands a slice of *each* borrow and the idle fraction **grows with every compound**, until an op that
+> resizes the book folds it back. Three properties the earlier wording understated: the drag is
+> **direction-independent** at the borrow sites (skew `2000` and `8000` both strand ≈ 33.5 % of each
+> borrow; ≈ 19 % at the documented `3500`), the stranded slice is **debt-funded** (it pays Moonwell borrow
+> interest while earning no LP fees), and it is still **delta-neutral** (the idle borrowed token hedges its
+> own debt 1:1, `nav()` prices it, net per-leg delta stays zero) and **not** an LTV/health change. The
+> operational mitigation (init `skewBps = 5000`, apply skew per-cycle via `rerange`) only **defers** the
+> drag: the next `deployIdle` borrows 50/50 into the stored skewed range. Making the borrow **range-aware**
+> is the planned follow-up that removes it at source and is **out of scope** here — see *Known gaps*, item 5.
+
+> **External security review of PR #71 (the skew change) — triage.** The PR was reviewed externally and
+> every finding was verified adversarially against source before disposition. **10 findings**, resolved as:
+> **2 code fixes landed in this PR** — the asset-mode `rerangeImpl` idle-draw snapshot and the need-sized
+> `_rebalanceCover` (both rows above); **1 hardening landed** — the `[minSkewBps, maxSkewBps]` governance
+> band, which is the reviewable answer to "what stops an operator key parking the fund at a
+> near-degenerate skew"; and **the remainder dispositioned** to named follow-ups or to other branches
+> rather than being fixed here. Two of those dispositions are corrections to *this document* and are
+> recorded below rather than silently amended: the calm-gate coverage map (see *Accepted patterns*) and
+> the persist-relocation rationale (same section). The restated skew-drag note above is a third. Nothing
+> in the review changed the delegatecall-layout, oracle or fee surfaces.
 
 Field names in `Layout` still read `cbBTC` / `weth` / `mCbBTC` / `mWeth`. These are **leg slots**, not
 token commitments — leg B and leg A respectively. Nothing in the code assumes those particular tokens
@@ -74,14 +94,18 @@ vanilla lifecycle — it is fork-local code, not vendored context.
 the wrapper's only diff is a NatSpec hunk repointing its terminal-state escape hatch at the vault's
 `redeemSettled`. They are exercised by the same unit gate (see Test evidence).
 
-**Deploy flow** (replaces Sherwood's `StrategyFactory.cloneAndInit`): deploy the vault → `Clones.clone`
-the strategy template → `strategy.initialize(vault, proposer = MAMO_BACKEND, initData)` →
-`vault.setStrategy(strategy)` (set-once) → `vault.setOpenDeposits(true)` →
-`vault.activateStrategy(seedAmount)`, which pulls the seed from the owner straight to the strategy and
-calls `execute()`. There is no template allowlist and no atomic clone+init: **the clone is initializable
-by anyone between `clone` and `initialize`**, so the two must be broadcast together or the deployment
-front-run check must be done by hand. The vault's `setStrategy` is the binding that matters — a clone
-someone else initialized against a different vault cannot mint here.
+**Deploy flow** (replaces Sherwood's `StrategyFactory.cloneAndInit`): deploy the vault → the owner calls
+`vault.cloneAndBind(template, proposer = MAMO_REBALANCER, initData)`, which does `Clones.clone` →
+`clone.initialize(address(this), proposer_, initData)` → `_bind(clone)` in **one `onlyOwner`
+transaction** → `vault.setOpenDeposits(true)` → `vault.activateStrategy(seedAmount)`, which pulls the seed
+from the owner straight to the strategy and calls `execute()`. Two corrections to earlier revisions of
+this paragraph: the proposer is the dedicated **`MAMO_REBALANCER`** operator key, deliberately **not**
+`MAMO_BACKEND` (which drives the account layer); and the clone+init **is** atomic now, closing the window
+where a fresh clone was initializable by anyone between `clone` and `initialize` and a front-runner could
+seize the `proposer` role. `setStrategy(address)` survives as the manual path for an already-initialized
+clone; both route through the same **set-once** `_bind`, which re-checks `clone.vault() == address(this)`,
+so a clone someone else initialized against a different vault can never be bound — and a wrong clone means
+a new vault, since there is no rotation. There is still no template allowlist.
 
 ## The corruption-critical invariant
 
@@ -98,7 +122,12 @@ textually compares the triplet between the two files. (The comparison strips lin
 blocks carry one intentionally asymmetric self-referential comment — "keep byte-identical in the
 manager" vs "…in the strategy" — while every storage-relevant token, the `RedeemRequest` struct, and the
 `STORAGE_SLOT` literal are compared verbatim.) `978e5af` appended 9 fields into one packed slot and the
-tripwire is green on both files.
+tripwire is green on both files. **This change touches `Layout` again**, and this time by **insertion**
+rather than append: `minSkewBps` / `maxSkewBps` go in immediately after `skewBps`, so every field after
+them shifts. The parity tripwire is exactly the control for that — the insert must be byte-identical in
+both files or the two halves of the delegatecall read different slots. Note the tripwire proves the two
+files **agree**, not that the new ordering is compatible with anything already deployed: it is not, and
+these are pre-launch clones, so a redeploy (not an upgrade) is the only path.
 
 **Bytecode margin note:** under this repo's optimizer profile (via_ir, `optimizer_runs = 200`, cancun):
 
@@ -121,8 +150,9 @@ ERC-20 shares — "strategy-serviced custody". Deposits are priced at oracle net
 fail-closed: a stale feed or shoved pool denies the deposit, never mints cheap shares). Exits have three
 entrypoints while the strategy is `Executed`: fast oracle-priced `redeem` (LTV-gated,
 collateral-funded), async oracle-free `requestRedeem → fulfillRedeem` (proposer, exact proportional
-unwind), and a trustless `emergencyRedeem` deadman after 2 days. The operator (Mamo backend, the
-"proposer") manages the position through a bounded interface (`deployIdle` / `compound` / `rerange` /
+unwind), and a trustless `emergencyRedeem` deadman after 2 days. The operator (the rebalancer service,
+`MAMO_REBALANCER` — the strategy's "proposer", **not** the Mamo backend, which drives the per-user account
+layer) manages the position through a bounded interface (`deployIdle` / `compound` / `rerange` /
 `adjustLeverage`) with hard LTV/health caps asserted after every action, plus a **permissionless**
 `deleverage` anyone can trigger when health slips. The agent can never withdraw user funds to itself.
 
@@ -211,14 +241,27 @@ for the strategy internals at the baseline commit. Items 10–12 are fork-local.
     `underlying()`, USDC-as-leg and reward-token-as-leg rejection, decimals in `[2, 18]`); (d)
     `wethDeliversNative == false` leaves `receive()` accepting ETH with no wrap (gap 3).
 12. **Rerange width band + skew + the vault's own surface** — `rerange(width, skewBps, …)` accepts a
-    per-cycle width **and skew** and `_checkWidth` enforces the grid + `[minWidth, maxWidth]` band on
-    both the genesis width and every subsequent one; the band itself is validated once at init
-    (`% spacing == 0`, `minWidth >= 2 × spacing`, `min <= max`). `skewBps` is checked alongside it —
-    strictly inside `(0, 10000)`, and **both** derived spans (`width × skewBps / 10000` and the
+    per-cycle width **and skew** and `LeveragedAeroValuation.checkRange` enforces the grid +
+    `[minWidth, maxWidth]` band on both the genesis width and every subsequent one; the band itself is
+    validated once at init (`% spacing == 0`, `minWidth >= 2 × spacing`, `min <= max`, and a
+    `maxWidth <= 2 × MAX_TICK` ceiling so an extreme skew cannot push a bound out of the tick domain or
+    wrap the `int24` arithmetic). The **skew band** is new and is validated the same way, and can only
+    ever **tighten** the open `(0, 10000)` interval (`0 < minSkewBps <= maxSkewBps < 10000`), never widen
+    it. `skewBps` itself is checked alongside the width — strictly inside `(0, 10000)`, inside
+    `[minSkewBps, maxSkewBps]`, and **both** derived spans (`width × skewBps / 10000` and the
     remainder) at least one `tickSpacing`, which is what keeps the range strictly bracketing spot at
-    small widths. Confirm a proposer cannot degenerate the range to an empty or single-tick band **by
+    small widths. All of it is one function now (the two former private helpers `_checkWidth` /
+    `_checkSkew` are gone), called from the strategy entrypoint before the venue delegatecall — review it
+    as such. Confirm a proposer cannot degenerate the range to an empty or single-tick band **by
     either knob**, that the down-alignment of both bounds cannot invert them or push spot outside the
     minted range, and that the persisted `$.width` / `$.skewBps` cannot desync from the minted position.
+    Two known, accepted geometric consequences to check rather than re-report: the down-alignment is
+    **asymmetric** — it preserves the realised width exactly but always transfers the residue (up to
+    `tickSpacing − 1` ticks) from the upper span into the lower one, so the realised upper side can be a
+    single tick at the guard's floor; and at `width == 2 × tickSpacing` every admissible skew aliases onto
+    the same centred range, making skew inert at minimum width. Both are bounded and fail-safe (spot stays
+    bracketed); they are documented as an ops sizing rule (`upperSpan >= 2 × tickSpacing`) rather than
+    tightened on-chain.
     Note also that an extreme (still-valid) skew can leave the range far enough off spot to trip the
     pre-existing `DegenerateRange()` in `assetModeSplit` — a new path to an old guard, not a new failure
     mode. On the vault: `setStrategy` set-once, `redeemSettled` rounding and the pre-burn/pre-transfer
@@ -247,6 +290,25 @@ Pre-declared so auditors don't re-report them; each is a deliberate, reviewed ch
 - **`Layout` leg field names.** `cbBTC` / `weth` / `mCbBTC` / `mWeth` / `wethIsToken0` are leg-slot
   names, kept because renaming them would break the byte-identical `Layout` parity across two files for
   no behavioral gain. Documented as leg B / leg A in the source.
+- **Calm-gate coverage is ADD-paths-only — corrected.** Earlier wording here read as though every venue
+  path were calm-gated. It is not, and the asymmetry is deliberate: the gate runs on `rerange`, `execute`,
+  `deployIdle` and lever-**up** (and on NAV pricing), while `deleverage`, `settle` and the redeem unwinds
+  (`fulfillRedeem` / `emergencyRedeem`) are **un-gated**. The rationale is directional — those paths
+  **burn** liquidity rather than mint it, so a shoved tick cannot be used to mint the fund a bad position
+  through them, and gating them would hand any pool-shover a way to block a user's exit or the
+  permissionless safety valve. Reviewers should confirm the direction argument, not the absence of a gate.
+- **The `width`/`skewBps`/`targetLtvBps` persists live in the STRATEGY frame — corrected rationale.** This
+  is a **bytecode relocation for EIP-170 headroom**, not a semantic choice: the strategy frame already
+  loads `_layout()` for the validation, so each `sstore` costs ~20 bytes there versus ~70 in
+  `LeveragedAeroManager`, which is at the size cap (551 bytes of margin — see above). Semantics are
+  identical either way: same transaction, same all-or-nothing revert, so a stored value that disagrees
+  with the minted position is unreachable. Earlier text implied a correctness motive; there is none.
+  The one genuinely deliberate behaviour it enables is the **flat-book persist**: with `tokenId == 0`
+  (still `Executed`) `rerangeImpl` returns early and the persist is all that happens, kept for
+  `layout()` / monitoring consistency rather than because anything re-reads it — such a book is
+  **terminal until settle** (`execute` is one-shot, `deployIdle` fails closed with no NFT to add into,
+  `compound` no-ops), which is itself worth a reviewer's attention as a liveness property rather than a
+  safety one.
 
 ### Trusted-vault note
 
@@ -281,6 +343,12 @@ Stated plainly; none are closed.
    warning and all three call sites pass it straight to `_calmGate`, but the type does not enforce it.
    The flagged structural fix is a distinct `CalmConfig` type — deferred because the manager has only
    551 bytes of EIP-170 headroom.
+5. **Range-aware borrowing is not implemented.** `_borrowHalfEach` splits every borrow 50/50 by USD value
+   regardless of where the range sits, which is what produces the per-borrow skew ratchet described in the
+   skew note above. The fix — sizing each cycle's borrow against the *stored* range so the mint consumes
+   what it borrows — is the named follow-up out of the PR #71 review and is out of scope here. Until it
+   lands, the operational mitigation (centered genesis, skew via `rerange`, fewer and larger deploys) only
+   defers the drag. Bounded and delta-neutral, so it is a capital-efficiency gap rather than a safety one.
 
 ## Specification & documentation
 
@@ -309,6 +377,10 @@ forge build --sizes                  # EIP-170 margins (table above)
 ```
 
 Last verified locally 2026-07-27: **459 passed / 0 failed / 0 skipped**. Relevant breakdown:
+
+> **These counts predate this change.** The skew-band validation and the two review remediations landed
+> with their own tests after that run, so the totals below are a floor, not the current figure. Re-run
+> `make test-unit` and the `test/leveraged-aero/*` match-path before quoting a number.
 
 | Suite | Tests | Covers |
 |---|---|---|

--- a/docs/LEVERAGED_AERO_CL_AUDIT.md
+++ b/docs/LEVERAGED_AERO_CL_AUDIT.md
@@ -27,7 +27,24 @@ Delta against the baseline:
 | Host swap (de-Sherwood) | New `src/LeveragedAeroVault.sol` replaces Sherwood's `SyndicateVault`; `sherwood/` shims shrunk to the surface the strategy actually consumes (`ISyndicateGovernor` + `BatchExecutorLib` deleted; `ISyndicateVault` → 3 functions; `BaseStrategy` rewritten for the vanilla vault-driven lifecycle) | `ea822be` |
 | Any-pool init + validation | Leg decimals read from the tokens at init and bounded `[2, 18]` (were `CBBTC_DECIMALS` / `WETH_DECIMALS` constants); pool token ordering derived from `pool.token0()` (`wethIsToken0`, mapped through `_tokens01` / `_amounts01`) instead of the manager's hardwired `token0 == WETH`; per-leg swap-pool `tickSpacing` inputs replace three hardcoded `int24(100)` literals; native-ETH borrow wrap made conditional (`wethDeliversNative`); init venue guards (pool `tickSpacing` + token-set match, Moonwell `underlying()` binding, reject USDC-as-leg and reward-token-as-leg) | `978e5af` |
 | Per-cycle rerange width | `rerange(uint24 width, uint256 minLiq0, uint256 minLiq1)` validated against an init-time `[minWidth, maxWidth]` band on the `tickSpacing` grid and persisted; `RANGE_TICK_SPACINGS` deleted; genesis mints at the init width; `WidthOutOfBounds()` = `0x1f9f54af` | `978e5af` |
+| Per-cycle rerange **skew** | `rerange` grew a second argument — `rerange(uint24 width_, uint16 skewBps_, uint256 minLiq0, uint256 minLiq1)`. `skewBps` is the fraction of `width` placed **below** the current tick (bps, `10000` = 1.00; `5000` = centered, the previous fixed behaviour and the genesis/ops default). `lowerSpan = width × skewBps / 10000`, `upperSpan = width − lowerSpan`, both bounds still aligned DOWN to `tickSpacing`. Stored in `Layout` and surfaced on `layout()` exactly like `width`, so a flat-book `rerange` persists both and the next genesis mint re-mints at the stored pair. `centeredTickRange` → `skewedTickRange(pool, tickSpacing, width, skewBps)`; `rerangeImpl` narrowed to `(minLiq0, minLiq1)` and reads both knobs from storage (the persists moved to the strategy). **`WidthOutOfBounds()` renamed `OutOfBounds()` = `0xb4120f14`** and reused for both knobs | *this change* |
 | Comment hygiene | Three comment-only hunks in the strategy retiring stale Sherwood rationale (`selfManagesFees`, `_protocolConfig`, `rescueToVault`); new docstring on the manager's trimmed `_config()` | `ea822be`, `978e5af` |
+
+> **Selector break in the skew row, called out deliberately.** The width row above records
+> `WidthOutOfBounds()`'s selector (`0x1f9f54af`), which was matched to the Mamo backend's rebalance-param
+> error code. The rename to `OutOfBounds()` **changes that selector to `0xb4120f14`** — the pairing is
+> broken until the backend's error table is re-pointed, and the error's meaning is now wider (width *or*
+> skew). `rerange`'s own selector changed with the added argument. Both are intentional, both are
+> pre-launch, and neither is upgrade-safe to do later; re-derive rather than copy
+> (`cast sig 'OutOfBounds()'`, `cast sig 'rerange(uint24,uint16,uint256,uint256)'`).
+
+> **Known, accepted consequence of skew — two-borrowed-legs shape only.** The genesis / `deployIdle`
+> borrow is range-blind (`_borrowHalfEach` splits 50/50 by USD value), so a **skewed** range is not 50/50
+> by value and the book carries a persistent idle remainder of one borrowed token. This is **not** a hedge
+> break (the idle borrowed token 1:1 hedges its own debt, and `nav()` prices it) and **not** an LTV/health
+> change — it is capital-utilisation drag: less of the book earns LP fees. Mitigated operationally
+> (init `skewBps = 5000`, apply skew via `rerange`, size the skew against the drag). Making the borrow
+> range-aware is a possible follow-up and is **out of scope** here.
 
 Field names in `Layout` still read `cbBTC` / `weth` / `mCbBTC` / `mWeth`. These are **leg slots**, not
 token commitments — leg B and leg A respectively. Nothing in the code assumes those particular tokens
@@ -193,13 +210,19 @@ for the strategy internals at the baseline commit. Items 10–12 are fork-local.
     guards actually bind the venue (`pool.tickSpacing()`, `token0`/`token1` set match, Moonwell
     `underlying()`, USDC-as-leg and reward-token-as-leg rejection, decimals in `[2, 18]`); (d)
     `wethDeliversNative == false` leaves `receive()` accepting ETH with no wrap (gap 3).
-12. **Rerange width band + the vault's own surface** — `rerange(width, …)` accepts a per-cycle width and
-    `_checkWidth` enforces the grid + `[minWidth, maxWidth]` band on both the genesis width and every
-    subsequent one; the band itself is validated once at init (`% spacing == 0`,
-    `minWidth >= 2 × spacing`, `min <= max`). Confirm a proposer cannot degenerate the range to an empty
-    or single-tick band, and that the persisted `$.width` cannot desync from the minted position. On the
-    vault: `setStrategy` set-once, `redeemSettled` rounding and the pre-burn/pre-transfer ordering, the
-    `decimals() = asset.decimals() + 6` coupling to the strategy's `SHARES_VIRTUAL_OFFSET = 1e6` genesis
+12. **Rerange width band + skew + the vault's own surface** — `rerange(width, skewBps, …)` accepts a
+    per-cycle width **and skew** and `_checkWidth` enforces the grid + `[minWidth, maxWidth]` band on
+    both the genesis width and every subsequent one; the band itself is validated once at init
+    (`% spacing == 0`, `minWidth >= 2 × spacing`, `min <= max`). `skewBps` is checked alongside it —
+    strictly inside `(0, 10000)`, and **both** derived spans (`width × skewBps / 10000` and the
+    remainder) at least one `tickSpacing`, which is what keeps the range strictly bracketing spot at
+    small widths. Confirm a proposer cannot degenerate the range to an empty or single-tick band **by
+    either knob**, that the down-alignment of both bounds cannot invert them or push spot outside the
+    minted range, and that the persisted `$.width` / `$.skewBps` cannot desync from the minted position.
+    Note also that an extreme (still-valid) skew can leave the range far enough off spot to trip the
+    pre-existing `DegenerateRange()` in `assetModeSplit` — a new path to an old guard, not a new failure
+    mode. On the vault: `setStrategy` set-once, `redeemSettled` rounding and the pre-burn/pre-transfer
+    ordering, the `decimals() = asset.decimals() + 6` coupling to the strategy's `SHARES_VIRTUAL_OFFSET = 1e6` genesis
     pricing, `activateStrategy`'s owner-funded seed path, and the `rescueERC20` asset carve-out.
 
 ## Accepted patterns / known non-issues
@@ -268,7 +291,7 @@ Stated plainly; none are closed.
   commit**, and its `§`-references are the ones cited in the source NatSpec. It is stale w.r.t. this
   fork in exactly the places the fork changed: the host/vault/governor sections describe Sherwood's
   proposal lifecycle rather than the vanilla activate/settle one, and it predates the any-pool init and
-  the rerange width band. The spec was re-verified claim-by-claim against source on 2026-07-13; two
+  the rerange width band and skew. The spec was re-verified claim-by-claim against source on 2026-07-13; two
   minor errata at the pinned commit relate to Sherwood governance constants and no longer apply here.
 - Product-level overview of the fund (roles, trust boundary, operating model) is summarized in the PR
   description introducing this package.
@@ -290,7 +313,7 @@ Last verified locally 2026-07-27: **459 passed / 0 failed / 0 skipped**. Relevan
 | Suite | Tests | Covers |
 |---|---|---|
 | `test/LeveragedAeroVault.unit.t.sol` | 45 | The vault end-to-end against a mock strategy: `strategyMint`/`strategyBurn` gating, set-once `setStrategy`, `depositsOpen`, decimals coupling, `activateStrategy`/`settleStrategy`, `redeemSettled` pro-rata + rounding, `rescueERC20` asset carve-out, fee-config hops |
-| `test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol` | 31 | Init validation (venue guards, leg decimals band, USDC/reward-token leg rejection, width band) and `rerange` width/auth — **including both pool orderings at init** |
+| `test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol` | 31 | Init validation (venue guards, leg decimals band, USDC/reward-token leg rejection, width band, `skewBps` bounds) and `rerange` width/skew/auth — **including both pool orderings at init** |
 | `test/MamoLeveragedAeroStrategy.unit.t.sol` | 51 | The per-user account wrapper (adjacent, not in this package's scope) |
 | `test/leveraged-aero/LayoutParity.t.sol` | 4 | The `Layout` / `RedeemRequest` / `STORAGE_SLOT` tripwire. **Not part of the 459** — it is not a `*.unit.t.sol` file; it runs under `make test` and under the `test/leveraged-aero/*` match-path above. 4/4 green. |
 
@@ -313,6 +336,6 @@ health/LTV bounds after every op, `totalSupply` conservation across the mint/bur
 
 **Read that evidence narrowly.** It exercises the strategy internals **at the baseline commit**, on the
 Sherwood host, with the legacy cbBTC/WETH config. It does NOT cover: the `LeveragedAeroVault` host swap,
-the any-pool ordering/decimals/swap-spacing rewrites, or the rerange width band. **There is no
+the any-pool ordering/decimals/swap-spacing rewrites, or the rerange width band and skew. **There is no
 behavioral (fork) suite in this repo for the forked code** — the in-repo gate is unit-level and
 mock-based. Closing that is follow-up 1 and it is the single largest evidence gap in this package.

--- a/docs/LEVERAGED_AERO_VNET_RUNBOOK.md
+++ b/docs/LEVERAGED_AERO_VNET_RUNBOOK.md
@@ -429,18 +429,22 @@ the vault's permissionless `redeemSettled(shares)` — pro-rata on pre-burn supp
 balance. Do **not** settle a staging instance you still want to use: the strategy's own redeem paths
 require `State.Executed` and there is no path back.
 
-> **Operational rule — ALWAYS `compound()` immediately before `settle()`.** Verified: settling **strands
-> the final AERO tranche.** The unwind's `gauge.withdraw` does auto-claim whatever emissions accrued since
-> the last harvest, but `settleImpl` never **sells** them — so that AERO sits on the strategy as an
-> unsold token: it does not reach the swap, does not reach NAV, and is not part of the USDC pushed to the
-> vault for `redeemSettled` to pay out. Harvesting in the block before settling bounds the loss to a
-> single block of emissions. The fix for this lives on the **venue-migration branch, not here**, so treat
-> the ordering as a procedure, not a nicety.
+> **Operational rule (defense-in-depth) — `compound()` immediately before `settle()`.** No longer
+> mandatory: `_settle` now **sells** the final AERO tranche its unwind auto-claims (`gauge.withdraw`
+> auto-claims whatever accrued since the last harvest), so the proceeds land in the USDC pushed to the
+> vault for `redeemSettled` to pay out. Compounding first is still the recommended procedure, because
+> that sale is **best-effort**: `settle()` is terminal, owner-driven and argument-less, so a hard revert
+> there would block the fund's only exit — the sale is therefore wrapped in a self-`try/catch` and a
+> stale AERO/USD feed, a broken AERO→USDC route, or a fill under the L9 oracle floor makes it **skip**
+> (the swap is rolled back whole — it never sells blind) and emit `SettleRewardSaleDeferred`. Harvesting
+> in the block before settling means you are not relying on that path at all, and bounds the residue to a
+> single block of emissions either way.
 >
-> The AERO is not lost, but recovering it is no longer automatic: it is claimable **only** through
+> **Check `SettleRewardSaleDeferred` / the strategy's AERO balance after settling.** If the sale did
+> skip, the AERO is not lost but recovery is not automatic: it is claimable **only** through
 > `rescueToVault(aero)` → the vault's `rescueERC20(aero, to, amount)`.
 > That path does work post-settle — `rescueToVault`'s reward-token block is scoped to `State.Executed`
-> precisely so a `Settled` strategy can sweep the stranded tranche — but it is two privileged
+> precisely so a `Settled` strategy can sweep a stranded tranche — but it is two privileged
 > transactions after the fact, and the AERO reaches the vault as a **stray token the owner disposes of**,
 > not as part of the settled USDC pot `redeemSettled` pays holders out of.
 

--- a/docs/LEVERAGED_AERO_VNET_RUNBOOK.md
+++ b/docs/LEVERAGED_AERO_VNET_RUNBOOK.md
@@ -29,7 +29,9 @@ Audience: Mamo engineers with a checkout of **this repo only**.
 > - Paths and type names under `src/leveraged-aero/sherwood/` are preserved **only** so the vendored
 >   strategy's imports still compile. They are shims. Nothing calls Sherwood.
 > - The post-settlement exit is the vault's **permissionless** `redeemSettled(shares)`.
-> - The strategy now initializes against **any** Aerodrome Slipstream pool, and `rerange` is in-repo.
+> - The strategy now initializes against **any** Aerodrome Slipstream pool, and `rerange` is in-repo —
+>   in its 4-arg `rerange(uint24 width_, uint16 skewBps_, uint256 minLiq0, uint256 minLiq1)` form, which
+>   carries a per-cycle **skew** alongside the width (see B.3).
 
 ---
 
@@ -318,7 +320,8 @@ phase).
 `VenueMismatch` (pool spacing or token set, a Moonwell `underlying()` that does not match its leg, or a
 leg↔USDC swap pool that does not exist at the configured spacing — both swap spacings are
 existence-probed through the CL factory), `UnsupportedLeg`, `LegDecimalsOutOfRange`, `AssetMismatch`,
-`UnexpectedFeedDecimals`, `WidthOutOfBounds`, or one of the risk / oracle / fee bound errors.
+`UnexpectedFeedDecimals`, `OutOfBounds` (the width band **or** `skewBps` — one error covers both), or one
+of the risk / oracle / fee bound errors.
 
 `InitParams` is **leg slots, not token identities** (`weth*` = leg A, the natively-wrappable slot;
 `cbBTC*` = leg B — the names are historical). Any Slipstream pool whose two tokens have Moonwell borrow
@@ -331,6 +334,7 @@ constants:
 | `cbBTCSwapTickSpacing`, `wethSwapTickSpacing` | spacings of the leg↔USDC **swap** pools — separate venues from the LP pool, nonzero required. These replaced three hardcoded `int24(100)` literals |
 | `wethDeliversNative` | leg A's Moonwell market pays native ETH on borrow → the strategy wraps it. `false` on an ERC-20-delivering market (and then stray ETH is stranded — there is no ETH rescue path) |
 | `width`, `minWidth`, `maxWidth` | rerange width band, validated once at init: both bounds on the spacing grid, `minWidth ≥ 2 × spacing`, `minWidth ≤ maxWidth`, and `width` inside the band. Genesis mints at `width` |
+| `skewBps` | fraction of `width` placed **below** the current tick, bps (`10000` = 1.00). `5000` = centered — the genesis/ops default, and what `SKEW_BPS` defaults to in the runner. Must be in `(0, 10000)` exclusive **and** leave both spans ≥ one `tickSpacing` → `OutOfBounds()`. Persisted like `width`: genesis mints at it, `rerange` moves it |
 
 Derived at init, never passed: **leg token ordering** (`wethIsToken0` from `pool.token0()`) and **leg
 decimals** (`IERC20Metadata.decimals()`, bounded `[2, 18]` → `LegDecimalsOutOfRange`).
@@ -348,10 +352,17 @@ Init guards that will bite during a first deploy against a new pool:
   `twapWindow ∈ (0, 1 day]`, `calmDeviationTicks ∈ (0, 5000]`, `maxSlippageBps ∈ (0, 1000]`.
 - Fee ceilings, and a nonzero `feeRecipient` whenever either fee bps is nonzero.
 
-`rerange(uint24 width, uint256 minLiq0, uint256 minLiq1)` is **in-repo** (`onlyProposer`, persisted
-per-cycle width, re-checked against the init band → `WidthOutOfBounds()`, selector `0x1f9f54af`). The
-old "the vendored copy is behind upstream, re-vendor pending" caveat is **obsolete** — delete it on
-sight.
+`rerange(uint24 width_, uint16 skewBps_, uint256 minLiq0, uint256 minLiq1)` is **in-repo**
+(`onlyProposer`, persisted per-cycle width **and** skew, re-checked against the init band and the skew
+bounds → `OutOfBounds()`, selector `0xb4120f14`). The old "the vendored copy is behind upstream,
+re-vendor pending" caveat is **obsolete** — delete it on sight.
+
+> **Two signature/selector changes landed together here.** `rerange` grew a `uint16 skewBps_` second
+> argument (was `rerange(uint24,uint256,uint256)`), and `WidthOutOfBounds()` (`0x1f9f54af`) was renamed
+> `OutOfBounds()` (`0xb4120f14`) and now covers skew failures as well as width ones. Anything holding
+> either value hardcoded — the Mamo backend's rebalance-param error table above all — must be
+> re-pointed. Re-derive rather than copy: `cast sig 'OutOfBounds()'`,
+> `cast sig 'rerange(uint24,uint16,uint256,uint256)'`.
 
 ### B.4 — the bind (already done by B.3)
 

--- a/docs/LEVERAGED_AERO_VNET_RUNBOOK.md
+++ b/docs/LEVERAGED_AERO_VNET_RUNBOOK.md
@@ -256,6 +256,13 @@ why B.1 is a forge script at all. Each library is its own tx, so the Base per-tx
 constructor sets `_initialized = true`, permanently locking `initialize` on the template itself
 (ERC-1167 clones skip constructors, so clones stay initializable).
 
+> **Never pass `--libraries` for this stack.** The three delegatecall libraries must be deployed and
+> linked by the **same compilation** that produces the template. Pointing the link at libraries from an
+> earlier run reverts inside the delegatecall dispatcher rather than failing at link time, and it is not
+> a theoretical risk here: this PR changed the libraries' public selectors (`centeredTickRange` →
+> `skewedTickRange`, the new `checkRange`). Let the broadcast deploy and link them; if you have stale
+> library addresses in an env or a config, delete them.
+
 **The vault.** `src/LeveragedAeroVault.sol`, constructor
 `(address asset_, address owner_, string name_, string symbol_)`:
 
@@ -334,7 +341,8 @@ constants:
 | `cbBTCSwapTickSpacing`, `wethSwapTickSpacing` | spacings of the leg↔USDC **swap** pools — separate venues from the LP pool, nonzero required. These replaced three hardcoded `int24(100)` literals |
 | `wethDeliversNative` | leg A's Moonwell market pays native ETH on borrow → the strategy wraps it. `false` on an ERC-20-delivering market (and then stray ETH is stranded — there is no ETH rescue path) |
 | `width`, `minWidth`, `maxWidth` | rerange width band, validated once at init: both bounds on the spacing grid, `minWidth ≥ 2 × spacing`, `minWidth ≤ maxWidth`, and `width` inside the band. Genesis mints at `width` |
-| `skewBps` | fraction of `width` placed **below** the current tick, bps (`10000` = 1.00). `5000` = centered — the genesis/ops default, and what `SKEW_BPS` defaults to in the runner. Must be in `(0, 10000)` exclusive **and** leave both spans ≥ one `tickSpacing` → `OutOfBounds()`. Persisted like `width`: genesis mints at it, `rerange` moves it |
+| `skewBps` | fraction of `width` placed **below** the current tick, bps (`10000` = 1.00). `5000` = centered — the genesis/ops default, and what `SKEW_BPS` defaults to in the runner. Must be in `(0, 10000)` exclusive, inside `[minSkewBps, maxSkewBps]`, **and** leave both spans ≥ one `tickSpacing` → `OutOfBounds()`. Persisted like `width`: genesis mints at it, `rerange` moves it |
+| `minSkewBps`, `maxSkewBps` | the **skew governance band**, the skew analogue of `[minWidth, maxWidth]`. Two new fields sitting immediately after `skewBps` in `InitParams` / `Layout` / `layout()`. The band itself is validated once at init — `0 < minSkewBps ≤ maxSkewBps < 10000`, so it can only ever **tighten** the open `(0, 10000)` interval, never widen it — and the genesis `skewBps` is then checked against it by the same `checkRange` that runs on **every** `rerange`. All of it raises the same `OutOfBounds()`; no new selector. Runner env: `MIN_SKEW_BPS` (default `1000`) / `MAX_SKEW_BPS` (default `9000`). Immutable after init: widening the band means a new clone |
 
 Derived at init, never passed: **leg token ordering** (`wethIsToken0` from `pool.token0()`) and **leg
 decimals** (`IERC20Metadata.decimals()`, bounded `[2, 18]` → `LegDecimalsOutOfRange`).
@@ -353,9 +361,11 @@ Init guards that will bite during a first deploy against a new pool:
 - Fee ceilings, and a nonzero `feeRecipient` whenever either fee bps is nonzero.
 
 `rerange(uint24 width_, uint16 skewBps_, uint256 minLiq0, uint256 minLiq1)` is **in-repo**
-(`onlyProposer`, persisted per-cycle width **and** skew, re-checked against the init band and the skew
-bounds → `OutOfBounds()`, selector `0xb4120f14`). The old "the vendored copy is behind upstream,
-re-vendor pending" caveat is **obsolete** — delete it on sight.
+(`onlyProposer`, persisted per-cycle width **and** skew, re-checked against the init width band, the
+init skew band and the one-spacing-per-side floor → `OutOfBounds()`, selector `0xb4120f14`). That whole
+check now lives in `LeveragedAeroValuation.checkRange`, called from the strategy before the venue
+delegatecall — same behaviour as the previous strategy-local checks, plus the skew band. The old "the
+vendored copy is behind upstream, re-vendor pending" caveat is **obsolete** — delete it on sight.
 
 > **Two signature/selector changes landed together here.** `rerange` grew a `uint16 skewBps_` second
 > argument (was `rerange(uint24,uint256,uint256)`), and `WidthOutOfBounds()` (`0x1f9f54af`) was renamed
@@ -363,6 +373,13 @@ re-vendor pending" caveat is **obsolete** — delete it on sight.
 > either value hardcoded — the Mamo backend's rebalance-param error table above all — must be
 > re-pointed. Re-derive rather than copy: `cast sig 'OutOfBounds()'`,
 > `cast sig 'rerange(uint24,uint16,uint256,uint256)'`.
+>
+> **A third break landed with the skew band: two fields were INSERTED, not appended.** `minSkewBps` /
+> `maxSkewBps` sit immediately after `skewBps` in both `InitParams` and `Layout`/`layout()`, so every
+> later field shifted by two (`hedgedDebtA`/`hedgedDebtB` moved from tuple positions 48/49 to 50/51).
+> Any hand-rolled `abi.encode` of `InitParams`, and any positional decode of `layout()`, must be
+> regenerated against the current ABI — `buildInitData()` is generated from the struct and needs no
+> change, but a copied calldata blob from an earlier run will initialize the wrong fields.
 
 ### B.4 — the bind (already done by B.3)
 
@@ -411,6 +428,21 @@ unwinds the whole levered book and pushes realized USDC to the vault, after whic
 the vault's permissionless `redeemSettled(shares)` — pro-rata on pre-burn supply and pre-transfer
 balance. Do **not** settle a staging instance you still want to use: the strategy's own redeem paths
 require `State.Executed` and there is no path back.
+
+> **Operational rule — ALWAYS `compound()` immediately before `settle()`.** Verified: settling **strands
+> the final AERO tranche.** The unwind's `gauge.withdraw` does auto-claim whatever emissions accrued since
+> the last harvest, but `settleImpl` never **sells** them — so that AERO sits on the strategy as an
+> unsold token: it does not reach the swap, does not reach NAV, and is not part of the USDC pushed to the
+> vault for `redeemSettled` to pay out. Harvesting in the block before settling bounds the loss to a
+> single block of emissions. The fix for this lives on the **venue-migration branch, not here**, so treat
+> the ordering as a procedure, not a nicety.
+>
+> The AERO is not lost, but recovering it is no longer automatic: it is claimable **only** through
+> `rescueToVault(aero)` → the vault's `rescueERC20(aero, to, amount)`.
+> That path does work post-settle — `rescueToVault`'s reward-token block is scoped to `State.Executed`
+> precisely so a `Settled` strategy can sweep the stranded tranche — but it is two privileged
+> transactions after the fact, and the AERO reaches the vault as a **stray token the owner disposes of**,
+> not as part of the settled USDC pot `redeemSettled` pays holders out of.
 
 ### B.6 — post-conditions Phase C requires
 

--- a/docs/integrations/LEVERAGED_AERO_FRONTEND.md
+++ b/docs/integrations/LEVERAGED_AERO_FRONTEND.md
@@ -326,6 +326,16 @@ sequenceDiagram
 > tx, so the owner receives USDC directly. `withdrawAll` redeems the account's entire share balance and
 > reverts `"No shares to withdraw"` if there is none.
 
+**What funds a fast withdraw — and therefore which route the user gets.** The fast path draws the fund's
+**idle USDC first** (the user's pro-rata `f × idle` share only, `f = shares/supply`), then frees whatever
+remains from the Moonwell **collateral**. It never touches the LP position or the debt — unwinding the LP
+happens only on the async path. That is why the LTV gate is scoped to the collateral-funded remainder:
+pulling collateral against unchanged debt raises LTV, and a would-be breach of the cap reverts
+`FastRedeemExceedsLtv` and sends the user to Flow 3. The corollary worth building around: **when idle
+alone covers the withdrawal the LTV gate is skipped entirely**, so small withdrawals against a
+well-funded book stay on the fast path even when the position itself is levered near its cap. Do not
+predict the route from position health alone — trust `previewWithdraw`'s `fastOk`.
+
 ---
 
 ## Flow 3 — async withdraw (request → pending → claim)
@@ -349,6 +359,11 @@ function claimWithdrawnUsdc() external returns (uint256 amount);                
 > the escrowed shares keep bearing the position's PnL until the rebalancer fulfils. The USDC the user
 > ultimately receives is priced at fulfill time, not request time. Surface this clearly (e.g. "amount
 > finalizes when processed") and do not display the request-time preview as a locked payout.
+
+> **The rebalancer cannot redirect a fulfillment.** `fulfillRedeem(id)` takes no recipient argument — the
+> payee is `redeemRequests[id].owner`, fixed to the user's account at `requestRedeem` and immutable
+> thereafter. The floor is the user's own stored `minAssetsOut`. The rebalancer chooses *when* a request
+> settles, never *to whom* or *for how much*.
 
 ```mermaid
 sequenceDiagram
@@ -392,6 +407,14 @@ function emergencyWithdraw(uint256 id, uint256 minAssetsOut) external returns (u
 Only enable this in the UI once `block.timestamp > requestedAt + 2 days` for the request; before then it
 reverts `FulfillWindowOpen()`. `minAssetsOut` is a **fresh** floor (the request's original floor may be
 stale after two days).
+
+> **It is unconditionally *reachable*, not unconditionally *successful*.** `emergencyWithdraw` runs the
+> same proportional unwind the rebalancer would have run, so it can still revert: on a partial redeem the
+> IL cover is capped at the redeemer's own budget and fails closed rather than touching other holders'
+> funds, so a deeply out-of-range position can bounce it. Do not present it as a guaranteed payout — treat
+> a revert as retryable, and always keep **Cancel** offered alongside it: `cancelWithdraw(id)` has no state
+> gate and no NAV gate, so the user can always retrieve the escrowed shares and exit afterwards. It is also
+> the *only* route once the strategy settles — `emergencyWithdraw` requires `Executed` (see *Settled exit*).
 
 ---
 

--- a/docs/integrations/LEVERAGED_AERO_REBALANCER.md
+++ b/docs/integrations/LEVERAGED_AERO_REBALANCER.md
@@ -322,9 +322,11 @@ Pushes the full balance of a **stray** ERC-20 (airdrop / accidental send) to `va
 `CannotRescuePositionToken()` for any position/accounting token: the vault's own share token, `usdc`,
 leg B, leg A, `mUsdc`, `mCbBTC`, `mWeth`, and — **while `Executed`** — the gauge reward token (read live
 from the gauge so a sweep can't bypass `compound()`). That last block is state-scoped on purpose: once
-`Settled`, `compound` is unreachable and the unwind's `gauge.withdraw` has auto-claimed a final AERO
-tranche that `settleImpl` never sells, so post-settle AERO **is** a stray and sweeping it is the only
-recovery. Harvest before settling (see the runbook) so there is nothing to recover. The
+`Settled`, `compound` is unreachable, so post-settle AERO **is** a stray and sweeping it is the only
+recovery. `_settle` does sell the tranche its unwind auto-claims, so this covers the **residual** case
+only: a best-effort sale that skipped (`SettleRewardSaleDeferred` — stale reward feed, broken reward
+route, or a fill under the oracle floor), a sub-micro-USD dust balance, or a post-settle donation.
+Harvest before settling (see the runbook) so there is nothing to recover. The
 position NFT is never swept (no ERC-721 path), and **native ETH is not sweepable at all** (§G).
 
 This is a two-hop recovery: the strategy can only push to the vault, and the vault owner then moves it out
@@ -408,12 +410,16 @@ request still outstanding when the vault owner calls `settleStrategy()` becomes 
 must `cancelRedeem(id)` (callable in **any** state) to get the shares back and then exit via the vault's
 `redeemSettled`. If a settlement is planned, clear the queue first and flag any request you can't fulfill.
 
-**And `compound()` last, immediately before the owner settles.** `settle`'s unwind auto-claims the final
-AERO tranche through `gauge.withdraw` but never **sells** it, so it is stranded on the strategy: outside
-NAV and outside the USDC pot `redeemSettled` pays holders from. A harvest in the block before settlement
-bounds that to a single block of emissions. Recovery afterwards is owner-only and manual
-(`rescueToVault(aero)` → `vault.rescueERC20`), so treat "compound, then hand off to the owner" as the
-settlement procedure.
+**And `compound()` last, immediately before the owner settles — defense-in-depth, not a requirement.**
+`settle`'s unwind auto-claims the final AERO tranche through `gauge.withdraw`, and `_settle` now **sells**
+it into the USDC pot `redeemSettled` pays holders from. That sale is **best-effort by design**: `settle()`
+is terminal, owner-driven and argument-less, so it is wrapped in a self-`try/catch` and skips (emitting
+`SettleRewardSaleDeferred`) on a stale AERO/USD feed, a broken AERO→USDC route, or a fill under the L9
+oracle floor — the swap rolls back whole, so it is never sold blind, but the tranche then stays on the
+strategy. Harvesting in the block before settlement means the exit never depends on that path and bounds
+any residue to a single block of emissions. Recovery of a residue is owner-only and manual
+(`rescueToVault(aero)` → `vault.rescueERC20`), so keep "compound, then hand off to the owner" as the
+settlement procedure and check the strategy's AERO balance afterwards.
 
 ### Why deleverage before fulfill — the self-funding unwind
 

--- a/docs/integrations/LEVERAGED_AERO_REBALANCER.md
+++ b/docs/integrations/LEVERAGED_AERO_REBALANCER.md
@@ -124,13 +124,13 @@ function deployIdle(uint256 amount, uint256 minLiquidity) external onlyProposer 
 
 | | |
 |---|---|
-| `amount` | USDC (6dp) to deploy; must be ≤ the strategy's idle USDC balance, else `InsufficientIdle()`. |
+| `amount` | USDC (6dp) to deploy. Bounded by the strategy's idle USDC balance and **nothing else** (`InsufficientIdle()` above it) — there is no leverage-derived size ceiling to compute, and structurally cannot be one: the op supplies fresh collateral and borrows against it at exactly the stored `targetLtvBps`, so the incremental tranche's LTV **is** the target. A bigger deploy therefore pulls blended LTV *toward* target and cannot itself breach `maxLtvBps`. Partial deploys are expected and legal; bigger is directionally the safer one. |
 | `minLiquidity` | Minimum CL liquidity the add must produce (slippage floor). |
 | Position effect (two borrowed legs) | supply **all** of `amount` USDC → mUSDC → borrow both legs at **`targetLtvBps`** (50/50 by USD value) → wrap native ETH **iff** `wethDeliversNative` (§G) → `increaseLiquidity` into the existing CL NFT → restake in the gauge. |
 | Position effect (asset-mode) | `LeveragedAeroValuation.assetModeSplit` solves the split closed-form against the **STORED** range: only `C < amount` is supplied as collateral, a **single** leg-A borrow is taken against `C` at `targetLtvBps`, and `U = amount − C` is held back as the LP's USDC side so the add lands at exactly the ratio the stored range needs. Net leg-A exposure stays 0 (LP leg == debt leg). |
-| Guards | Two-borrowed-legs: borrow sized at `amount × targetLtvBps / 1e4`. Asset-mode: borrow sized at `C × targetLtvBps / 1e4` with `C` from the split — so the **effective** collateral is less than `amount` and a naive `amount × targetLtvBps` model will over-predict the borrow. Both: two-sided `maxSlippageBps` mins on the add plus the caller's `minLiquidity`; closes with `_assertHealthy()` (post-op LTV ≤ `maxLtvBps` **and** no Moonwell shortfall). |
-| Errors | `InsufficientIdle`, `InsufficientLiquidity`, `MoonwellMintFailed`/`MoonwellBorrowFailed(errCode)`, `UnhealthyPosition(ltvBps, limitBps)`; **asset-mode also** `DegenerateRange()` — the split is sized against the STORED range (`posTickLower`/`posTickUpper`), so a range the price has already left is one-sided and fails closed. A `rerange` back onto spot unblocks it. |
-| When to call | Deposits land as idle USDC (see §D) and earn nothing until deployed. Run periodically to sweep accumulated idle into the position, within leverage caps. |
+| Guards | Two-borrowed-legs: borrow sized at `amount × targetLtvBps / 1e4`. Asset-mode: borrow sized at `C × targetLtvBps / 1e4` with `C` from the split — so the **effective** collateral is less than `amount` and a naive `amount × targetLtvBps` model will over-predict the borrow. Both: two-sided `maxSlippageBps` mins on the add plus the caller's `minLiquidity`; closes with `_assertHealthy()` (post-op LTV ≤ `maxLtvBps` **and** no Moonwell shortfall) — that assert runs **after** the deploy, so the caps constrain the *result*, not the input. |
+| Errors | `InsufficientIdle`, `InsufficientLiquidity`, `MoonwellMintFailed`/`MoonwellBorrowFailed(errCode)`, `UnhealthyPosition(ltvBps, limitBps)`; **asset-mode also** `DegenerateRange()` — the split is sized against the STORED range (`posTickLower`/`posTickUpper`), so a range the price has already left is one-sided and fails closed. A `rerange` back onto spot unblocks it. The one genuine **external** ceiling on `amount` is Moonwell's borrow cap on the leg market(s), which surfaces as `MoonwellBorrowFailed(errCode)` — size down and retry. Naming trap: `InsufficientIdleForLeverUp` is **not** a `deployIdle` error despite reading like one; it belongs to asset-mode `adjustLeverage` (below). |
+| When to call | Deposits land as idle USDC (see §D) and earn nothing until deployed. Run periodically to sweep accumulated idle into the position. Since `amount` is free up to idle, the decision is not "how much fits under the caps" but **how much idle to hold back**: the reserve is the instant-redeem cover (§D) and, in asset-mode, the funding for a lever-**up** (§G). Choose it deliberately rather than deploying to zero. |
 
 ### `compound` — harvest AERO, reinvest, crystallize fees
 
@@ -340,6 +340,14 @@ can trustlessly self-service via `emergencyRedeem(id, minAssetsOut)` (owner-gate
 `WithdrawEmergency`/`RedeemEmergency`. **Every emergency exit is a missed SLA** and strips the agent
 from the loop. Treat 2 days as the hard fulfillment SLA; alert well before it.
 
+**Reachable is not the same as successful.** `emergencyRedeem` runs the *same* proportional unwind as
+`fulfillRedeem`, so it inherits its failure modes: on a **partial** redeem the IL cover is capped at the
+redeemer's own budget (`balance − stayersIdle`) and fails closed rather than dipping into stayers' funds,
+so a deeply out-of-range book can bounce the deadman itself. It is an unconditional right to *try*, not a
+guaranteed payout — one more reason not to let a request reach the window. The user is never trapped by
+that: `cancelRedeem` has **no state gate and no NAV gate** (owner-only, un-settled-only), so the escrowed
+shares can always be retrieved and exited later.
+
 **Drain the queue before settlement.** `fulfillRedeem` and `emergencyRedeem` both require `Executed`, so any
 request still outstanding when the vault owner calls `settleStrategy()` becomes unfulfillable — its owner
 must `cancelRedeem(id)` (callable in **any** state) to get the shares back and then exit via the vault's
@@ -411,8 +419,18 @@ and earn nothing until deployed. Key facts for the agent:
   `IERC20(usdc).balanceOf(address(this))` — the strategy's own balance — and the docstring states vault
   float is excluded to preserve deposit/redeem symmetry). So idle-but-undeployed deposits are in NAV and
   correctly priced.
-- The agent's job is to **periodically `deployIdle`** accumulated idle USDC within the leverage caps
-  (`targetLtvBps`, bounded by `maxLtvBps` via the closing health assert).
+- The agent's job is to **periodically `deployIdle`** accumulated idle USDC. `amount` is bounded only by
+  the idle balance — the leverage caps bind the *result* (the closing `_assertHealthy()`), not the input,
+  because the tranche is borrowed at exactly `targetLtvBps` (§B). The real decision is the size of the
+  reserve you leave behind.
+- **Why the reserve matters: the fast `redeem` path draws idle FIRST, then Moonwell collateral** — via
+  `_redeemUnderlying($.mUsdc, …)` — and **never** touches the LP position or the debt (the fast path has
+  zero LP call sites; unwinding the LP happens only on the async `fulfillRedeem` path). The LTV gate
+  applies to the collateral-funded remainder only, since pulling collateral against unchanged debt raises
+  LTV: a breach of `maxLtvBps` reverts `FastRedeemExceedsLtv` and forces the redeemer onto the request
+  queue. **When idle fully covers the redeem the gate is skipped entirely** (`if (fromCollateral == 0)
+  return;`), so a healthy idle balance is what keeps ordinary exits off your SLA loop. Note a redeemer can
+  only draw their own pro-rata `f × idle` (`f = shares/supply`); the stayers' `(1−f)` share is reserved.
 - **Do not confuse this with the account-level `depositIdle` nudge.** That is a *separate* surface on the
   per-user `MamoLeveragedAeroStrategy` account (sibling backend doc), gated to the owner or registry
   backend member-0, and it moves a user's plain-transferred USDC into the fund. This section is about
@@ -540,7 +558,9 @@ Strategy events that exist today:
   carries them, rather than leaning on those sweeps under stressed leg-pool conditions. (The
   *deleverage/adjustLeverage* residual swap is separately oracle-floored — `_rebalanceCover` raises any
   caller `minOut` to `oracleValue × (1 − maxSlippageBps)` — so the permissionless `deleverage(0)` is not
-  sandwichable.)
+  sandwichable. That raised floor is handed to the router, so a breach surfaces as the **router's own
+  `amountOutMinimum` revert**, not as `BelowOracleFloor`, which has exactly one raise site: `compound`'s
+  AERO→USDC sell. Alert on both.)
 - **Fee-path asymmetry (audit item 7).** Crystallize is **best-effort** on user-exit paths (defers +
   emits `FeeCrystallizeDeferred`) but **hard-reverts** on `compound`/`settle`/the redeem skim. A persistent
   `FeeCrystallizeDeferred` on deposits/redeems while `compound` reverts points at a **frozen vault**
@@ -627,7 +647,7 @@ appears. But there is one misconception worth killing up front, because it waste
 | Driven by the **Chainlink feed** (the FreshFeed mock) | Driven by the **pool tick** (a real swap) |
 | --- | --- |
 | `nav()` and all USD valuation (`readUsd8`) | LP leg composition (how much cbBTC vs USDC the position holds) |
-| Slippage floors / `minOut` sizing, `BelowOracleFloor` | Whether the position is in or out of range |
+| Slippage floors / `minOut` sizing, `compound`'s `BelowOracleFloor` | Whether the position is in or out of range |
 | The interest hedge's oracle-priced buy sizing | Where `rerange` anchors the new range (it brackets the pool tick, split by `skewBps`) |
 | The staleness gate (`maxDelay`, currently 172800 s) | `calmGate` — **both** sides of it |
 | Health / LTV ratios and the `deleverage` trigger | Realized swap price, and therefore actual slippage |
@@ -677,7 +697,11 @@ The public RPC cannot do any of this.
 3. **Move the feed to match** — deploy a new `FreshFeed` carrying the new answer and `tenderly_setCode` it
    over the **same** feed address. The answer is an `immutable`, so **there is no setter**; "moving" the
    price means replacing the code. If you skip this, the oracle still reports the old price, the router
-   quote diverges from oracle fair by more than `maxSlippageBps`, and swaps revert `BelowOracleFloor`.
+   quote diverges from oracle fair by more than `maxSlippageBps`, and the oracle-floored swaps fail closed
+   — but **with two different selectors**: `compound`'s AERO→USDC sell reverts `BelowOracleFloor` (its one
+   and only raise site), while the `deleverage` / `adjustLeverage` lever-down residual swap has its min-out
+   *raised* to the oracle floor and handed to the router, so it reverts inside **Slipstream's own
+   `amountOutMinimum`** check. Same economic protection, different revert to alert on.
 4. **Re-assert freshness** — `./script/tenderly/compound-cycle.sh check-feeds` after *every* warp. This is
    the gate that catches a non-FreshFeed instance before you waste a run.
 5. **Now rebalance** — `rerange`, `adjustLeverage`, or `compound` as the scenario requires.
@@ -795,7 +819,8 @@ runs Aerodrome's weekly epoch flip. Re-arm it the production way:
 | Revert | Cause | Fix |
 | --- | --- | --- |
 | `CalmGateBreached` | pool moved > `calmDeviationTicks` from its TWAP | warp ≥ `twapWindow`, then retry |
-| `BelowOracleFloor` | pool and feed disagree by > `maxSlippageBps` | move the feed to match the pool (step 3) |
+| `BelowOracleFloor` | **`compound` only** — its AERO→USDC sell is the single raise site; the realized fill came in under the AERO/USD oracle floor because pool and feed disagree by > `maxSlippageBps` | move the feed to match the pool (step 3) |
+| Slipstream `amountOutMinimum` revert (no named selector) | the same pool/feed disagreement hitting a **lever-down residual swap** (`deleverage` / `adjustLeverage`): its min-out is raised to the oracle floor and enforced by the router, **not** by `BelowOracleFloor` | same fix — re-align the feed with the pool |
 | `StaleOracle` | warped on a **non**-FreshFeed instance | wrong instance — check `check-feeds` |
 | `OLD` from `pool.observe` | state sync is ON — observation ring re-hydrated from mainnet while `observationIndex` froze | not repairable; recreate the vnet with sync OFF |
 | `ZeroMinOut` | `minUsdcOut == 0` | derive one from `quote` |
@@ -876,7 +901,7 @@ Production addresses are published separately at deploy.
 
 - [ ] Sign every operator op with the strategy **proposer** key (`MAMO_REBALANCER`, `0x73f6…8FAf` on staging) — **never** the backend key (`MAMO_BACKEND`); confirm `strategy.proposer()` matches before wiring.
 - [ ] Gate the whole operator loop on `state() == Executed`; `execute`/`settle` are `onlyVault` and belong to the vault owner's `activateStrategy` / `settleStrategy`, not to you.
-- [ ] Periodically `deployIdle(amount, minLiquidity)` accumulated strategy-idle USDC within leverage caps; pass a real `minLiquidity`.
+- [ ] Periodically `deployIdle(amount, minLiquidity)` accumulated strategy-idle USDC; pass a real `minLiquidity`. `amount` is capped by idle alone — no leverage-derived ceiling to compute (§B) — so decide the **reserve you hold back**: it is the instant-redeem cover that keeps exits off the queue (§D), and in asset-mode the lever-up funding (§G).
 - [ ] **Read `layout().legBIsAsset` first and branch on it** — asset-mode changes `deployIdle` sizing, makes lever-**up** consume idle USDC, lets `rerange` draw on idle, and adds `InsufficientIdleForLeverUp` / `DegenerateRange` to the error set (§G).
 - [ ] `compound(minUsdcOut, minLiquidity)` on cadence with a **non-zero** `minUsdcOut`; expect it to defer (revert) on a stale AERO feed. **Do not predict the redeploy as `usdcOut − fee`** — `compound` first repays accrued borrow interest out of the harvest (§B), so the CL add is smaller by that amount; `MoonwellRepayFailed` is on that path.
 - [ ] Track drift with `hedgedDebt()` vs. each market's `borrowBalanceStored` (§E) to size the harvest cadence, and confirm it returns to ~0 after a compound; remember the on-chain measure accrues first, so the off-chain `…Stored` read is a lower bound.

--- a/docs/integrations/LEVERAGED_AERO_REBALANCER.md
+++ b/docs/integrations/LEVERAGED_AERO_REBALANCER.md
@@ -165,16 +165,17 @@ changed**, so anything holding a hardcoded one must be re-derived (`cast sig 're
 | | |
 |---|---|
 | `width_` | New position width in **raw ticks** (must be a multiple of `tickSpacing`), validated strategy-side against the init-immutable `[minWidth, maxWidth]` band **before** the venue delegatecall → `OutOfBounds()`. The width is **persisted** — subsequent range math (and the genesis mint path) reads the stored value; only `rerange` moves it, the band never moves after init. `layout()` exposes `width` / `minWidth` / `maxWidth` for the rebalancer to read on-chain — always read them off the clone you actually point at (the current staging clone was init'd width **4000**, band **[200, 20000]**). |
-| `skewBps_` | The fraction of `width_` placed **BELOW** the current tick, in bps (`10000` = 1.00). `5000` = centered — the old, and still the genesis/ops default. `3500` puts 35 % of the range below spot and 65 % above, i.e. more room for the price to rise. Concretely `lowerSpan = width_ × skewBps_ / 10000`, `upperSpan = width_ − lowerSpan`; both bounds are still aligned **DOWN** to `tickSpacing`, so the realised on-grid width stays within one spacing of the request. Validated with the width, **before** the venue delegatecall → `OutOfBounds()`: `skewBps_` must be in `(0, 10000)` **exclusive**, and **both** spans must be ≥ one `tickSpacing` — the second check is what protects the strict-bracketing invariant at small widths, where a legal-looking skew would otherwise collapse a side to zero. Like `width`, `skewBps` is **persisted** and exposed on `layout()`; the next `execute`/genesis mint re-mints at the stored width **and** the stored skew. |
+| `skewBps_` | The fraction of `width_` placed **BELOW** the current tick, in bps (`10000` = 1.00). `5000` = centered — the old, and still the genesis/ops default. `3500` puts 35 % of the range below spot and 65 % above, i.e. more room for the price to rise. Concretely `lowerSpan = width_ × skewBps_ / 10000`, `upperSpan = width_ − lowerSpan`; both bounds are then aligned **DOWN** to `tickSpacing`, which preserves the realised **width** exactly but moves part of the requested upper span into the lower one — see *Realised split precision* below, and do not read the request as the realised split. Validated with the width, **before** the venue delegatecall → `OutOfBounds()`: `skewBps_` must be in `(0, 10000)` **exclusive**, must lie inside the clone's init-immutable `[minSkewBps, maxSkewBps]` band, and **both** spans must be ≥ one `tickSpacing` — the last check is what protects the strict-bracketing invariant at small widths, where a legal-looking skew would otherwise collapse a side to zero. Like `width`, `skewBps` is **persisted** and exposed on `layout()`; the next `execute`/genesis mint re-mints at the stored width **and** the stored skew. |
+| `minSkewBps` / `maxSkewBps` | **Not arguments — the governance band on `skewBps_`.** Two init-time fields (`InitParams` / `Layout` / `layout()`, immediately after `skewBps`), fixed for the life of the clone exactly like `[minWidth, maxWidth]`. They are validated at **init** *and* re-checked on **every** `rerange`, and a violation raises the same `OutOfBounds()` — there is no separate selector. The band is what stops an operator key from parking the fund at a near-degenerate skew even though the raw `(0, 10000)` bound and the one-spacing floor would allow it; the harness default is `[1000, 9000]` (`MIN_SKEW_BPS` / `MAX_SKEW_BPS`). Read them off the clone before the rebalancer proposes a skew — a policy that can emit values outside the band is a policy that will revert. |
 | `minLiq0` / `minLiq1` | Minimum **token0** / **token1** the re-add must consume (two-sided slippage guard) → `InsufficientLiquidity()`. `token0`/`token1` are **pool ordering**, derived at init from `pool.token0()` and exposed as `layout().wethIsToken0` — do not assume which leg is which (see §G). |
 | Position effect | **Calm-gate runs FIRST** (`LeveragedAeroValuation._calmGate`) so a reposition can never execute at a manipulated tick → remove 100% liquidity + collect → mint a **new** CL NFT bracketing the current tick, `width_ × skewBps_ / 10000` raw ticks below it and the remainder above (equal halves at the default `skewBps_ = 5000`) → restake. The **old NFT is left empty** (Slipstream ticks are immutable; the stale NFT is harmless dust). |
 | What happens to principal | **No swap → principal conserved** (IL is realized only on a true exit). The collected ratio can't match the new range, so a remainder of **one** leg is left idle in the strategy — `nav()` prices it, so the reposition is NAV-neutral and the remainder stays redeployable. Debt + collateral untouched (health preserved). |
-| Asset-mode difference | The re-add offers the mint the strategy's **whole balance of each leg slot as `amountDesired`** — and in asset-mode the leg-B slot **is USDC** (`layout().cbBTC == layout().usdc`). So the amount of USDC the mint consumes is whatever the new range needs to pair with the collected leg A, which can be **more than the unwind itself collected**, drawing the difference from idle USDC. That is value-conserving (idle → LP, `nav()` unchanged) but it shrinks the redeem cover budget, the same operator consequence as an asset-mode lever-up. Conversely the leftover remainder is plain USDC rather than a borrowed leg. Size reranges against available idle when the clone is asset-mode. |
+| Asset-mode difference | **`rerange` can no longer draw on idle USDC.** In asset-mode the leg-B slot **is** USDC (`layout().cbBTC == layout().usdc`), so a naive "offer the whole balance as `amountDesired`" re-add would have swept stayers' idle USDC — and the redeemers' cover reserve with it — into the LP. The impl now **snapshots the leg-B (USDC) balance before the unwind** and offers the mint only the delta the unwind itself collected; everything that was idle before the call is still idle after it. Operator consequence: a rerange no longer shrinks the redeem-cover budget, and it is **not** an idle-consuming op the way an asset-mode lever-up is. What is unchanged: the leftover remainder left idle is plain USDC rather than a borrowed leg. |
 | Fee interaction | **No crystallization** — supply and NAV are unchanged; the streaming fee simply defers to the next crystallize point and the HWM is unaffected. |
-| Guards | Calm-gate; two-sided `maxSlippageBps` mins + caller `minLiq0/minLiq1`; closing `_assertHealthy()`. |
-| Errors | `OutOfBounds` — **one error now covers both knobs**: an out-of-band or misaligned `width_`, *and* a `skewBps_` outside `(0, 10000)` or one whose spans do not both reach a `tickSpacing`. Plus calm-gate reverts (`TwapDeviation`/`StaleOracle` family), `InsufficientLiquidity`, `UnhealthyPosition`. **`OutOfBounds()` is the rename of the old `WidthOutOfBounds()` and therefore has a NEW selector** — see the note below. |
+| Guards | Calm-gate; width **and** skew validation (both bands + the one-spacing-per-side floor) now live in `LeveragedAeroValuation.checkRange`, called from the strategy before the venue delegatecall — the behaviour is identical to the previous strategy-local checks, plus the new `[minSkewBps, maxSkewBps]` band; two-sided `maxSlippageBps` mins + caller `minLiq0/minLiq1`; closing `_assertHealthy()`. |
+| Errors | `OutOfBounds` — **one error covers every range knob**: an out-of-band or misaligned `width_`, a `skewBps_` outside `(0, 10000)`, a `skewBps_` outside the init band `[minSkewBps, maxSkewBps]`, and one whose spans do not both reach a `tickSpacing`. Plus calm-gate reverts (`TwapDeviation`/`StaleOracle` family), `InsufficientLiquidity`, `UnhealthyPosition`. **`OutOfBounds()` is the rename of the old `WidthOutOfBounds()` and therefore has a NEW selector** — see the note below. |
 | Errors — asset-mode reachability | An **extreme** skew makes the range very lopsided, and a very lopsided range is exactly the shape `LeveragedAeroValuation.assetModeSplit` fails closed on: the next `deployIdle` / lever-up can then revert `DegenerateRange()`. This is **not a new failure mode** — it is the existing one-sided-range guard — but skew is a new way to reach it. Prefer moderate skews, and if you do park the range far off spot, expect the deploy paths to want a `rerange` back before they will size. |
-| When to call | When spot has drifted out of the active range, or when the rebalance model chooses a new width **or a new skew** for the cycle. Width and skew selection policy is the rebalancer's (`RebalanceParams.width` in the backend spec); the chain only enforces the band, the `(0, 10000)` bound and the one-spacing-per-side floor. |
+| When to call | When spot has drifted out of the active range, or when the rebalance model chooses a new width **or a new skew** for the cycle. Width and skew selection policy is the rebalancer's (`RebalanceParams.width` in the backend spec); the chain only enforces the two init bands (`[minWidth, maxWidth]`, `[minSkewBps, maxSkewBps]`), the `(0, 10000)` bound and the one-spacing-per-side floor. |
 
 > **Selector change — the backend error table must be updated.** `WidthOutOfBounds()` (`0x1f9f54af`)
 > is gone; it is renamed `OutOfBounds()`, selector **`0xb4120f14`** (`cast sig 'OutOfBounds()'`). The old
@@ -190,21 +191,70 @@ changed**, so anything holding a hardcoded one must be re-derived (`cast sig 're
 > width **or skew** bug. A backend decoding both products needs both entries, keyed by which contract
 > reverted.
 
-> **Two-borrowed-legs shape: a skewed range leaves a persistent idle remainder (deliberate).** The
-> genesis / `deployIdle` borrow is **range-blind** — `_borrowHalfEach` splits the borrow 50/50 by USD
-> value regardless of where the range sits. A skewed range does **not** want 50/50 by value, so the mint
-> consumes an unequal amount of the two legs and the book carries a standing idle balance of one borrowed
-> token. To be explicit about what this is and is not:
-> - **Not a hedge break.** The idle borrowed token hedges its own debt 1:1 exactly as it would inside the
->   LP, and `nav()` prices it. Net exposure is unchanged.
-> - **Not an LTV or health change.** Collateral and debt are untouched; `_assertHealthy()` sees the same
->   numbers.
-> - **It is capital-utilisation drag** — a slice of the book sits idle instead of earning LP fees.
+#### Realised split precision — the request is not what you get
+
+The alignment is **down-only on both bounds**, and that is not symmetric. `tickLower = alignDown(tick −
+lowerSpan)` and `tickUpper = alignDown(tick + upperSpan)`, so:
+
+- **The realised WIDTH is exact.** Both bounds move down by the same residue, so `tickUpper − tickLower`
+  reproduces the request on the nose (`width_` is already a multiple of `tickSpacing`). The old claim that
+  the realised width is only "within one spacing of the request" was about the wrong quantity — width is
+  the part that *is* preserved.
+- **The realised SPLIT always loses ticks from the UPPER side to the lower one — never the reverse.** Both
+  bounds shift down by the same residue `r = (tick − lowerSpan) mod tickSpacing`, so `lowerSpan` **gains**
+  `r` and `upperSpan` **loses** it — up to `tickSpacing − 1` ticks. The realised skew is therefore
+  systematically **more below-weighted** than requested, by an amount the market's tick at execution
+  decides, not the proposer.
+- **At the guard's floor this is not a rounding detail.** The on-chain floor is `upperSpan ≥ one
+  tickSpacing`; combined with a residue of up to `tickSpacing − 1`, the realised upper side can come out
+  as a **single tick**. The guard guarantees strict bracketing of spot and nothing more — it is not a
+  promise of a meaningful upper side.
+
+**Ops rule: keep `upperSpan ≥ 2 × tickSpacing`** — i.e. pick `(width_, skewBps_)` such that
+`(10000 − skewBps_) × width_ / 10000 ≥ 2 × tickSpacing`. That is what buys the upper side a real span
+after the residue is taken out of it. The consequence of ignoring it is unchanged and already documented:
+a one-tick side is a lopsided range, and in asset-mode the next `deployIdle` / lever-up sized against the
+**stored** range can fail closed on the pre-existing `DegenerateRange()` guard until a `rerange` fixes it.
+
+> **Skew quantization cliff at `width_ == 2 × tickSpacing`.** At the smallest legal width the geometry has
+> exactly one legal shape: one spacing below, one above — **centered**. Every `skewBps_` the guard admits
+> at that width (at spacing 100 and `width_ = 200`: exactly `[5000, 5049]`) aliases onto the same range, so skew is a knob
+> with no effect there. **Meaningful skew needs `width_ ≥ 3 × tickSpacing`**, and a *usable* upper side
+> needs the `2 × tickSpacing` rule above on top of that. A rebalance model that sweeps skew at minimum
+> width will read as "the parameter does nothing" — it is the width that is binding, not the skew.
+
+> **Two-borrowed-legs shape: skew ratchets a debt-funded idle slice, once per borrow (deliberate).** The
+> genesis / `deployIdle` / `compound` borrow is **range-blind** — `_borrowHalfEach` splits each borrow
+> 50/50 by USD value regardless of where the range sits. A skewed range does not want 50/50 by value, so
+> the mint consumes an unequal amount of the two legs and leaves the surplus one idle. Read the shape of
+> this carefully, because it is worse than a standing balance:
+> - **It is a per-borrow ratchet, not a one-off.** Each borrow site offers the mint only the amounts
+>   **freshly borrowed in that cycle**; pre-existing idle leg balances are never swept back into the LP.
+>   So every `deployIdle` and every `compound` strands a fresh slice of its own borrow on top of what is
+>   already stranded, and the idle fraction **grows with each compound** until an op that resizes the
+>   book folds it back in. `rerange` is that op here: in this shape it re-adds the **full** balance of
+>   both legs, so a reposition sweeps the accumulated remainder back into the LP. (The pre-unwind
+>   snapshot that stops a rerange reaching idle is **asset-mode only**, where the leg-B slot is the
+>   fund's USDC; it does not apply to two borrowed legs, whose idle balances are genuine remainders that
+>   redeploying is *supposed* to absorb.) Treat a periodic `rerange` as the de-ratchet.
+> - **It is direction-independent at the borrow sites.** The drag is a function of how far the range is
+>   from 50/50, not which way it leans: skew `2000` and skew `8000` both strand ≈ **33.5 %** of each
+>   borrow, and the documented `3500` strands ≈ **19 %**. There is no "safe side" to skew toward.
+> - **The stranded slice is debt-funded.** It was borrowed, so it pays Moonwell borrow interest while
+>   earning no LP fees — that is the actual cost, and it compounds with the ratchet.
+> - **Not a hedge break, not an LTV or health change.** The idle borrowed token hedges its own debt 1:1
+>   exactly as it would inside the LP, `nav()` prices it, and net per-leg delta stays **zero**. Collateral
+>   and debt are untouched; `_assertHealthy()` sees the same numbers. The cost is carry and lost fees, not
+>   exposure.
 >
-> Recommended ops default: **initialize with `skewBps = 5000` (centered) and apply skew per-cycle via
-> `rerange`**, sizing it against how much drag you are willing to carry. Asset-mode is unaffected in kind
-> (its leg-B slot is USDC, so the remainder is plain idle USDC — see the asset-mode row above). Making the
-> borrow range-aware would remove the drag and is a possible follow-up; it is **out of scope** here.
+> Recommended ops default is unchanged — **initialize with `skewBps = 5000` (centered) and apply skew
+> per-cycle via `rerange`** — but be clear about what it buys: it **defers** the drag rather than avoiding
+> it. The borrow never consults the range, so the very next `deployIdle` borrows 50/50 into the *stored*
+> skewed range and starts the ratchet anyway. Size the skew against the drag you are willing to carry, and
+> prefer fewer, larger deploys over many small ones. Asset-mode is unaffected in kind (its leg-B slot is
+> USDC, so the surplus is plain idle USDC — and since the rerange fix it is no longer even consumed by the
+> re-add). Making the borrow **range-aware** is the planned follow-up that removes the drag at source; it
+> is **out of scope** here.
 
 ### `adjustLeverage` — move LTV toward a target
 
@@ -219,6 +269,7 @@ function adjustLeverage(uint16 targetLtvBps_, uint256 minLiq, uint256 minOut)
 | `minLiq` | Minimum CL liquidity on a lever-**UP** add. |
 | `minOut` | Minimum USDC out of a lever-**DOWN** residual rebalancing swap. |
 | Position effect (both shapes) | Collateral untouched; LTV moves on the **debt** side. `targetDebt = targetLtvBps_ × collateralUsdc / 1e4`. Lever **down**: unwind the matching CL fraction and repay, per-leg residual rebalanced through USDC (`minOut`) — unchanged in asset-mode, where the leg-B residual **is** USDC and flows straight into the leg-A cover. Closes with `_assertHealthy()`. |
+| Lever **down** — the cover sell is now **need-sized** | When one leg comes back short and the other long, `_rebalanceCover` sells the surplus leg to cover the shortfall. It now sells **only as much as covering the shortfall requires** and keeps the rest, instead of dumping the whole surplus balance. Two consequences for the operator: a lever-down (and the permissionless `deleverage`, same helper) realizes **less** unnecessary swap slippage and fees, and it **leaves the unsold surplus as an idle leg balance** — priced by `nav()`, still hedging its own debt, and redeployable on the next add. Do not model the residual sweep as "the surplus leg ends at zero" any more. |
 | Lever **up** — two borrowed legs | Borrow the delta 50/50 by USD across both legs and LP them against each other. **Self-funding**: the pair *is* the two borrows, so no idle USDC is consumed. |
 | Lever **up** — asset-mode | Borrows **only leg A** and pairs it with USDC **drawn from the strategy's idle balance**, sized closed-form (`assetModeLeverUpPair`) so the LP's leg-A amount equals the added leg-A debt — that is what preserves the delta-hedge (swapping part of the borrow to USDC would leave the book net short). **Operator consequence: an asset-mode lever-up CONSUMES idle USDC.** Value-conserving (a NAV component moving idle → LP, not a loss) but it shrinks the redeem cover budget until the next deposit. **Size lever-ups against available idle**; an under-funded one reverts `InsufficientIdleForLeverUp(needed, available)` and changes nothing — deliberately not a partial fill and not a silent cap. |
 | `targetLtvBps_` is **persisted** | The value is stored as the fund's standing target, so `execute` / `deployIdle` / `compound` size their **next** borrow at it. This holds even when neither branch runs (`targetDebt == debtUsdc`) — the retarget still takes effect, exactly like `rerange`-on-a-flat-book persisting `width` and `skewBps`. Read it back with `targetLtvBps()` or `layout().targetLtvBps` (§E). |
@@ -268,8 +319,12 @@ function rescueToVault(address token) external nonReentrant;  // proposer OR vau
 Pushes the full balance of a **stray** ERC-20 (airdrop / accidental send) to `vault()`. Reverts
 `NotProposerOrOwner()` if the caller is neither the proposer nor the vault owner (`Ownable(vault()).owner()`
 — on `LeveragedAeroVault` that is the accepted `Ownable2Step` owner, MAMO_MULTISIG). Reverts
-`CannotRescuePositionToken()` for any position/accounting token: `usdc`, leg B, leg A, `mUsdc`, `mCbBTC`,
-`mWeth`, and the gauge reward token (read live from the gauge so a sweep can't bypass `compound()`). The
+`CannotRescuePositionToken()` for any position/accounting token: the vault's own share token, `usdc`,
+leg B, leg A, `mUsdc`, `mCbBTC`, `mWeth`, and — **while `Executed`** — the gauge reward token (read live
+from the gauge so a sweep can't bypass `compound()`). That last block is state-scoped on purpose: once
+`Settled`, `compound` is unreachable and the unwind's `gauge.withdraw` has auto-claimed a final AERO
+tranche that `settleImpl` never sells, so post-settle AERO **is** a stray and sweeping it is the only
+recovery. Harvest before settling (see the runbook) so there is nothing to recover. The
 position NFT is never swept (no ERC-721 path), and **native ETH is not sweepable at all** (§G).
 
 This is a two-hop recovery: the strategy can only push to the vault, and the vault owner then moves it out
@@ -352,6 +407,13 @@ shares can always be retrieved and exited later.
 request still outstanding when the vault owner calls `settleStrategy()` becomes unfulfillable — its owner
 must `cancelRedeem(id)` (callable in **any** state) to get the shares back and then exit via the vault's
 `redeemSettled`. If a settlement is planned, clear the queue first and flag any request you can't fulfill.
+
+**And `compound()` last, immediately before the owner settles.** `settle`'s unwind auto-claims the final
+AERO tranche through `gauge.withdraw` but never **sells** it, so it is stranded on the strategy: outside
+NAV and outside the USDC pot `redeemSettled` pays holders from. A harvest in the block before settlement
+bounds that to a single block of emissions. Recovery afterwards is owner-only and manual
+(`rescueToVault(aero)` → `vault.rescueERC20`), so treat "compound, then hand off to the owner" as the
+settlement procedure.
 
 ### Why deleverage before fulfill — the self-funding unwind
 
@@ -487,7 +549,8 @@ function hedgedDebt() external view returns (uint128 legA, uint128 legB);       
   gauge, swapRouter, comptroller, the Moonwell markets, the Chainlink feeds incl. `aeroUsdFeed`,
   `sequencerFeed`), **oracle config** (`maxDelay`, `gracePeriod`, `calmDeviationTicks`, `twapWindow`,
   `tickSpacing`), **position state** (`tokenId`, `posTickLower`, `posTickUpper`, `nextRedeemRequestId`),
-  the **range knobs** (`width`, `minWidth`, `maxWidth`, `skewBps`), the **hedged-debt basis** (`hedgedDebtA`,
+  the **range knobs and their two init bands** (`width`, `minWidth`, `maxWidth`, `skewBps`, `minSkewBps`,
+  `maxSkewBps`), the **hedged-debt basis** (`hedgedDebtA`,
   `hedgedDebtB`), and the **venue-shape fields the keeper must not assume** (`legBIsAsset`,
   `cbBTCDecimals`, `wethDecimals`, `wethIsToken0`, `wethDeliversNative`, `cbBTCSwapTickSpacing`,
   `wethSwapTickSpacing` — see §G).
@@ -540,6 +603,11 @@ Strategy events that exist today:
   breach reverts the **whole** transaction atomically — there is no state to unwind by hand and no partial
   deploy to reconcile — but a shoved-tick `deployIdle` trace will show a Moonwell borrow before the
   `CalmGateBreached` revert. That is expected, not a partial failure.
+  **Coverage map — correction: the gate is on ADD paths only.** `deleverage`, `settle` and the redeem
+  unwinds (`fulfillRedeem` / `emergencyRedeem`) are deliberately **un-gated**. They burn liquidity rather
+  than mint it, so a shoved tick cannot be used to mint the fund a bad position through them — and gating
+  them would let anyone block a user's exit or the safety valve by shoving the pool. Do not read an
+  un-gated unwind as a missing check.
 - **Per-op slippage bounds.** Every value-moving op takes a caller `min*` floor **and** is additionally
   bounded by the always-on `maxSlippageBps` (∈ (0, 1000] = ≤10%, set at init). `compound` is further
   floored by the AERO/USD oracle (`BelowOracleFloor`). Pass **tight, freshly-quoted** floors; `0` is not
@@ -558,7 +626,9 @@ Strategy events that exist today:
   carries them, rather than leaning on those sweeps under stressed leg-pool conditions. (The
   *deleverage/adjustLeverage* residual swap is separately oracle-floored — `_rebalanceCover` raises any
   caller `minOut` to `oracleValue × (1 − maxSlippageBps)` — so the permissionless `deleverage(0)` is not
-  sandwichable. That raised floor is handed to the router, so a breach surfaces as the **router's own
+  sandwichable. It is now also **need-sized**: it sells only the surplus required to cover the shortfall
+  and keeps the remainder as an idle leg balance, which shrinks the swapped notional and therefore the
+  slippage surface on every lever-down. That raised floor is handed to the router, so a breach surfaces as the **router's own
   `amountOutMinimum` revert**, not as `BelowOracleFloor`, which has exactly one raise site: `compound`'s
   AERO→USDC sell. Alert on both.)
 - **Fee-path asymmetry (audit item 7).** Crystallize is **best-effort** on user-exit paths (defers +
@@ -569,6 +639,22 @@ Strategy events that exist today:
 - **`deleverage` accepted residual (audit item 9).** Our-feed staleness can block `deleverage` in a window
   where Moonwell's own oracle is fresh enough to liquidate; documented and accepted. Monitor Moonwell
   account liquidity independently.
+- **The flat book is a TERMINAL state — the fund cannot re-enter the LP.** After a **full** redeem (the
+  last holder exits via `fulfillRedeem` or `emergencyRedeem`) the position NFT is gone: `tokenId == 0`
+  while `state()` is still `Executed`. Everything then degrades quietly rather than reverting, which is
+  exactly why it needs saying out loud:
+  - `rerange` **persists but mints nothing** — the width/skew writes land in storage, the venue call has
+    no position to re-add, and you get a success receipt for a no-op.
+  - `deployIdle` **fails closed** — there is no NFT to `increaseLiquidity` into.
+  - `compound` **no-ops** (its explicit `tokenId == 0` early return), so it cannot rebuild the book either.
+  - `execute` is **one-shot** (`Pending → Executed`) and cannot be replayed to re-mint a genesis position.
+
+  Deposits still work and land as idle USDC, `nav()` still prices them, and they remain withdrawable at
+  face — nobody is trapped and nothing is lost. But the capital **cannot be put back to work**: the only
+  path forward is `settleStrategy()` and a **new vault**, because the vault's strategy binding is
+  **set-once** (`_bind`, no rotation). Treat "supply went to zero" as an incident that ends the fund's
+  life, not as an idle state to redeploy from — and keep a non-zero stake in the book if you want the
+  option to continue.
 
 See [`docs/LEVERAGED_AERO_CL_AUDIT.md`](../LEVERAGED_AERO_CL_AUDIT.md) for the full audit focus-area list.
 
@@ -593,12 +679,14 @@ the clone rather than assuming the launch pair:
   | `hedgedDebt()` | both `legA` and `legB` move | `legB` is structurally **0** |
   | `compound` interest hedge | hedges **both** legs from one shared budget | hedges **leg A only** (leg B can't drift) |
   | Lever **up** | self-funding (the pair is the two borrows) | **consumes idle USDC**; reverts `InsufficientIdleForLeverUp(needed, available)` if short |
-  | `rerange` | remainder left idle is a borrowed leg | may **draw idle USDC** into the add; the remainder left idle is USDC |
+  | `rerange` | remainder left idle is a borrowed leg | **never draws idle USDC** (the re-add is capped at what the unwind collected, snapshot pre-unwind); the remainder left idle is USDC |
   | Range-sensitivity | none on the deploy path | `deployIdle` / lever-up size against the **STORED** range → `DegenerateRange()` when it is one-sided; `rerange` first |
 
-  The operator rule of thumb for asset-mode: **idle USDC is no longer just a redeem buffer, it is an input
-  to `deployIdle`, `adjustLeverage` (up) and `rerange`.** Track it as a budget, and prefer a `rerange`
-  back onto spot before any op that sizes against the stored range.
+  The operator rule of thumb for asset-mode: **idle USDC is both the redeem buffer and an input to
+  `deployIdle` and `adjustLeverage` (up)** — but **not** to `rerange`, which since the pre-unwind leg-B
+  snapshot re-adds only what it collected and can no longer reach idle or the redeem cover. Track idle as
+  a budget for the two ops that do spend it, and prefer a `rerange` back onto spot before any op that
+  sizes against the stored range.
 - **`weth*` / `cbBTC*` are leg SLOTS, not tokens.** `weth`/`mWeth`/`wethFeed`/`wethDecimals` are **leg A**
   (the slot that may be delivered natively on borrow); `cbBTC`/`mCbBTC`/`cbBTCFeed`/`cbBTCDecimals` are
   **leg B**. The names are historical — read the actual token addresses from `layout()`. Every error
@@ -677,7 +765,16 @@ mechanism protecting the fund from being rebalanced at a manipulated price — a
 | `posTickLower` / `posTickUpper` | 27 / 28 | −66300 / −63300 | current range (width 3000 ≈ 35 % span, centered — `skewBps` 5000) |
 | width band | 44 / 45 | [200, 20000] | `rerange` width bounds (`OutOfBounds` outside) |
 | `legBIsAsset` | 46 | `true` | asset mode: leg B **is** USDC |
-| `skewBps` | 47 | **5000** | fraction of `width` placed BELOW spot; 5000 = centered (`OutOfBounds` outside `(0, 10000)` or if either span < `tickSpacing`). **Appended after `legBIsAsset`, not next to the width band** — decode by name, not by eyeballing the group |
+| `skewBps` | 47 | **5000** | fraction of `width` placed BELOW spot; 5000 = centered (`OutOfBounds` outside `(0, 10000)`, outside the skew band below, or if either span < `tickSpacing`). **Appended after `legBIsAsset`, not next to the width band** — decode by name, not by eyeballing the group |
+| skew band (`minSkewBps` / `maxSkewBps`) | 48 / 49 | [1000, 9000] (harness default) | init-immutable governance band on `skewBps`, checked at init **and** every `rerange` → the same `OutOfBounds` |
+| `hedgedDebtA` / `hedgedDebtB` | 50 / 51 | — | hedged borrow principal per leg; **these moved from 48/49** when the skew band was inserted |
+
+> **The two skew-band fields were INSERTED after `skewBps`, not appended**, so every field below them
+> shifted by two — `hedgedDebtA`/`hedgedDebtB` were 48/49 and are now 50/51. Anything decoding `layout()`
+> positionally (a raw `abi.decode`, a hand-written tuple, a cached ABI) will read the wrong values against
+> a clone built from this PR. Decode by **name** off a freshly generated ABI. A clone deployed *before*
+> this PR — the current staging one included — has neither field at all; re-deploy the pooled layer to
+> read them.
 
 At the time of writing spot tick is **−64796** and the TWAP tick is **−64796** (identical — no recent
 swaps), so the gate has full headroom. Note the range edges are ~1500 ticks away, i.e. it takes roughly a
@@ -777,15 +874,19 @@ cd script/tenderly
 #   ... converged), then "spot is OUT OF RANGE (single-sided; rerange to reposition (width + skew))"
 
 # The rebalance under test. rerange brackets the NEW pool tick, split by skewBps; width must be a
-# multiple of tickSpacing (100) and inside the clone's [minWidth, maxWidth] band — read them from
-# layout(). skewBps = 3500 => 35 % of the width below spot, 65 % above (the cbBTC/WETH backtest's
-# skew): a deliberate lean that leaves more room for the price to recover upward.
+# multiple of tickSpacing (100) and inside the clone's [minWidth, maxWidth] band, and skewBps must be
+# inside [minSkewBps, maxSkewBps] — read all four from layout(). skewBps = 3500 => 35 % of the width
+# below spot, 65 % above (the cbBTC/WETH backtest's skew): a deliberate lean that leaves more room for
+# the price to recover upward.
 cast send "$STRAT" 'rerange(uint24,uint16,uint256,uint256)' 3000 3500 0 0 \
   --from "$PROPOSER" --unlocked --gas-limit 14000000 --rpc-url "$LEVERAGED_AERO_ADMIN_RPC_URL"
 # lowerSpan = 3000 × 3500/10000 = 1050, upperSpan = 1950, both bounds aligned DOWN to spacing 100:
 #   tickLower = alignDown(-66400 - 1050) = -67500,  tickUpper = alignDown(-66400 + 1950) = -64500
-# => realised width 3000 (on the nose) and a realised ~1100/1900 split — the grid rounding is why
-# the realised skew is only "within one spacing" of the request, never exact.
+# => realised WIDTH 3000, exactly as requested (both bounds moved down by the same residue), but a
+# realised 1100/1900 split: the 50-tick residue came OUT of the upper span and went INTO the lower
+# one. That direction is systematic — down-alignment can only ever move ticks upper -> lower, up to
+# tickSpacing - 1 of them, and the market's tick at execution decides how many. Budget for it
+# (upperSpan >= 2 x tickSpacing) rather than expecting the requested split.
 # Pass 5000 instead of 3500 for the old centered behaviour.
 
 ./compound-cycle.sh calm                       # expect "spot is in range" again — new range, same spot
@@ -824,7 +925,7 @@ runs Aerodrome's weekly epoch flip. Re-arm it the production way:
 | `StaleOracle` | warped on a **non**-FreshFeed instance | wrong instance — check `check-feeds` |
 | `OLD` from `pool.observe` | state sync is ON — observation ring re-hydrated from mainnet while `observationIndex` froze | not repairable; recreate the vnet with sync OFF |
 | `ZeroMinOut` | `minUsdcOut == 0` | derive one from `quote` |
-| `OutOfBounds` | width outside [200, 20000] or off the spacing grid; **or** `skewBps` outside `(0, 10000)` or with a span shorter than one `tickSpacing` | pick a valid width / skew (selector `0xb4120f14` — this is the renamed `WidthOutOfBounds`) |
+| `OutOfBounds` | width outside [200, 20000] or off the spacing grid; **or** `skewBps` outside `(0, 10000)`, outside the init-immutable `[minSkewBps, maxSkewBps]` band, or with a span shorter than one `tickSpacing` | pick a valid width / skew — read all four bounds off `layout()` (selector `0xb4120f14` — this is the renamed `WidthOutOfBounds`; the skew band raises the **same** error, there is no new selector) |
 | `DegenerateRange` | asset-mode deploy/lever-up sized against a range the price has left — reachable by an extreme skew as well as by drift | `rerange` back onto spot with a moderate skew |
 | `TargetLtvExceedsMax` | target above `maxLtvBps` | lower the target |
 | `InsufficientIdleForLeverUp` | lever-up needs idle USDC it doesn't have | deposit more, then retry — this is correct fail-closed behaviour |
@@ -902,14 +1003,17 @@ Production addresses are published separately at deploy.
 - [ ] Sign every operator op with the strategy **proposer** key (`MAMO_REBALANCER`, `0x73f6…8FAf` on staging) — **never** the backend key (`MAMO_BACKEND`); confirm `strategy.proposer()` matches before wiring.
 - [ ] Gate the whole operator loop on `state() == Executed`; `execute`/`settle` are `onlyVault` and belong to the vault owner's `activateStrategy` / `settleStrategy`, not to you.
 - [ ] Periodically `deployIdle(amount, minLiquidity)` accumulated strategy-idle USDC; pass a real `minLiquidity`. `amount` is capped by idle alone — no leverage-derived ceiling to compute (§B) — so decide the **reserve you hold back**: it is the instant-redeem cover that keeps exits off the queue (§D), and in asset-mode the lever-up funding (§G).
-- [ ] **Read `layout().legBIsAsset` first and branch on it** — asset-mode changes `deployIdle` sizing, makes lever-**up** consume idle USDC, lets `rerange` draw on idle, and adds `InsufficientIdleForLeverUp` / `DegenerateRange` to the error set (§G).
+- [ ] **Read `layout().legBIsAsset` first and branch on it** — asset-mode changes `deployIdle` sizing, makes lever-**up** consume idle USDC, and adds `InsufficientIdleForLeverUp` / `DegenerateRange` to the error set (§G). `rerange` is **not** on that list any more: it re-adds only what its own unwind collected and never reaches idle.
 - [ ] `compound(minUsdcOut, minLiquidity)` on cadence with a **non-zero** `minUsdcOut`; expect it to defer (revert) on a stale AERO feed. **Do not predict the redeploy as `usdcOut − fee`** — `compound` first repays accrued borrow interest out of the harvest (§B), so the CL add is smaller by that amount; `MoonwellRepayFailed` is on that path.
 - [ ] Track drift with `hedgedDebt()` vs. each market's `borrowBalanceStored` (§E) to size the harvest cadence, and confirm it returns to ~0 after a compound; remember the on-chain measure accrues first, so the off-chain `…Stored` read is a lower bound.
 - [ ] Read the standing target with `targetLtvBps()`, not from the position's current LTV — `adjustLeverage` **persists** it and the next `deployIdle`/`compound` borrows at it.
-- [ ] `rerange(width, skewBps, minLiq0, minLiq1)` when spot drifts out of range or the model picks a new width **or skew** — `width` in raw ticks, tickSpacing-aligned, inside `[minWidth, maxWidth]`; `skewBps` in `(0, 10000)` (5000 = centered) with **both** spans ≥ one `tickSpacing` (else `OutOfBounds`, selector `0xb4120f14` — **re-point the backend error table off the retired `WidthOutOfBounds` `0x1f9f54af`**); expect calm-gate reverts on a shoved pool (retry when calm). In the two-borrowed-legs shape, budget for the standing idle remainder a skewed range leaves against the range-blind 50/50 borrow (§B) — utilisation drag, not a hedge or health change.
+- [ ] `rerange(width, skewBps, minLiq0, minLiq1)` when spot drifts out of range or the model picks a new width **or skew** — `width` in raw ticks, tickSpacing-aligned, inside `[minWidth, maxWidth]`; `skewBps` in `(0, 10000)` (5000 = centered), inside the init-immutable `[minSkewBps, maxSkewBps]` band, with **both** spans ≥ one `tickSpacing` (else `OutOfBounds`, selector `0xb4120f14` — **re-point the backend error table off the retired `WidthOutOfBounds` `0x1f9f54af`**); expect calm-gate reverts on a shoved pool (retry when calm).
+- [ ] Size `(width, skewBps)` for the **realised** geometry, not the requested one: down-alignment preserves width exactly but always moves up to `tickSpacing − 1` ticks from the upper span into the lower one, so keep `upperSpan ≥ 2 × tickSpacing`; and remember skew is inert at `width == 2 × tickSpacing` (needs `≥ 3 × tickSpacing` to do anything) (§B).
+- [ ] In the two-borrowed-legs shape, budget for the **per-borrow ratchet** a skewed range creates against the range-blind 50/50 borrow: each `deployIdle`/`compound` strands a fresh, debt-funded slice of its own borrow (≈19 % at `skewBps` 3500, ≈33.5 % at 2000 *or* 8000) and the idle fraction grows with every compound until an op that resizes the book folds it back in (§B). Utilisation drag and borrow carry — not a hedge or health change.
 - [ ] `adjustLeverage(target, minLiq, minOut)` to hold near `targetLtvBps` — and to lever **down before `fulfillRedeem`** so the oracle-free unwind self-funds.
 - [ ] Watch `RedeemRequested` → assess self-funding via `redeemRequest(id)`/`previewRedeem` → (deleverage if needed) → `fulfillRedeem(id)`; on `InsufficientAssetsOut`, deleverage more or wait — never lower the requester's floor.
 - [ ] Treat `FULFILL_WINDOW = 2 days` as the hard SLA; alert before it; every `RedeemEmergency` is a missed SLA.
+- [ ] Alert on **supply reaching zero**: a full redeem burns the position NFT (`tokenId == 0` while still `Executed`) and the book cannot be rebuilt — `rerange` silently mints nothing, `deployIdle` fails closed, `compound` no-ops, and the only way forward is `settleStrategy()` plus a **new vault** (§F).
 - [ ] Run `deleverage(minOut)` proactively as health nears `minHealthBps`; remember it is permissionless (others will trigger it too).
 - [ ] Monitor `nav()` reverts as a "priced paths degraded to async" signal — **not** a fulfill blocker (the queue is oracle-free); monitor `FeeCrystallizeDeferred`, whose realistic cause is a frozen vault (`depositsOpen == false`).
 - [ ] Read the venue shape off `layout()` before wiring anything numeric — leg tokens, `cbBTCDecimals`/`wethDecimals`, `wethIsToken0`, the two leg-swap spacings, the width band and the stored `skewBps` (§G). Never hardcode the launch pair.

--- a/docs/integrations/LEVERAGED_AERO_REBALANCER.md
+++ b/docs/integrations/LEVERAGED_AERO_REBALANCER.md
@@ -129,7 +129,7 @@ function deployIdle(uint256 amount, uint256 minLiquidity) external onlyProposer 
 | Position effect (two borrowed legs) | supply **all** of `amount` USDC → mUSDC → borrow both legs at **`targetLtvBps`** (50/50 by USD value) → wrap native ETH **iff** `wethDeliversNative` (§G) → `increaseLiquidity` into the existing CL NFT → restake in the gauge. |
 | Position effect (asset-mode) | `LeveragedAeroValuation.assetModeSplit` solves the split closed-form against the **STORED** range: only `C < amount` is supplied as collateral, a **single** leg-A borrow is taken against `C` at `targetLtvBps`, and `U = amount − C` is held back as the LP's USDC side so the add lands at exactly the ratio the stored range needs. Net leg-A exposure stays 0 (LP leg == debt leg). |
 | Guards | Two-borrowed-legs: borrow sized at `amount × targetLtvBps / 1e4`. Asset-mode: borrow sized at `C × targetLtvBps / 1e4` with `C` from the split — so the **effective** collateral is less than `amount` and a naive `amount × targetLtvBps` model will over-predict the borrow. Both: two-sided `maxSlippageBps` mins on the add plus the caller's `minLiquidity`; closes with `_assertHealthy()` (post-op LTV ≤ `maxLtvBps` **and** no Moonwell shortfall). |
-| Errors | `InsufficientIdle`, `InsufficientLiquidity`, `MoonwellMintFailed`/`MoonwellBorrowFailed(errCode)`, `UnhealthyPosition(ltvBps, limitBps)`; **asset-mode also** `DegenerateRange()` — the split is sized against the STORED range (`posTickLower`/`posTickUpper`), so a range the price has already left is one-sided and fails closed. `rerange` recenters and unblocks it. |
+| Errors | `InsufficientIdle`, `InsufficientLiquidity`, `MoonwellMintFailed`/`MoonwellBorrowFailed(errCode)`, `UnhealthyPosition(ltvBps, limitBps)`; **asset-mode also** `DegenerateRange()` — the split is sized against the STORED range (`posTickLower`/`posTickUpper`), so a range the price has already left is one-sided and fails closed. A `rerange` back onto spot unblocks it. |
 | When to call | Deposits land as idle USDC (see §D) and earn nothing until deployed. Run periodically to sweep accumulated idle into the position, within leverage caps. |
 
 ### `compound` — harvest AERO, reinvest, crystallize fees
@@ -151,26 +151,60 @@ function compound(uint256 minUsdcOut, uint256 minLiquidity) external onlyPropose
 | Errors | `ZeroMinOut`, `BelowOracleFloor`, `UnhealthyPosition`; **`MoonwellRepayFailed(errCode)` from the interest re-hedge**; `MoonwellMintFailed`/`MoonwellBorrowFailed(errCode)`, `InsufficientLiquidity` and (asset-mode) `DegenerateRange()` from the redeploy. A stale/mismatched feed fail-closes the whole call — the AERO feed at the swap floor, and the leg + USDC feeds at the hedge (`compound` already fail-closes on those via the pre-compound `nav()`, so the hedge widens no oracle exposure). |
 | When to call | On a yield/gas cadence. A stale AERO feed intentionally blocks it — defer and retry. Use `hedgedDebt()` vs. the markets' `borrowBalanceStored` (§E) to see how much drift a harvest will have to buy back, and to verify it went to ~0 afterwards. |
 
-### `rerange` — re-center and re-width the CL range (no swap)
+### `rerange` — reposition the CL range: re-width, re-skew, re-anchor (no swap)
 
 ```solidity
-function rerange(uint24 width, uint256 minLiq0, uint256 minLiq1) external onlyProposer nonReentrant;
+function rerange(uint24 width_, uint16 skewBps_, uint256 minLiq0, uint256 minLiq1)
+    external onlyProposer nonReentrant;
 ```
 
-The 3-arg form (per-cycle width) is the in-repo signature — `src/leveraged-aero/LeveragedAerodromeCLStrategy.sol`
-is the authority for it; there is no older 2-arg variant to reconcile against any more.
+The 4-arg form (per-cycle width **and** skew) is the in-repo signature — `src/leveraged-aero/LeveragedAerodromeCLStrategy.sol`
+is the authority for it. It replaces the previous 3-arg `rerange(uint24,uint256,uint256)`; **the selector
+changed**, so anything holding a hardcoded one must be re-derived (`cast sig 'rerange(uint24,uint16,uint256,uint256)'`).
 
 | | |
 |---|---|
-| `width` | New position width in **raw ticks** (must be a multiple of `tickSpacing`), validated strategy-side against the init-immutable `[minWidth, maxWidth]` band **before** the venue delegatecall → `WidthOutOfBounds()` (selector `0x1f9f54af`, deliberately matching the Mamo backend's rebalance-param error). The width is **persisted** — subsequent range math (and the genesis mint path) reads the stored value; only `rerange` moves it, the band never moves after init. `layout()` exposes `width` / `minWidth` / `maxWidth` for the rebalancer to read on-chain — always read them off the clone you actually point at (the current staging clone was init'd width **4000**, band **[200, 20000]**). |
+| `width_` | New position width in **raw ticks** (must be a multiple of `tickSpacing`), validated strategy-side against the init-immutable `[minWidth, maxWidth]` band **before** the venue delegatecall → `OutOfBounds()`. The width is **persisted** — subsequent range math (and the genesis mint path) reads the stored value; only `rerange` moves it, the band never moves after init. `layout()` exposes `width` / `minWidth` / `maxWidth` for the rebalancer to read on-chain — always read them off the clone you actually point at (the current staging clone was init'd width **4000**, band **[200, 20000]**). |
+| `skewBps_` | The fraction of `width_` placed **BELOW** the current tick, in bps (`10000` = 1.00). `5000` = centered — the old, and still the genesis/ops default. `3500` puts 35 % of the range below spot and 65 % above, i.e. more room for the price to rise. Concretely `lowerSpan = width_ × skewBps_ / 10000`, `upperSpan = width_ − lowerSpan`; both bounds are still aligned **DOWN** to `tickSpacing`, so the realised on-grid width stays within one spacing of the request. Validated with the width, **before** the venue delegatecall → `OutOfBounds()`: `skewBps_` must be in `(0, 10000)` **exclusive**, and **both** spans must be ≥ one `tickSpacing` — the second check is what protects the strict-bracketing invariant at small widths, where a legal-looking skew would otherwise collapse a side to zero. Like `width`, `skewBps` is **persisted** and exposed on `layout()`; the next `execute`/genesis mint re-mints at the stored width **and** the stored skew. |
 | `minLiq0` / `minLiq1` | Minimum **token0** / **token1** the re-add must consume (two-sided slippage guard) → `InsufficientLiquidity()`. `token0`/`token1` are **pool ordering**, derived at init from `pool.token0()` and exposed as `layout().wethIsToken0` — do not assume which leg is which (see §G). |
-| Position effect | **Calm-gate runs FIRST** (`LeveragedAeroValuation._calmGate`) so a recenter can never execute at a manipulated tick → remove 100% liquidity + collect → mint a **new** CL NFT spanning `width/2` raw ticks each side of the current tick → restake. The **old NFT is left empty** (Slipstream ticks are immutable; the stale NFT is harmless dust). |
-| What happens to principal | **No swap → principal conserved** (IL is realized only on a true exit). The collected ratio can't match the new range, so a remainder of **one** leg is left idle in the strategy — `nav()` prices it, so the recenter is NAV-neutral and the remainder stays redeployable. Debt + collateral untouched (health preserved). |
+| Position effect | **Calm-gate runs FIRST** (`LeveragedAeroValuation._calmGate`) so a reposition can never execute at a manipulated tick → remove 100% liquidity + collect → mint a **new** CL NFT bracketing the current tick, `width_ × skewBps_ / 10000` raw ticks below it and the remainder above (equal halves at the default `skewBps_ = 5000`) → restake. The **old NFT is left empty** (Slipstream ticks are immutable; the stale NFT is harmless dust). |
+| What happens to principal | **No swap → principal conserved** (IL is realized only on a true exit). The collected ratio can't match the new range, so a remainder of **one** leg is left idle in the strategy — `nav()` prices it, so the reposition is NAV-neutral and the remainder stays redeployable. Debt + collateral untouched (health preserved). |
 | Asset-mode difference | The re-add offers the mint the strategy's **whole balance of each leg slot as `amountDesired`** — and in asset-mode the leg-B slot **is USDC** (`layout().cbBTC == layout().usdc`). So the amount of USDC the mint consumes is whatever the new range needs to pair with the collected leg A, which can be **more than the unwind itself collected**, drawing the difference from idle USDC. That is value-conserving (idle → LP, `nav()` unchanged) but it shrinks the redeem cover budget, the same operator consequence as an asset-mode lever-up. Conversely the leftover remainder is plain USDC rather than a borrowed leg. Size reranges against available idle when the clone is asset-mode. |
 | Fee interaction | **No crystallization** — supply and NAV are unchanged; the streaming fee simply defers to the next crystallize point and the HWM is unaffected. |
 | Guards | Calm-gate; two-sided `maxSlippageBps` mins + caller `minLiq0/minLiq1`; closing `_assertHealthy()`. |
-| Errors | `WidthOutOfBounds` (out-of-band or misaligned `width`), calm-gate reverts (`TwapDeviation`/`StaleOracle` family), `InsufficientLiquidity`, `UnhealthyPosition`. |
-| When to call | When spot has drifted out of the active range, or when the rebalance model chooses a new width for the cycle. Width selection policy is the rebalancer's (`RebalanceParams.width` in the backend spec); the chain only enforces the band. |
+| Errors | `OutOfBounds` — **one error now covers both knobs**: an out-of-band or misaligned `width_`, *and* a `skewBps_` outside `(0, 10000)` or one whose spans do not both reach a `tickSpacing`. Plus calm-gate reverts (`TwapDeviation`/`StaleOracle` family), `InsufficientLiquidity`, `UnhealthyPosition`. **`OutOfBounds()` is the rename of the old `WidthOutOfBounds()` and therefore has a NEW selector** — see the note below. |
+| Errors — asset-mode reachability | An **extreme** skew makes the range very lopsided, and a very lopsided range is exactly the shape `LeveragedAeroValuation.assetModeSplit` fails closed on: the next `deployIdle` / lever-up can then revert `DegenerateRange()`. This is **not a new failure mode** — it is the existing one-sided-range guard — but skew is a new way to reach it. Prefer moderate skews, and if you do park the range far off spot, expect the deploy paths to want a `rerange` back before they will size. |
+| When to call | When spot has drifted out of the active range, or when the rebalance model chooses a new width **or a new skew** for the cycle. Width and skew selection policy is the rebalancer's (`RebalanceParams.width` in the backend spec); the chain only enforces the band, the `(0, 10000)` bound and the one-spacing-per-side floor. |
+
+> **Selector change — the backend error table must be updated.** `WidthOutOfBounds()` (`0x1f9f54af`)
+> is gone; it is renamed `OutOfBounds()`, selector **`0xb4120f14`** (`cast sig 'OutOfBounds()'`). The old
+> selector was deliberately paired with the Mamo backend's rebalance-param error code — that pairing now
+> points at a selector the strategy no longer emits, so the backend's decode table has to be re-pointed at
+> `0xb4120f14` or every out-of-band width/skew will surface as an unknown revert. The error's *meaning*
+> widened too: it is no longer width-only.
+>
+> **Do not "fix" `docs/superpowers/specs/2026-07-03-lp-auto-balancer-v2-backend-spec.md`.** That table
+> also lists `0x1f9f54af → WidthOutOfBounds()`, and it is still **correct** — it describes
+> `LPAutoBalancerV2`, a different contract that keeps its own `WidthOutOfBounds()`. The two contracts'
+> errors have now **diverged**: `0x1f9f54af` means an LPV2 width bug, `0xb4120f14` means a leveraged-Aero
+> width **or skew** bug. A backend decoding both products needs both entries, keyed by which contract
+> reverted.
+
+> **Two-borrowed-legs shape: a skewed range leaves a persistent idle remainder (deliberate).** The
+> genesis / `deployIdle` borrow is **range-blind** — `_borrowHalfEach` splits the borrow 50/50 by USD
+> value regardless of where the range sits. A skewed range does **not** want 50/50 by value, so the mint
+> consumes an unequal amount of the two legs and the book carries a standing idle balance of one borrowed
+> token. To be explicit about what this is and is not:
+> - **Not a hedge break.** The idle borrowed token hedges its own debt 1:1 exactly as it would inside the
+>   LP, and `nav()` prices it. Net exposure is unchanged.
+> - **Not an LTV or health change.** Collateral and debt are untouched; `_assertHealthy()` sees the same
+>   numbers.
+> - **It is capital-utilisation drag** — a slice of the book sits idle instead of earning LP fees.
+>
+> Recommended ops default: **initialize with `skewBps = 5000` (centered) and apply skew per-cycle via
+> `rerange`**, sizing it against how much drag you are willing to carry. Asset-mode is unaffected in kind
+> (its leg-B slot is USDC, so the remainder is plain idle USDC — see the asset-mode row above). Making the
+> borrow range-aware would remove the drag and is a possible follow-up; it is **out of scope** here.
 
 ### `adjustLeverage` — move LTV toward a target
 
@@ -187,7 +221,7 @@ function adjustLeverage(uint16 targetLtvBps_, uint256 minLiq, uint256 minOut)
 | Position effect (both shapes) | Collateral untouched; LTV moves on the **debt** side. `targetDebt = targetLtvBps_ × collateralUsdc / 1e4`. Lever **down**: unwind the matching CL fraction and repay, per-leg residual rebalanced through USDC (`minOut`) — unchanged in asset-mode, where the leg-B residual **is** USDC and flows straight into the leg-A cover. Closes with `_assertHealthy()`. |
 | Lever **up** — two borrowed legs | Borrow the delta 50/50 by USD across both legs and LP them against each other. **Self-funding**: the pair *is* the two borrows, so no idle USDC is consumed. |
 | Lever **up** — asset-mode | Borrows **only leg A** and pairs it with USDC **drawn from the strategy's idle balance**, sized closed-form (`assetModeLeverUpPair`) so the LP's leg-A amount equals the added leg-A debt — that is what preserves the delta-hedge (swapping part of the borrow to USDC would leave the book net short). **Operator consequence: an asset-mode lever-up CONSUMES idle USDC.** Value-conserving (a NAV component moving idle → LP, not a loss) but it shrinks the redeem cover budget until the next deposit. **Size lever-ups against available idle**; an under-funded one reverts `InsufficientIdleForLeverUp(needed, available)` and changes nothing — deliberately not a partial fill and not a silent cap. |
-| `targetLtvBps_` is **persisted** | The value is stored as the fund's standing target, so `execute` / `deployIdle` / `compound` size their **next** borrow at it. This holds even when neither branch runs (`targetDebt == debtUsdc`) — the retarget still takes effect, exactly like `rerange`-on-a-flat-book persisting `width`. Read it back with `targetLtvBps()` or `layout().targetLtvBps` (§E). |
+| `targetLtvBps_` is **persisted** | The value is stored as the fund's standing target, so `execute` / `deployIdle` / `compound` size their **next** borrow at it. This holds even when neither branch runs (`targetDebt == debtUsdc`) — the retarget still takes effect, exactly like `rerange`-on-a-flat-book persisting `width` and `skewBps`. Read it back with `targetLtvBps()` or `layout().targetLtvBps` (§E). |
 | Fee interaction | **No crystallization** (like `rerange`): no supply change, no PnL realized; streaming fee defers, HWM unaffected. |
 | Errors | `TargetLtvExceedsMax`, `InsufficientLiquidity`, `MoonwellRepayFailed`/`MoonwellBorrowFailed`, `UnhealthyPosition`; **asset-mode lever-up also** `InsufficientIdleForLeverUp(uint256 needed, uint256 available)` and `DegenerateRange()` (the pairing is sized against the STORED range — a one-sided one fails closed; `rerange` unblocks it). `InsufficientIdleForLeverUp` is raised inside `LeveragedAeroValuation` but **re-declared on the strategy** (`LeveragedAerodromeCLStrategy.sol:93`, same selector) so it is on the clone's own ABI for the rebalancer / frontend — decode it off the strategy ABI, no library ABI needed. |
 | When to call | To hold the fund near `targetLtvBps`, and — critically — **before `fulfillRedeem`** to lever **down** so the oracle-free proportional unwind self-funds its IL/debt shortfall (see §C). In asset-mode note the two directions are asymmetric on idle: lever **down** frees USDC, lever **up** spends it. |
@@ -435,7 +469,7 @@ function hedgedDebt() external view returns (uint128 legA, uint128 legB);       
   gauge, swapRouter, comptroller, the Moonwell markets, the Chainlink feeds incl. `aeroUsdFeed`,
   `sequencerFeed`), **oracle config** (`maxDelay`, `gracePeriod`, `calmDeviationTicks`, `twapWindow`,
   `tickSpacing`), **position state** (`tokenId`, `posTickLower`, `posTickUpper`, `nextRedeemRequestId`),
-  the **width band** (`width`, `minWidth`, `maxWidth`), the **hedged-debt basis** (`hedgedDebtA`,
+  the **range knobs** (`width`, `minWidth`, `maxWidth`, `skewBps`), the **hedged-debt basis** (`hedgedDebtA`,
   `hedgedDebtB`), and the **venue-shape fields the keeper must not assume** (`legBIsAsset`,
   `cbBTCDecimals`, `wethDecimals`, `wethIsToken0`, `wethDeliversNative`, `cbBTCSwapTickSpacing`,
   `wethSwapTickSpacing` — see §G).
@@ -479,7 +513,7 @@ Strategy events that exist today:
   and a calm-gate. A stale feed or a down sequencer **fail-closes** — the op reverts. This is intended
   posture: defer the harvest / re-range / deleverage and rely on the oracle-free async queue for exits.
 - **Calm gate.** Every mint/add path runs the calm-gate (`|spotTick − twapTick| ≤ calmDeviationTicks` over
-  `twapWindow`) before the pool is touched, as does NAV pricing — so the agent can never recenter, add or
+  `twapWindow`) before the pool is touched, as does NAV pricing — so the agent can never reposition, add or
   price at a manipulated tick. A shoved pool blocks `rerange`, `deployIdle`, `compound`'s redeploy and a
   lever-**up**; retry once calm. **Where in the op the gate fires is not uniform**, and an operator reading
   a reverted trace should expect it: `rerange` gates first, before any venue call; `execute` gates after
@@ -543,8 +577,8 @@ the clone rather than assuming the launch pair:
   | Range-sensitivity | none on the deploy path | `deployIdle` / lever-up size against the **STORED** range → `DegenerateRange()` when it is one-sided; `rerange` first |
 
   The operator rule of thumb for asset-mode: **idle USDC is no longer just a redeem buffer, it is an input
-  to `deployIdle`, `adjustLeverage` (up) and `rerange`.** Track it as a budget, and prefer a `rerange` to
-  recenter before any op that sizes against the stored range.
+  to `deployIdle`, `adjustLeverage` (up) and `rerange`.** Track it as a budget, and prefer a `rerange`
+  back onto spot before any op that sizes against the stored range.
 - **`weth*` / `cbBTC*` are leg SLOTS, not tokens.** `weth`/`mWeth`/`wethFeed`/`wethDecimals` are **leg A**
   (the slot that may be delivered natively on borrow); `cbBTC`/`mCbBTC`/`cbBTCFeed`/`cbBTCDecimals` are
   **leg B**. The names are historical — read the actual token addresses from `layout()`. Every error
@@ -594,7 +628,7 @@ appears. But there is one misconception worth killing up front, because it waste
 | --- | --- |
 | `nav()` and all USD valuation (`readUsd8`) | LP leg composition (how much cbBTC vs USDC the position holds) |
 | Slippage floors / `minOut` sizing, `BelowOracleFloor` | Whether the position is in or out of range |
-| The interest hedge's oracle-priced buy sizing | Where `rerange` re-centres (it centres on the pool tick) |
+| The interest hedge's oracle-priced buy sizing | Where `rerange` anchors the new range (it brackets the pool tick, split by `skewBps`) |
 | The staleness gate (`maxDelay`, currently 172800 s) | `calmGate` — **both** sides of it |
 | Health / LTV ratios and the `deleverage` trigger | Realized swap price, and therefore actual slippage |
 
@@ -620,9 +654,10 @@ mechanism protecting the fund from being rebalanced at a manipulated price — a
 | `twapWindow` | 15 | **1800 s** | TWAP averaging window (30 min) |
 | `tickSpacing` | 20 | 100 | LP pool spacing |
 | `maxSlippageBps` | 24 | 100 | 1 % — also the oracle-floor tolerance on swaps |
-| `posTickLower` / `posTickUpper` | 27 / 28 | −66300 / −63300 | current range (width 3000 ≈ 35 % span) |
-| width band | 44 / 45 | [200, 20000] | `rerange` width bounds (`WidthOutOfBounds` outside) |
+| `posTickLower` / `posTickUpper` | 27 / 28 | −66300 / −63300 | current range (width 3000 ≈ 35 % span, centered — `skewBps` 5000) |
+| width band | 44 / 45 | [200, 20000] | `rerange` width bounds (`OutOfBounds` outside) |
 | `legBIsAsset` | 46 | `true` | asset mode: leg B **is** USDC |
+| `skewBps` | 47 | **5000** | fraction of `width` placed BELOW spot; 5000 = centered (`OutOfBounds` outside `(0, 10000)` or if either span < `tickSpacing`). **Appended after `legBIsAsset`, not next to the width band** — decode by name, not by eyeballing the group |
 
 At the time of writing spot tick is **−64796** and the TWAP tick is **−64796** (identical — no recent
 swaps), so the gate has full headroom. Note the range edges are ~1500 ticks away, i.e. it takes roughly a
@@ -715,12 +750,19 @@ cd script/tenderly
 # One command: swap the pool → warp 1860 s → re-price leg-A/USD → re-gate the feeds → calm.
 ./compound-cycle.sh move-price -66400
 #   ... expect: ">> target REACHED", then "PASS" with 0 ticks of deviation (the TWAP has
-#   ... converged), then "spot is OUT OF RANGE (single-sided; rerange to re-centre)"
+#   ... converged), then "spot is OUT OF RANGE (single-sided; rerange to reposition (width + skew))"
 
-# The rebalance under test. rerange re-centres on the NEW pool tick; width must be a multiple
-# of tickSpacing (100) and inside the clone's [minWidth, maxWidth] band — read them from layout().
-cast send "$STRAT" 'rerange(uint24,uint256,uint256)' 3000 0 0 \
+# The rebalance under test. rerange brackets the NEW pool tick, split by skewBps; width must be a
+# multiple of tickSpacing (100) and inside the clone's [minWidth, maxWidth] band — read them from
+# layout(). skewBps = 3500 => 35 % of the width below spot, 65 % above (the cbBTC/WETH backtest's
+# skew): a deliberate lean that leaves more room for the price to recover upward.
+cast send "$STRAT" 'rerange(uint24,uint16,uint256,uint256)' 3000 3500 0 0 \
   --from "$PROPOSER" --unlocked --gas-limit 14000000 --rpc-url "$LEVERAGED_AERO_ADMIN_RPC_URL"
+# lowerSpan = 3000 × 3500/10000 = 1050, upperSpan = 1950, both bounds aligned DOWN to spacing 100:
+#   tickLower = alignDown(-66400 - 1050) = -67500,  tickUpper = alignDown(-66400 + 1950) = -64500
+# => realised width 3000 (on the nose) and a realised ~1100/1900 split — the grid rounding is why
+# the realised skew is only "within one spacing" of the request, never exact.
+# Pass 5000 instead of 3500 for the old centered behaviour.
 
 ./compound-cycle.sh calm                       # expect "spot is in range" again — new range, same spot
 ./compound-cycle.sh snap after-rerange         # principal conserved; one leg left idle (see §B)
@@ -757,7 +799,8 @@ runs Aerodrome's weekly epoch flip. Re-arm it the production way:
 | `StaleOracle` | warped on a **non**-FreshFeed instance | wrong instance — check `check-feeds` |
 | `OLD` from `pool.observe` | state sync is ON — observation ring re-hydrated from mainnet while `observationIndex` froze | not repairable; recreate the vnet with sync OFF |
 | `ZeroMinOut` | `minUsdcOut == 0` | derive one from `quote` |
-| `WidthOutOfBounds` | width outside [200, 20000] or off the spacing grid | pick a valid width |
+| `OutOfBounds` | width outside [200, 20000] or off the spacing grid; **or** `skewBps` outside `(0, 10000)` or with a span shorter than one `tickSpacing` | pick a valid width / skew (selector `0xb4120f14` — this is the renamed `WidthOutOfBounds`) |
+| `DegenerateRange` | asset-mode deploy/lever-up sized against a range the price has left — reachable by an extreme skew as well as by drift | `rerange` back onto spot with a moderate skew |
 | `TargetLtvExceedsMax` | target above `maxLtvBps` | lower the target |
 | `InsufficientIdleForLeverUp` | lever-up needs idle USDC it doesn't have | deposit more, then retry — this is correct fail-closed behaviour |
 | `NotProposer` | signed with the wrong key | sign as the **rebalancer**, not `MAMO_BACKEND` |
@@ -838,12 +881,12 @@ Production addresses are published separately at deploy.
 - [ ] `compound(minUsdcOut, minLiquidity)` on cadence with a **non-zero** `minUsdcOut`; expect it to defer (revert) on a stale AERO feed. **Do not predict the redeploy as `usdcOut − fee`** — `compound` first repays accrued borrow interest out of the harvest (§B), so the CL add is smaller by that amount; `MoonwellRepayFailed` is on that path.
 - [ ] Track drift with `hedgedDebt()` vs. each market's `borrowBalanceStored` (§E) to size the harvest cadence, and confirm it returns to ~0 after a compound; remember the on-chain measure accrues first, so the off-chain `…Stored` read is a lower bound.
 - [ ] Read the standing target with `targetLtvBps()`, not from the position's current LTV — `adjustLeverage` **persists** it and the next `deployIdle`/`compound` borrows at it.
-- [ ] `rerange(width, minLiq0, minLiq1)` when spot drifts out of range or the model picks a new width — `width` in raw ticks, tickSpacing-aligned, inside `[minWidth, maxWidth]` (else `WidthOutOfBounds`); expect calm-gate reverts on a shoved pool (retry when calm).
+- [ ] `rerange(width, skewBps, minLiq0, minLiq1)` when spot drifts out of range or the model picks a new width **or skew** — `width` in raw ticks, tickSpacing-aligned, inside `[minWidth, maxWidth]`; `skewBps` in `(0, 10000)` (5000 = centered) with **both** spans ≥ one `tickSpacing` (else `OutOfBounds`, selector `0xb4120f14` — **re-point the backend error table off the retired `WidthOutOfBounds` `0x1f9f54af`**); expect calm-gate reverts on a shoved pool (retry when calm). In the two-borrowed-legs shape, budget for the standing idle remainder a skewed range leaves against the range-blind 50/50 borrow (§B) — utilisation drag, not a hedge or health change.
 - [ ] `adjustLeverage(target, minLiq, minOut)` to hold near `targetLtvBps` — and to lever **down before `fulfillRedeem`** so the oracle-free unwind self-funds.
 - [ ] Watch `RedeemRequested` → assess self-funding via `redeemRequest(id)`/`previewRedeem` → (deleverage if needed) → `fulfillRedeem(id)`; on `InsufficientAssetsOut`, deleverage more or wait — never lower the requester's floor.
 - [ ] Treat `FULFILL_WINDOW = 2 days` as the hard SLA; alert before it; every `RedeemEmergency` is a missed SLA.
 - [ ] Run `deleverage(minOut)` proactively as health nears `minHealthBps`; remember it is permissionless (others will trigger it too).
 - [ ] Monitor `nav()` reverts as a "priced paths degraded to async" signal — **not** a fulfill blocker (the queue is oracle-free); monitor `FeeCrystallizeDeferred`, whose realistic cause is a frozen vault (`depositsOpen == false`).
-- [ ] Read the venue shape off `layout()` before wiring anything numeric — leg tokens, `cbBTCDecimals`/`wethDecimals`, `wethIsToken0`, the two leg-swap spacings, the width band (§G). Never hardcode the launch pair.
+- [ ] Read the venue shape off `layout()` before wiring anything numeric — leg tokens, `cbBTCDecimals`/`wethDecimals`, `wethIsToken0`, the two leg-swap spacings, the width band and the stored `skewBps` (§G). Never hardcode the launch pair.
 - [ ] Know the open gaps: the any-pool rewrites have **no behavioral fork coverage** yet, and the Moonwell `underlying()` init guard is unverified on the live markets (§G).
 - [ ] Use `rescueToVault(token)` only for genuine stray tokens; it reverts on any position/accounting token and always pays the vault.

--- a/script/tenderly/LeveragedAeroStackHarness.s.sol
+++ b/script/tenderly/LeveragedAeroStackHarness.s.sol
@@ -152,7 +152,12 @@ contract LeveragedAeroStackHarness is Script {
         console.log("  width band min/width/max:", uint256(p.minWidth), uint256(p.width), uint256(p.maxWidth));
         // Separate line: console.log tops out at 4 args, and the band already uses all of them.
         // Keep the "width band" prefix — run-leveraged-aero-stack.sh Phase B.2 greps for it.
-        console.log("  width band skewBps (below-fraction, 5000 = centered):", uint256(p.skewBps));
+        console.log(
+            "  width band skewBps (below-fraction, 5000 = centered) min/skew/max:",
+            uint256(p.minSkewBps),
+            uint256(p.skewBps),
+            uint256(p.maxSkewBps)
+        );
     }
 
     /// @dev Build `InitParams` from env vars. Field-by-field (not a struct literal) to keep the Yul IR
@@ -200,9 +205,13 @@ contract LeveragedAeroStackHarness is Script {
         p.maxWidth = uint24(vm.envOr("MAX_WIDTH", uint256(20_000)));
         // ── range skew: fraction of `width` placed BELOW the current tick, bps (10000 = 1.00).
         // 5000 = centered, which is the ops default at genesis — skew is applied per-cycle via
-        // `rerange`, not baked into init. Must be in (0, 10000) exclusive AND leave BOTH spans
-        // >= one tickSpacing, else OutOfBounds().
+        // `rerange`, not baked into init. Must be in (0, 10000) exclusive, inside the governance band
+        // [MIN_SKEW_BPS, MAX_SKEW_BPS], AND leave BOTH spans >= one tickSpacing, else OutOfBounds().
         p.skewBps = uint16(vm.envOr("SKEW_BPS", uint256(5000)));
+        // ── skew governance band: fixed for the clone's life, `0 < min <= max < 10000`. It caps how far
+        // off centre a proposer may rerange; ±40 points around centre is the ops default.
+        p.minSkewBps = uint16(vm.envOr("MIN_SKEW_BPS", uint256(1000)));
+        p.maxSkewBps = uint16(vm.envOr("MAX_SKEW_BPS", uint256(9000)));
         // ── risk params: targetLtv ≤ maxLtv < USDC CF, minHealth ≥ 10500, minHealth×maxLtv < 1e8 ──
         p.targetLtvBps = uint16(vm.envOr("TARGET_LTV_BPS", uint256(5000)));
         p.maxLtvBps = uint16(vm.envOr("MAX_LTV_BPS", uint256(6500)));

--- a/script/tenderly/LeveragedAeroStackHarness.s.sol
+++ b/script/tenderly/LeveragedAeroStackHarness.s.sol
@@ -150,6 +150,9 @@ contract LeveragedAeroStackHarness is Script {
         console.log("  feeRecip :", p.feeRecipient);
         console.log("  mgmt/perf fee bps:", uint256(p.managementFeeBps), uint256(p.performanceFeeBps));
         console.log("  width band min/width/max:", uint256(p.minWidth), uint256(p.width), uint256(p.maxWidth));
+        // Separate line: console.log tops out at 4 args, and the band already uses all of them.
+        // Keep the "width band" prefix — run-leveraged-aero-stack.sh Phase B.2 greps for it.
+        console.log("  width band skewBps (below-fraction, 5000 = centered):", uint256(p.skewBps));
     }
 
     /// @dev Build `InitParams` from env vars. Field-by-field (not a struct literal) to keep the Yul IR
@@ -195,6 +198,11 @@ contract LeveragedAeroStackHarness is Script {
         p.width = uint24(vm.envOr("WIDTH", uint256(4000))); // 40 × spacing — genesis mints at this
         p.minWidth = uint24(vm.envOr("MIN_WIDTH", uint256(200))); // 2 × spacing
         p.maxWidth = uint24(vm.envOr("MAX_WIDTH", uint256(20_000)));
+        // ── range skew: fraction of `width` placed BELOW the current tick, bps (10000 = 1.00).
+        // 5000 = centered, which is the ops default at genesis — skew is applied per-cycle via
+        // `rerange`, not baked into init. Must be in (0, 10000) exclusive AND leave BOTH spans
+        // >= one tickSpacing, else OutOfBounds().
+        p.skewBps = uint16(vm.envOr("SKEW_BPS", uint256(5000)));
         // ── risk params: targetLtv ≤ maxLtv < USDC CF, minHealth ≥ 10500, minHealth×maxLtv < 1e8 ──
         p.targetLtvBps = uint16(vm.envOr("TARGET_LTV_BPS", uint256(5000)));
         p.maxLtvBps = uint16(vm.envOr("MAX_LTV_BPS", uint256(6500)));

--- a/script/tenderly/compound-cycle.sh
+++ b/script/tenderly/compound-cycle.sh
@@ -75,10 +75,13 @@ AERO_V2_ROUTER=0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43
 AERO_V2_FACTORY=0x420DD381b31aEf6683db6B902084cB0FFECe40Da
 NPM=0x827922686190790b37229fd06084350E74485b72
 
-# NB: keep in lockstep with LeveragedAerodromeCLStrategy.LayoutView. b9ea6ac appended
-# `uint128 hedgedDebtA` + `uint128 hedgedDebtB` (fields 47/48) for the borrow-interest hedge; a
-# short signature here makes `cast call` fail to decode and every `lay N` read comes back empty.
-LAYOUT_SIG='layout()((address,address,address,address,address,address,address,address,address,address,address,uint256,uint256,uint16,uint32,address,address,address,address,int24,uint16,uint16,uint16,uint16,uint16,uint256,int24,int24,uint16,uint16,address,uint256,uint256,uint256,address,uint256,uint8,uint8,bool,bool,int24,int24,uint24,uint24,uint24,bool,uint128,uint128))'
+# NB: keep in lockstep with LeveragedAerodromeCLStrategy.LayoutView — BOTH arity and field ORDER.
+# b9ea6ac appended `uint128 hedgedDebtA` + `uint128 hedgedDebtB` for the borrow-interest hedge; the
+# rerange-skew change appended `uint16 skewBps` AFTER `legBIsAsset` — i.e. field 47, NOT next to the
+# width band (`width`/`minWidth`/`maxWidth`, 43/44/45) where you would expect it — pushing the two
+# hedgedDebt fields to 48/49. A short or mis-ordered signature here makes `cast call` fail to decode
+# and every `lay N` read comes back empty — if `lay` starts returning nothing, check this line FIRST.
+LAYOUT_SIG='layout()((address,address,address,address,address,address,address,address,address,address,address,uint256,uint256,uint16,uint32,address,address,address,address,int24,uint16,uint16,uint16,uint16,uint16,uint256,int24,int24,uint16,uint16,address,uint256,uint256,uint256,address,uint256,uint8,uint8,bool,bool,int24,int24,uint24,uint24,uint24,bool,uint16,uint128,uint128))'
 
 c() { cast call --rpc-url "$RPC" "$@" 2>/dev/null; }
 num() { echo "${1%% *}"; }
@@ -378,8 +381,8 @@ cmd_compound_expect_revert() {
 # INDEPENDENT price sources driving different things:
 #   • the FEED drives nav()/valuation, slippage floors and `BelowOracleFloor`, hedge sizing, the
 #     staleness gate, health/LTV;
-#   • the POOL TICK drives LP leg composition, in/out-of-range, where `rerange` re-centres, and the
-#     realized swap price;
+#   • the POOL TICK drives LP leg composition, in/out-of-range, where `rerange` anchors the new range
+#     (it brackets the pool tick, split by `skewBps` — 5000 = centered), and the realized swap price;
 #   • `calmGate` reads NO feed at all — it compares pool spot against the pool's OWN TWAP.
 # So moving exactly one of them fails closed, in two different ways: pool-only reverts
 # `CalmGateBreached` until the TWAP catches up and then `BelowOracleFloor` because the oracle is
@@ -409,7 +412,7 @@ cmd_calm() {
     echo ">> PASS — calmGate is satisfied ($((cd - diff)) ticks of headroom); a rebalance can run."
   fi
   if (( spot < lo || spot > hi )); then
-    echo "position range      $lo / $hi  ->  spot is OUT OF RANGE (single-sided; rerange to re-centre)"
+    echo "position range      $lo / $hi  ->  spot is OUT OF RANGE (single-sided; rerange to reposition (width + skew))"
   else
     echo "position range      $lo / $hi  ->  spot is in range"
   fi

--- a/script/tenderly/compound-cycle.sh
+++ b/script/tenderly/compound-cycle.sh
@@ -78,10 +78,11 @@ NPM=0x827922686190790b37229fd06084350E74485b72
 # NB: keep in lockstep with LeveragedAerodromeCLStrategy.LayoutView — BOTH arity and field ORDER.
 # b9ea6ac appended `uint128 hedgedDebtA` + `uint128 hedgedDebtB` for the borrow-interest hedge; the
 # rerange-skew change appended `uint16 skewBps` AFTER `legBIsAsset` — i.e. field 47, NOT next to the
-# width band (`width`/`minWidth`/`maxWidth`, 43/44/45) where you would expect it — pushing the two
-# hedgedDebt fields to 48/49. A short or mis-ordered signature here makes `cast call` fail to decode
+# width band (`width`/`minWidth`/`maxWidth`, 43/44/45) where you would expect it — and the skew
+# GOVERNANCE BAND (`uint16 minSkewBps`, `uint16 maxSkewBps`) follows it at 48/49, pushing the two
+# hedgedDebt fields to 50/51. A short or mis-ordered signature here makes `cast call` fail to decode
 # and every `lay N` read comes back empty — if `lay` starts returning nothing, check this line FIRST.
-LAYOUT_SIG='layout()((address,address,address,address,address,address,address,address,address,address,address,uint256,uint256,uint16,uint32,address,address,address,address,int24,uint16,uint16,uint16,uint16,uint16,uint256,int24,int24,uint16,uint16,address,uint256,uint256,uint256,address,uint256,uint8,uint8,bool,bool,int24,int24,uint24,uint24,uint24,bool,uint16,uint128,uint128))'
+LAYOUT_SIG='layout()((address,address,address,address,address,address,address,address,address,address,address,uint256,uint256,uint16,uint32,address,address,address,address,int24,uint16,uint16,uint16,uint16,uint16,uint256,int24,int24,uint16,uint16,address,uint256,uint256,uint256,address,uint256,uint8,uint8,bool,bool,int24,int24,uint24,uint24,uint24,bool,uint16,uint16,uint16,uint128,uint128))'
 
 c() { cast call --rpc-url "$RPC" "$@" 2>/dev/null; }
 num() { echo "${1%% *}"; }

--- a/script/tenderly/run-leveraged-aero-stack.sh
+++ b/script/tenderly/run-leveraged-aero-stack.sh
@@ -64,7 +64,9 @@
 #   LEG_A/LEG_B, M_LEG_A/M_LEG_B, M_USDC, COMPTROLLER, NPM, GAUGE, SWAP_ROUTER
 #   LEG_A_FEED/LEG_B_FEED/USDC_FEED/AERO_FEED/SEQ_FEED
 #   TICK_SPACING, LEG_A_SWAP_TICK_SPACING, LEG_B_SWAP_TICK_SPACING, WETH_DELIVERS_NATIVE
-#   WIDTH/MIN_WIDTH/MAX_WIDTH, TARGET_LTV_BPS/MAX_LTV_BPS/MIN_HEALTH_BPS/MAX_SLIPPAGE_BPS
+#   WIDTH/MIN_WIDTH/MAX_WIDTH, SKEW_BPS (5000 = centered — the ops default; skew is meant to be
+#     applied per-cycle via `rerange`, not baked into genesis), TARGET_LTV_BPS/MAX_LTV_BPS/
+#     MIN_HEALTH_BPS/MAX_SLIPPAGE_BPS
 #   MAX_DELAY/GRACE_PERIOD/TWAP_WINDOW/CALM_DEVIATION_TICKS
 #   MGMT_FEE_BPS (100) / PERF_FEE_BPS (1000) / FEE_RECIPIENT (= MAMO_REBALANCER)
 #   VAULT_NAME / VAULT_SYMBOL
@@ -112,7 +114,8 @@ _CLI_VNET_RPC="${TENDERLY_VNET_RPC_URL:-}"
 # These are the subset THIS script also needs (the 5 feeds for B.0, the pool for the
 # log, USDC for the seed). LeveragedAeroStackHarness.s.sol carries identical defaults for
 # them plus the fields only it reads (legs, Moonwell markets, NPM, gauge, router, risk /
-# oracle / width / fee params) — keep the two default sets in lockstep.
+# oracle / width+skew / fee params) — keep the two default sets in lockstep. SKEW_BPS defaults
+# to 5000 (centered) on both sides.
 #
 # ── SHAPE: which pool family this fund LPs ────────────────────────────────────
 # `asset` (DEFAULT — the launch product): leg B IS the unit of account, i.e. a cbBTC/USDC
@@ -388,6 +391,8 @@ forge script "$FQ" --sig 'buildInitData()' -vvv > "$INITDATA_LOG" 2>&1 \
   || { grep -iE "error|revert|fail" "$INITDATA_LOG" | tail -20 | tee -a "$RESULTS"; die "buildInitData() failed"; }
 INITDATA="$(grep -oE 'HARNESS_INITDATA=0x[0-9a-fA-F]+' "$INITDATA_LOG" | head -1 | cut -d= -f2)"
 [ -n "$INITDATA" ] || die "could not parse HARNESS_INITDATA from $INITDATA_LOG"
+# "width band" matches BOTH harness lines: the min/width/max triple and the skewBps line, which
+# keeps that prefix deliberately so this one pattern covers the whole range config.
 grep -E "(pool +:|legA/legB:|feeRecip +:|mgmt/perf fee bps|width band)" "$INITDATA_LOG" | tee -a "$RESULTS"
 ok "initData = ${#INITDATA} hex chars"
 
@@ -400,7 +405,8 @@ section "Phase B.3 — vault.cloneAndBind(template, MAMO_REBALANCER, initData) [
 # A wrong venue value fails HERE, loudly: VenueMismatch (pool spacing / token set / Moonwell
 # underlying / a swap pool that does not exist at the configured spacing), UnsupportedLeg
 # (USDC or AERO as a leg), LegDecimalsOutOfRange, AssetMismatch, UnexpectedFeedDecimals,
-# WidthOutOfBounds, or one of the risk/oracle/fee bound errors.
+# OutOfBounds (width band OR skewBps — one error covers both), or one of the risk/oracle/fee
+# bound errors.
 csend_gas "$GAS_CLONE_AND_BIND" "cloneAndBind" "$MULTISIG" "$VAULT" \
   'cloneAndBind(address,address,bytes)' "$TEMPLATE" "$MAMO_REBALANCER" "$INITDATA"
 CLONE="$(ccall "$VAULT" 'strategy()(address)' | field)"

--- a/script/tenderly/run-leveraged-aero-stack.sh
+++ b/script/tenderly/run-leveraged-aero-stack.sh
@@ -65,8 +65,12 @@
 #   LEG_A_FEED/LEG_B_FEED/USDC_FEED/AERO_FEED/SEQ_FEED
 #   TICK_SPACING, LEG_A_SWAP_TICK_SPACING, LEG_B_SWAP_TICK_SPACING, WETH_DELIVERS_NATIVE
 #   WIDTH/MIN_WIDTH/MAX_WIDTH, SKEW_BPS (5000 = centered — the ops default; skew is meant to be
-#     applied per-cycle via `rerange`, not baked into genesis), TARGET_LTV_BPS/MAX_LTV_BPS/
-#     MIN_HEALTH_BPS/MAX_SLIPPAGE_BPS
+#     applied per-cycle via `rerange`, not baked into genesis),
+#   MIN_SKEW_BPS (1000) / MAX_SKEW_BPS (9000) — the INIT-IMMUTABLE governance band on skewBps, the
+#     skew analogue of MIN_WIDTH/MAX_WIDTH. Validated at init AND re-checked on every rerange, and a
+#     violation raises the SAME OutOfBounds() as a bad width — there is no new selector, so the
+#     expected-error list below needs no new entry. Immutable per clone: widening it means redeploying.
+#   TARGET_LTV_BPS/MAX_LTV_BPS/MIN_HEALTH_BPS/MAX_SLIPPAGE_BPS
 #   MAX_DELAY/GRACE_PERIOD/TWAP_WINDOW/CALM_DEVIATION_TICKS
 #   MGMT_FEE_BPS (100) / PERF_FEE_BPS (1000) / FEE_RECIPIENT (= MAMO_REBALANCER)
 #   VAULT_NAME / VAULT_SYMBOL
@@ -115,7 +119,10 @@ _CLI_VNET_RPC="${TENDERLY_VNET_RPC_URL:-}"
 # log, USDC for the seed). LeveragedAeroStackHarness.s.sol carries identical defaults for
 # them plus the fields only it reads (legs, Moonwell markets, NPM, gauge, router, risk /
 # oracle / width+skew / fee params) — keep the two default sets in lockstep. SKEW_BPS defaults
-# to 5000 (centered) on both sides.
+# to 5000 (centered) on both sides, and its governance band defaults to MIN_SKEW_BPS=1000 /
+# MAX_SKEW_BPS=9000 (init-immutable; re-checked on every rerange, same OutOfBounds()). Like WIDTH
+# and SKEW_BPS these are read straight from the process env by LeveragedAeroStackHarness.buildInitData()
+# — this script does not re-export them, so a caller override reaches the harness unchanged.
 #
 # ── SHAPE: which pool family this fund LPs ────────────────────────────────────
 # `asset` (DEFAULT — the launch product): leg B IS the unit of account, i.e. a cbBTC/USDC
@@ -391,8 +398,9 @@ forge script "$FQ" --sig 'buildInitData()' -vvv > "$INITDATA_LOG" 2>&1 \
   || { grep -iE "error|revert|fail" "$INITDATA_LOG" | tail -20 | tee -a "$RESULTS"; die "buildInitData() failed"; }
 INITDATA="$(grep -oE 'HARNESS_INITDATA=0x[0-9a-fA-F]+' "$INITDATA_LOG" | head -1 | cut -d= -f2)"
 [ -n "$INITDATA" ] || die "could not parse HARNESS_INITDATA from $INITDATA_LOG"
-# "width band" matches BOTH harness lines: the min/width/max triple and the skewBps line, which
-# keeps that prefix deliberately so this one pattern covers the whole range config.
+# "width band" matches EVERY harness range line: the min/width/max triple AND the min/skew/max skew
+# triple. Both keep that prefix deliberately so this one pattern covers the whole range config — if you
+# add another range knob, prefix its log line the same way rather than widening this grep.
 grep -E "(pool +:|legA/legB:|feeRecip +:|mgmt/perf fee bps|width band)" "$INITDATA_LOG" | tee -a "$RESULTS"
 ok "initData = ${#INITDATA} hex chars"
 
@@ -405,8 +413,8 @@ section "Phase B.3 — vault.cloneAndBind(template, MAMO_REBALANCER, initData) [
 # A wrong venue value fails HERE, loudly: VenueMismatch (pool spacing / token set / Moonwell
 # underlying / a swap pool that does not exist at the configured spacing), UnsupportedLeg
 # (USDC or AERO as a leg), LegDecimalsOutOfRange, AssetMismatch, UnexpectedFeedDecimals,
-# OutOfBounds (width band OR skewBps — one error covers both), or one of the risk/oracle/fee
-# bound errors.
+# OutOfBounds (width band OR skewBps OR the [MIN_SKEW_BPS, MAX_SKEW_BPS] band — one error covers
+# every range knob), or one of the risk/oracle/fee bound errors.
 csend_gas "$GAS_CLONE_AND_BIND" "cloneAndBind" "$MULTISIG" "$VAULT" \
   'cloneAndBind(address,address,bytes)' "$TEMPLATE" "$MAMO_REBALANCER" "$INITDATA"
 CLONE="$(ccall "$VAULT" 'strategy()(address)' | field)"

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -1081,25 +1081,23 @@ library LeveragedAeroManager {
             (uint256 exp0, uint256 exp1) =
                 LiquidityAmounts.getAmountsForLiquidity(sqrtP, sqrtLower, sqrtUpper, liqToRemove);
             uint256 slip = uint256($.maxSlippageBps);
-            INonfungiblePositionManager(npm_)
-                .decreaseLiquidity(
-                    INonfungiblePositionManager.DecreaseLiquidityParams({
+            INonfungiblePositionManager(npm_).decreaseLiquidity(
+                INonfungiblePositionManager.DecreaseLiquidityParams({
                     tokenId: tokenId_,
                     liquidity: liqToRemove,
                     amount0Min: exp0 * (10000 - slip) / 10000,
                     amount1Min: exp1 * (10000 - slip) / 10000,
                     deadline: block.timestamp + 600
                 })
-                );
-            INonfungiblePositionManager(npm_)
-                .collect(
-                    INonfungiblePositionManager.CollectParams({
+            );
+            INonfungiblePositionManager(npm_).collect(
+                INonfungiblePositionManager.CollectParams({
                     tokenId: tokenId_,
                     recipient: address(this),
                     amount0Max: type(uint128).max,
                     amount1Max: type(uint128).max
                 })
-                );
+            );
         }
 
         // Re-stake only when remaining liquidity is non-zero.
@@ -1284,9 +1282,8 @@ library LeveragedAeroManager {
         (address tok0, address tok1) = _tokens01();
         IERC20(tok0).forceApprove(npm_, amt0);
         IERC20(tok1).forceApprove(npm_, amt1);
-        (uint128 liq,,) = INonfungiblePositionManager(npm_)
-            .increaseLiquidity(
-                INonfungiblePositionManager.IncreaseLiquidityParams({
+        (uint128 liq,,) = INonfungiblePositionManager(npm_).increaseLiquidity(
+            INonfungiblePositionManager.IncreaseLiquidityParams({
                 tokenId: tokenId_,
                 amount0Desired: amt0,
                 amount1Desired: amt1,
@@ -1294,7 +1291,7 @@ library LeveragedAeroManager {
                 amount1Min: amt1Min,
                 deadline: block.timestamp + 600
             })
-            );
+        );
         if (uint256(liq) < minLiquidity) revert InsufficientLiquidity();
     }
 

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -261,6 +261,12 @@ library LeveragedAeroManager {
 
     /// @notice Full proportional unwind to the strategy (body of the strategy's `_settle`). The
     ///         strategy forwards the realized USDC to the vault afterward.
+    /// @dev Sweeps the two LEG tokens ONLY. The `gauge.withdraw` inside `_unwindLiquidity` auto-claims
+    ///      a final reward tranche, and selling THAT is the caller's job — deliberately, because the
+    ///      two callers need opposite failure modes on the same sale: `LeveragedAeroVenue.flattenImpl`
+    ///      sells it fail-closed under the proposer's floor (it is resumable), while the strategy's
+    ///      terminal `_settle` sells it best-effort through a self-`try/catch` (it must not be
+    ///      blockable). Doing it here would collapse the two and silently drop `flatten`'s floor.
     /// @return realizedUsdc USDC held by the strategy after the unwind.
     function settleImpl() public returns (uint256 realizedUsdc) {
         Layout storage $ = _layout();

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -163,11 +163,15 @@ library LeveragedAeroManager {
         int24 cbBTCSwapTickSpacing; // leg B↔USDC swap-pool tickSpacing (NOT the LP pool's)
         int24 wethSwapTickSpacing; // leg A↔USDC swap-pool tickSpacing (NOT the LP pool's)
         // ── appended for the per-cycle rerange width band (keep byte-identical) ──
-        uint24 width; // current full range width in ticks (rerange spans width/2 each side)
+        uint24 width; // current full range width in ticks (split across the tick by `skewBps`)
         uint24 minWidth; // lower bound for a proposer-supplied rerange width
         uint24 maxWidth; // upper bound for a proposer-supplied rerange width
         // ── appended for the config-emergent pool shape (keep byte-identical) ──
         bool legBIsAsset; // DERIVED at init: leg-B slot == usdc → asset-as-a-leg shape (packs above)
+        // ── appended for the rerange SKEW (keep byte-identical). Placed HERE, not after the hedged
+        //    principals, so it free-packs into the existing tail slot (20 bytes used → 22) and
+        //    `hedgedDebtA`/`hedgedDebtB` keep a byte-identical slot AND offset. ──
+        uint16 skewBps; // fraction of `width` placed BELOW the pool tick (1e4 scale; 5000 == centred)
         // ── LAST fields: appended for the borrow-interest hedge (keep byte-identical) ──
         uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with the widths above)
         uint128 hedgedDebtB; // leg-B borrowed principal the LP hedges (0 in asset-mode: leg B never borrows)
@@ -216,7 +220,8 @@ library LeveragedAeroManager {
         markets[0] = $.mUsdc;
         IComptroller($.comptroller).enterMarkets(markets);
         LeveragedAeroValuation.calmGate($.pool, $.twapWindow, $.calmDeviationTicks);
-        (int24 tickLower, int24 tickUpper) = LeveragedAeroValuation.centeredTickRange($.pool, $.tickSpacing, $.width);
+        (int24 tickLower, int24 tickUpper) =
+            LeveragedAeroValuation.skewedTickRange($.pool, $.tickSpacing, $.width, $.skewBps);
         (uint256 cbBTCAmt, uint256 wethAmt) = _supplyAndBorrow(usdcAmt, tickLower, tickUpper);
         _wrapNativeEth();
         _mintAndStake(cbBTCAmt, wethAmt, tickLower, tickUpper);
@@ -526,7 +531,7 @@ library LeveragedAeroManager {
         return LeveragedAeroValuation.hedgeBorrowInterest(b);
     }
 
-    /// @notice Recenter the CL position on the current tick WITHOUT swapping (body of the strategy's
+    /// @notice Re-range the CL position around the current tick WITHOUT swapping (body of the strategy's
     ///         `rerange`): calm-gate → remove 100% liquidity + collect → new tickSpacing-aligned range
     ///         → re-add the collected legs → restake → assert health. Debt + collateral untouched.
     ///
@@ -534,18 +539,17 @@ library LeveragedAeroManager {
     ///         remainder of ONE borrowed leg is left idle (NAV-counted, stays redeployable). A new
     ///         tokenId is minted (Slipstream ticks are immutable); the old empty NFT is harmless dust.
     ///         No-op on a flat book.
-    /// @param width_  Full range width in ticks for this cycle (validated against the stored band by
-    ///                the strategy entrypoint, then persisted here as the new `width`).
+    /// @dev TAKES NO RANGE PARAMS. The proposer's `width` / `skewBps` for this cycle were validated AND
+    ///      PERSISTED by the strategy entrypoint before this delegatecall (see the ordering note on
+    ///      `LeveragedAerodromeCLStrategy.rerange`), so this reads both straight out of storage. The
+    ///      persists deliberately sit ahead of the flat-book bail-out below, so a re-range on a flat book
+    ///      still takes effect for the next `deployIdle` / `compound` mint — the property is unchanged,
+    ///      only the frame the two `sstore`s live in moved, for EIP-170 headroom.
     /// @param minLiq0 Minimum token0 the re-add must consume (two-sided slippage guard).
     /// @param minLiq1 Minimum token1 the re-add must consume (two-sided slippage guard).
-    function rerangeImpl(uint24 width_, uint256 minLiq0, uint256 minLiq1) public {
+    function rerangeImpl(uint256 minLiq0, uint256 minLiq1) public {
         Layout storage $ = _layout();
-        // Persist the (already band-validated) width BEFORE the flat-book bail-out. `deployIdle` /
-        // `compound` mint at the STORED width, so a rerange on a flat book must still take effect —
-        // otherwise the proposer's width choice is silently dropped and the next redeploy reopens at
-        // the stale one.
-        $.width = width_;
-        if ($.tokenId == 0) return; // flat book — nothing to recenter (width above already stored)
+        if ($.tokenId == 0) return; // flat book — nothing to re-range (width/skew already stored)
 
         // 1. Calm-gate BEFORE touching the pool — never recenter at a manipulated tick.
         LeveragedAeroValuation.calmGate($.pool, $.twapWindow, $.calmDeviationTicks);
@@ -554,9 +558,10 @@ library LeveragedAeroManager {
         //    left empty + unstaked; a recenter needs a fresh range == fresh tokenId.
         _unwindLiquidity(1, 1);
 
-        // 3. Derive the tickSpacing-aligned range centered on the current (calm) tick from the width
-        //    stored above. Every later mint (deployIdle / compound) reuses that stored width.
-        (int24 tickLower, int24 tickUpper) = LeveragedAeroValuation.centeredTickRange($.pool, $.tickSpacing, $.width);
+        // 3. Derive the tickSpacing-aligned range around the current (calm) tick from the width/skew
+        //    the entrypoint stored. Every later mint (deployIdle / compound) reuses that same pair.
+        (int24 tickLower, int24 tickUpper) =
+            LeveragedAeroValuation.skewedTickRange($.pool, $.tickSpacing, $.width, $.skewBps);
 
         // 4. Re-add the collected legs (full balances as desired) into the new range. No swap →
         //    principal conserved. `_mintPosition` enforces the two-sided `maxSlippageBps` mins
@@ -600,8 +605,8 @@ library LeveragedAeroManager {
     /// @param minLiq        Minimum CL liquidity on a lever-UP add (slippage guard).
     /// @param minOut        Minimum USDC out of a lever-DOWN residual swap (slippage guard).
     function adjustLeverageImpl(uint16 targetLtvBps_, uint256 minLiq, uint256 minOut) public {
-        // Persist the (already max-validated) target BEFORE the venue ops, exactly as `rerangeImpl`
-        // persists `width`. Three reasons this ordering is the right one:
+        // Persist the (already max-validated) target BEFORE the venue ops, exactly as `rerange`
+        // persists `width` / `skewBps`. Three reasons this ordering is the right one:
         //
         //   1. SAFETY IS UNAFFECTED. The strategy entrypoint already rejected `targetLtvBps_ >
         //      maxLtvBps`, and this is the ONLY caller — so no out-of-band value can reach this write.
@@ -623,9 +628,11 @@ library LeveragedAeroManager {
         //      headroom: that frame already loads `_layout()` for the `maxLtvBps` check, so the write
         //      costs ~20 bytes there versus ~71 in this library, and this library is at the cap.
         //      Semantics are identical — same transaction, same all-or-nothing revert, and still ahead
-        //      of the no-op branch below. (`rerangeImpl` persists `width` in-library because the
-        //      manager had room when it was written; if this file is ever refactored for space, that
-        //      write is the same candidate for relocation.)
+        //      of the no-op branch below. (`rerangeImpl` used to persist `width` in-library, back when
+        //      the manager had room; the rerange-skew work made it the earmarked relocation candidate
+        //      and took it — `rerange` now writes BOTH `width` and `skewBps` in the strategy frame,
+        //      still ahead of the impl's own flat-book bail-out, and `rerangeImpl` takes no range
+        //      params at all.)
         (uint256 collateralUsdc, uint256 debtUsdc) = _readCollateralDebt();
         uint256 targetDebt = (uint256(targetLtvBps_) * collateralUsdc) / 10000;
         if (targetDebt > debtUsdc) {
@@ -1074,23 +1081,25 @@ library LeveragedAeroManager {
             (uint256 exp0, uint256 exp1) =
                 LiquidityAmounts.getAmountsForLiquidity(sqrtP, sqrtLower, sqrtUpper, liqToRemove);
             uint256 slip = uint256($.maxSlippageBps);
-            INonfungiblePositionManager(npm_).decreaseLiquidity(
-                INonfungiblePositionManager.DecreaseLiquidityParams({
+            INonfungiblePositionManager(npm_)
+                .decreaseLiquidity(
+                    INonfungiblePositionManager.DecreaseLiquidityParams({
                     tokenId: tokenId_,
                     liquidity: liqToRemove,
                     amount0Min: exp0 * (10000 - slip) / 10000,
                     amount1Min: exp1 * (10000 - slip) / 10000,
                     deadline: block.timestamp + 600
                 })
-            );
-            INonfungiblePositionManager(npm_).collect(
-                INonfungiblePositionManager.CollectParams({
+                );
+            INonfungiblePositionManager(npm_)
+                .collect(
+                    INonfungiblePositionManager.CollectParams({
                     tokenId: tokenId_,
                     recipient: address(this),
                     amount0Max: type(uint128).max,
                     amount1Max: type(uint128).max
                 })
-            );
+                );
         }
 
         // Re-stake only when remaining liquidity is non-zero.
@@ -1275,8 +1284,9 @@ library LeveragedAeroManager {
         (address tok0, address tok1) = _tokens01();
         IERC20(tok0).forceApprove(npm_, amt0);
         IERC20(tok1).forceApprove(npm_, amt1);
-        (uint128 liq,,) = INonfungiblePositionManager(npm_).increaseLiquidity(
-            INonfungiblePositionManager.IncreaseLiquidityParams({
+        (uint128 liq,,) = INonfungiblePositionManager(npm_)
+            .increaseLiquidity(
+                INonfungiblePositionManager.IncreaseLiquidityParams({
                 tokenId: tokenId_,
                 amount0Desired: amt0,
                 amount1Desired: amt1,
@@ -1284,7 +1294,7 @@ library LeveragedAeroManager {
                 amount1Min: amt1Min,
                 deadline: block.timestamp + 600
             })
-        );
+            );
         if (uint256(liq) < minLiquidity) revert InsufficientLiquidity();
     }
 

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -168,10 +168,13 @@ library LeveragedAeroManager {
         uint24 maxWidth; // upper bound for a proposer-supplied rerange width
         // ── appended for the config-emergent pool shape (keep byte-identical) ──
         bool legBIsAsset; // DERIVED at init: leg-B slot == usdc → asset-as-a-leg shape (packs above)
-        // ── appended for the rerange SKEW (keep byte-identical). Placed HERE, not after the hedged
-        //    principals, so it free-packs into the existing tail slot (20 bytes used → 22) and
-        //    `hedgedDebtA`/`hedgedDebtB` keep a byte-identical slot AND offset. ──
+        // ── appended for the rerange SKEW and its governance band (keep byte-identical). Placed HERE,
+        //    not after the hedged principals, so all three free-pack into the existing tail slot
+        //    (20 bytes used → 26) and `hedgedDebtA`/`hedgedDebtB` keep a byte-identical slot AND offset:
+        //    26 + 16 > 32, so `hedgedDebtA` still starts the NEXT slot at offset 0. ──
         uint16 skewBps; // fraction of `width` placed BELOW the pool tick (1e4 scale; 5000 == centred)
+        uint16 minSkewBps; // lower bound for a proposer-supplied rerange skew
+        uint16 maxSkewBps; // upper bound for a proposer-supplied rerange skew
         // ── LAST fields: appended for the borrow-interest hedge (keep byte-identical) ──
         uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with the widths above)
         uint128 hedgedDebtB; // leg-B borrowed principal the LP hedges (0 in asset-mode: leg B never borrows)
@@ -212,6 +215,21 @@ library LeveragedAeroManager {
     ///      library already at the EIP-170 margin, for no behavioural change. Asset-mode is the case that
     ///      LOOKS worst — `assetModeSplit` reads the live `sqrtP` for its sizing before any gate — but
     ///      the mint that consumes that sizing is gated, so a shoved tick still unwinds the whole op.
+    ///
+    ///      THE PATHS THAT REACH NO CALM GATE AT ALL — `_leverDown` (`adjustLeverage` down and the
+    ///      permissionless `deleverage`), `settleImpl` and `redeemUnwindImpl` — are omitted from the list
+    ///      above because they never mint. That is deliberate, not an oversight, and it is safe for three
+    ///      independent reasons. (1) CONCAVITY: they BURN liquidity. A CL bundle removed at a shoved
+    ///      price is worth strictly MORE at the true price than one removed at it, so shoving the pool
+    ///      hands the protocol the better side of the trade — a gate would only let an attacker DENY an
+    ///      exit, which is the wrong failure mode for a redeem valve. (2) THE UNWIND MINS CANNOT BIND:
+    ///      they are derived from the SAME `slot0` the `decreaseLiquidity` executes at (see
+    ///      `_unwindLiquidity`), so the comparison is a strict identity — gating would change nothing
+    ///      about what those mins admit. (3) THE ENTRY HEALTH GATE IS ORACLE-PRICED: `_assertHealthy` and
+    ///      `_readCollateralDebt` read Chainlink-priced Moonwell state, which a pool shove cannot move,
+    ///      so `deleverage`'s "am I unhealthy" trigger is not shove-able either. The residual swaps on
+    ///      those paths are bounded instead by oracle floors/ceilings (`_rebalanceCover`) or by the
+    ///      redeemer's own budget — a slippage bound, not a tick bound.
     function executeImpl() public {
         Layout storage $ = _layout();
         uint256 usdcAmt = IERC20($.usdc).balanceOf(address(this));
@@ -246,17 +264,8 @@ library LeveragedAeroManager {
         // 5. Sweep residual WETH + cbBTC → USDC (Chainlink-bounded min-out)
         {
             (uint256 pBTC, uint256 pETH, uint256 pUsdc) = _readAllPrices();
-            uint256 slip = uint256($.maxSlippageBps);
-            _swapTokenToUsdc(
-                $.weth,
-                _tokenToUsdc(IERC20($.weth).balanceOf(address(this)), $.wethDecimals, pETH, pUsdc) * (10000 - slip)
-                    / 10000
-            );
-            _swapTokenToUsdc(
-                $.cbBTC,
-                _tokenToUsdc(IERC20($.cbBTC).balanceOf(address(this)), $.cbBTCDecimals, pBTC, pUsdc) * (10000 - slip)
-                    / 10000
-            );
+            _sweepAtOracleFloor($.weth, $.wethDecimals, pETH, pUsdc);
+            _sweepAtOracleFloor($.cbBTC, $.cbBTCDecimals, pBTC, pUsdc);
         }
         // 6. Clear position state (flat-book invariant: nav() reads tokenId==0 branch)
         $.tokenId = 0;
@@ -539,12 +548,13 @@ library LeveragedAeroManager {
     ///         remainder of ONE borrowed leg is left idle (NAV-counted, stays redeployable). A new
     ///         tokenId is minted (Slipstream ticks are immutable); the old empty NFT is harmless dust.
     ///         No-op on a flat book.
-    /// @dev TAKES NO RANGE PARAMS. The proposer's `width` / `skewBps` for this cycle were validated AND
-    ///      PERSISTED by the strategy entrypoint before this delegatecall (see the ordering note on
-    ///      `LeveragedAerodromeCLStrategy.rerange`), so this reads both straight out of storage. The
-    ///      persists deliberately sit ahead of the flat-book bail-out below, so a re-range on a flat book
-    ///      still takes effect for the next `deployIdle` / `compound` mint — the property is unchanged,
-    ///      only the frame the two `sstore`s live in moved, for EIP-170 headroom.
+    /// @dev TAKES NO RANGE PARAMS — which is exactly WHY the persist must precede this delegatecall. The
+    ///      proposer's `width` / `skewBps` for this cycle were validated AND PERSISTED by the strategy
+    ///      entrypoint (see the ordering note on `LeveragedAerodromeCLStrategy.rerange`), and step 3
+    ///      below reads both straight out of storage: write after, and the re-range would land at the OLD
+    ///      pair. The frame the two `sstore`s live in is a bytecode relocation for EIP-170 headroom, not a
+    ///      semantic choice. The persists also sit ahead of the flat-book bail-out below — see the
+    ///      entrypoint's note for what that does and does NOT buy on a terminal (fully-redeemed) book.
     /// @param minLiq0 Minimum token0 the re-add must consume (two-sided slippage guard).
     /// @param minLiq1 Minimum token1 the re-add must consume (two-sided slippage guard).
     function rerangeImpl(uint256 minLiq0, uint256 minLiq1) public {
@@ -556,6 +566,15 @@ library LeveragedAeroManager {
 
         // 2. Unstake + remove 100% liquidity + collect (num==den → no restake). The old NFT is
         //    left empty + unstaked; a recenter needs a fresh range == fresh tokenId.
+        //
+        //    ASSET-MODE: snapshot leg B BEFORE the unwind, exactly as `redeemUnwindImpl` snapshots
+        //    `idleUsdcBefore` and for the same reason (see its comment). Leg B IS the unit of account
+        //    there, so its raw balance is idle deposits + the redeem cover budget — NOT what this op
+        //    collected. Only the DELTA is this re-range's own principal; folding the rest in would let a
+        //    re-range silently draw unlevered idle USDC into the LP, a capability no entrypoint declares
+        //    (`deployIdle` is THE path that adds idle, and it levers it). Zero in the two-borrowed-legs
+        //    shape, where the leg-B balance is a genuine rerange remainder and redeploying it IS intended.
+        uint256 legBBefore = $.legBIsAsset ? IERC20($.cbBTC).balanceOf(address(this)) : 0;
         _unwindLiquidity(1, 1);
 
         // 3. Derive the tickSpacing-aligned range around the current (calm) tick from the width/skew
@@ -563,13 +582,14 @@ library LeveragedAeroManager {
         (int24 tickLower, int24 tickUpper) =
             LeveragedAeroValuation.skewedTickRange($.pool, $.tickSpacing, $.width, $.skewBps);
 
-        // 4. Re-add the collected legs (full balances as desired) into the new range. No swap →
-        //    principal conserved. `_mintPosition` enforces the two-sided `maxSlippageBps` mins
+        // 4. Re-add the legs THIS op collected into the new range — the full leg-A balance, and leg B
+        //    net of the pre-unwind snapshot (0 outside asset-mode, so this is the full balance there).
+        //    No swap → principal conserved. `_mintPosition` enforces the two-sided `maxSlippageBps` mins
         //    (the §8 always-on floor) and approves the NPM; the caller's `minLiq0/minLiq1` add an
         //    explicit two-sided guard on the consumed amounts (proposer-tightenable, like
         //    compound's `minUsdcOut`).
         (uint256 amt0, uint256 amt1) =
-            _amounts01(IERC20($.cbBTC).balanceOf(address(this)), IERC20($.weth).balanceOf(address(this)));
+            _amounts01(IERC20($.cbBTC).balanceOf(address(this)) - legBBefore, IERC20($.weth).balanceOf(address(this)));
         (uint256 newTokenId, uint256 used0, uint256 used1) = _mintPosition(amt0, amt1, tickLower, tickUpper);
         if (used0 < minLiq0 || used1 < minLiq1) revert InsufficientLiquidity();
 
@@ -763,16 +783,32 @@ library LeveragedAeroManager {
         }
     }
 
-    /// @dev Cover an IL-driven debt shortfall on `deficitTok` by selling the over-collected
-    ///      `surplusTok` → USDC, then buying exactly the deficit from that USDC and repaying it.
-    ///      Any leftover USDC stays idle (NAV-counted; recoverable via `deployIdle`/`redeem`).
+    /// @dev Cover an IL-driven debt shortfall on `deficitTok` by selling ONLY AS MUCH of the over-collected
+    ///      `surplusTok` as that cover needs → USDC, then buying exactly the deficit from that USDC and
+    ///      repaying it. Any leftover USDC stays idle (NAV-counted; recoverable via `deployIdle`/`redeem`).
+    ///
+    ///      **NEED-SIZED, NOT WHOLESALE** — the sell keeps `surplusBal − needed`. The surplus-leg BALANCE
+    ///      is not the same thing as this op's surplus: it can also hold a PRE-EXISTING idle remainder (a
+    ///      skewed-`rerange` leftover is the ordinary source) which is still matched 1:1 by that leg's
+    ///      Moonwell debt and is therefore delta-NEUTRAL where it sits. Selling it would convert a hedged
+    ///      holding into an unrecorded SHORT that no monitor surfaces: `hedgeBorrowInterest` measures
+    ///      interest drift (`debt − hedgedDebt`) only, and `_repay`'s clamp re-anchors `hedgedDebt` to the
+    ///      post-repay debt, so the missing leg leaves no trace in either. Same reasoning as the stayer
+    ///      snapshots `redeemUnwindImpl` documents — a balance is not evidence of entitlement to it.
+    ///      `needed` is the ORACLE conversion of `shortAmt` into surplus-leg units, grossed up by
+    ///      `maxSlippageBps` on BOTH conversions (the buy ceiling and the sell floor) so a fill landing on
+    ///      the floor still raises the ceiling-priced buy; short of that the exact-output cover would
+    ///      revert on `amountInMax` rather than silently under-repay.
     ///
     ///      **Oracle-floor guard** — the minimum USDC out of the surplus-leg sell is enforced as
     ///      `max(callerMinUsdcOut, oracleFloor)` where
-    ///      `oracleFloor = _tokenToUsdc(surplusBal) × (1 − maxSlippageBps)`.
+    ///      `oracleFloor = _tokenToUsdc(amount ACTUALLY sold) × (1 − maxSlippageBps)`.
     ///      This prevents a griefer from passing `minOut=0` to the permissionless `deleverage()`
     ///      and sandwiching the IL-residual swap.  If a Chainlink feed is stale the read reverts —
-    ///      fail-safe and consistent with `_assertHealthy`.
+    ///      fail-safe and consistent with `_assertHealthy`. The floor tracks the SOLD amount, not the
+    ///      balance: derived off the balance it would be unreachable whenever `keep > 0` and would brick
+    ///      every need-sized sell. A caller `minUsdcOut` sized for the whole balance can still bind — it
+    ///      is a per-call proposer guard, so size it against the shortfall, not the wallet.
     ///
     ///      **Redeem path unaffected** — redeem calls `_sweepLegToUsdc` directly with a
     ///      stayers' `keep > 0`; it never routes through `_rebalanceCover`.
@@ -784,26 +820,27 @@ library LeveragedAeroManager {
         uint256 minUsdcOut
     ) private {
         Layout storage $ = _layout();
-        uint256 pUsdc = _readUsd8($.usdcFeed); // hoisted: floors the surplus sell AND ceils the deficit buy
-        uint256 surplusBal = IERC20(surplusTok).balanceOf(address(this));
-        // ASSET-MODE: when the surplus leg IS the unit of account there is nothing to sell — the sweep
-        // below no-ops, so deriving an oracle floor for it would be dead arithmetic. Skip straight to
-        // the deficit buy, which spends that surplus USDC directly (bounded by the oracle ceiling).
-        if (surplusBal > 0 && surplusTok != $.usdc) {
-            bool isCbBTC = surplusTok == $.cbBTC;
-            uint8 dec = isCbBTC ? $.cbBTCDecimals : $.wethDecimals;
-            uint256 pSurplus = _readUsd8(isCbBTC ? $.cbBTCFeed : $.wethFeed);
-            uint256 oracleFloor =
-                _tokenToUsdc(surplusBal, dec, pSurplus, pUsdc) * (10000 - uint256($.maxSlippageBps)) / 10000;
-            if (oracleFloor > minUsdcOut) minUsdcOut = oracleFloor;
-        }
-        _sweepLegToUsdc(surplusTok, 0, minUsdcOut);
-        // Oracle-ceiling the deficit BUY (H1): a sandwiched/manipulated permissionless `deleverage`
-        // can't overpay past the oracle+slippage bound. The redeem path passes max (oracle-free).
         bool deficitIsCb = deficitTok == $.cbBTC;
-        uint256 pDeficit = _readUsd8(deficitIsCb ? $.cbBTCFeed : $.wethFeed);
-        uint256 buyMax = _tokenToUsdc(shortAmt, deficitIsCb ? $.cbBTCDecimals : $.wethDecimals, pDeficit, pUsdc)
-            * (10000 + uint256($.maxSlippageBps)) / 10000;
+        bool surplusIsCb = surplusTok == $.cbBTC;
+        // ASSET-MODE: when the surplus leg IS the unit of account there is nothing to sell — the sweep
+        // below no-ops, so pricing it would be dead arithmetic (and one more feed that could revert).
+        // A zero balance short-circuits `coverBounds` to the deficit buy alone, which spends that
+        // surplus USDC directly (bounded by the oracle ceiling).
+        uint256 surplusBal = surplusTok == $.usdc ? 0 : IERC20(surplusTok).balanceOf(address(this));
+        // The three oracle bounds (need-sized sell amount, its floor, the buy ceiling) are derived in
+        // `LeveragedAeroValuation.coverBounds` — this library is at the EIP-170 cap.
+        (uint256 buyMax, uint256 sellAmt, uint256 sellFloor) = LeveragedAeroValuation.coverBounds(
+            shortAmt,
+            deficitIsCb ? $.cbBTCDecimals : $.wethDecimals,
+            _readUsd8(deficitIsCb ? $.cbBTCFeed : $.wethFeed),
+            surplusBal,
+            surplusIsCb ? $.cbBTCDecimals : $.wethDecimals,
+            surplusBal == 0 ? 0 : _readUsd8(surplusIsCb ? $.cbBTCFeed : $.wethFeed),
+            _readUsd8($.usdcFeed),
+            uint256($.maxSlippageBps)
+        );
+        if (sellFloor > minUsdcOut) minUsdcOut = sellFloor;
+        _sweepLegToUsdc(surplusTok, surplusBal - sellAmt, minUsdcOut);
         _redeemCoverShortfall(deficitTok, deficitMkt, shortAmt, buyMax);
     }
 
@@ -1199,9 +1236,14 @@ library LeveragedAeroManager {
         );
     }
 
-    /// @dev Sweep the full balance of `tokenIn` to USDC via exactInputSingle (minOut may be 0).
-    function _swapTokenToUsdc(address tokenIn, uint256 minOut) private {
-        _sweepLegToUsdc(tokenIn, 0, minOut);
+    /// @dev Sweep the WHOLE `tokenIn` balance → USDC at a Chainlink-derived floor
+    ///      (`oracle value × (1 − maxSlippageBps)`). One definition for both settle legs; the asset-mode
+    ///      identity is handled downstream (`_sweepLegToUsdc` early-returns on the unit of account, where
+    ///      the floor is dead arithmetic anyway).
+    function _sweepAtOracleFloor(address tokenIn, uint8 dec, uint256 price, uint256 pUsdc) private {
+        uint256 floor = _tokenToUsdc(IERC20(tokenIn).balanceOf(address(this)), dec, price, pUsdc)
+            * (10000 - uint256(_layout().maxSlippageBps)) / 10000;
+        _sweepLegToUsdc(tokenIn, 0, floor);
     }
 
     /// @dev Sweep (balance − `keep`) of `tokenIn` → USDC via exactInputSingle. `keep` reserves a

--- a/src/leveraged-aero/LeveragedAeroValuation.sol
+++ b/src/leveraged-aero/LeveragedAeroValuation.sol
@@ -496,9 +496,8 @@ library LeveragedAeroValuation {
         uint256 minOut
     ) public {
         IERC20(tokenIn).forceApprove(router, amountIn);
-        ICLSwapRouter(router)
-            .exactInputSingle(
-                ICLSwapRouter.ExactInputSingleParams({
+        ICLSwapRouter(router).exactInputSingle(
+            ICLSwapRouter.ExactInputSingleParams({
                 tokenIn: tokenIn,
                 tokenOut: tokenOut,
                 tickSpacing: tickSpacing,
@@ -508,7 +507,7 @@ library LeveragedAeroValuation {
                 amountOutMinimum: minOut,
                 sqrtPriceLimitX96: 0
             })
-            );
+        );
     }
 
     /// @notice Slipstream `exactOutputSingle` (approve, swap, then RESET the approval to 0).
@@ -533,9 +532,8 @@ library LeveragedAeroValuation {
         uint256 amountInMax
     ) public {
         IERC20(tokenIn).forceApprove(router, amountInMax);
-        ICLSwapRouter(router)
-            .exactOutputSingle(
-                ICLSwapRouter.ExactOutputSingleParams({
+        ICLSwapRouter(router).exactOutputSingle(
+            ICLSwapRouter.ExactOutputSingleParams({
                 tokenIn: tokenIn,
                 tokenOut: tokenOut,
                 tickSpacing: tickSpacing,
@@ -545,7 +543,7 @@ library LeveragedAeroValuation {
                 amountInMaximum: amountInMax,
                 sqrtPriceLimitX96: 0
             })
-            );
+        );
         IERC20(tokenIn).forceApprove(router, 0);
     }
 
@@ -580,8 +578,9 @@ library LeveragedAeroValuation {
         IERC20(aero).forceApprove(AERO_V2_ROUTER, amountIn);
         IAeroRouter.Route[] memory routes = new IAeroRouter.Route[](1);
         routes[0] = IAeroRouter.Route({from: aero, to: usdc, stable: false, factory: AERO_V2_FACTORY});
-        IAeroRouter(AERO_V2_ROUTER)
-            .swapExactTokensForTokens(amountIn, minOut, routes, address(this), block.timestamp + 600);
+        IAeroRouter(AERO_V2_ROUTER).swapExactTokensForTokens(
+            amountIn, minOut, routes, address(this), block.timestamp + 600
+        );
         usdcOut = IERC20(usdc).balanceOf(address(this)) - usdcBefore;
     }
 

--- a/src/leveraged-aero/LeveragedAeroValuation.sol
+++ b/src/leveraged-aero/LeveragedAeroValuation.sol
@@ -242,37 +242,48 @@ library LeveragedAeroValuation {
     // Range geometry + ASSET-MODE deploy sizing
     // ---------------------------------------------------------------------------
 
-    /// @notice The tickSpacing-aligned range centred on `pool`'s current tick, spanning `width/2` ticks
-    ///         each side. Lives here (rather than in `LeveragedAeroManager`, which is at the EIP-170
-    ///         margin) alongside `assetModeSplit`, the sizing math that consumes it.
+    /// @notice The tickSpacing-aligned range around `pool`'s current tick, SKEWED by `skewBps`: that
+    ///         fraction of `width` (1e4 scale) is placed BELOW the current tick and the exact complement
+    ///         above. `skewBps == 5000` is the centred range (and reproduces the old `centeredTickRange`
+    ///         bit-for-bit whenever `width` is even); `3500` puts 35% of the width below spot and 65%
+    ///         above. Lives here (rather than in `LeveragedAeroManager`, which is at the EIP-170 margin)
+    ///         alongside `assetModeSplit`, the sizing math that consumes it.
     ///
-    /// @dev "Centred" is grid-approximate, not exact. Both bounds round DOWN onto the grid, so the
-    ///      realised centre can sit up to one `tickSpacing` below the current tick and the realised
-    ///      width can differ from `width` by up to one spacing; when `width / tickSpacing` is ODD the
-    ///      half-span is itself off-grid, which is where the skew is largest. Accepted: the band is
-    ///      orders of magnitude wider than one spacing, and re-centring exactly would need an align-up
-    ///      on one side, silently widening the range past the band validated at init.
+    /// @dev The two spans are EXACT COMPLEMENTS — `upperSpan = width − lowerSpan` — so the nominal range
+    ///      is always exactly `width` ticks wide before alignment, with no double rounding.
+    ///
+    ///      Placement is grid-approximate, not exact. Both bounds round DOWN onto the grid, so the
+    ///      realised split can sit up to one `tickSpacing` below the requested one and the realised
+    ///      width can differ from `width` by up to one spacing; when a span is not itself a multiple of
+    ///      the spacing that is where the drift is largest. Accepted: the band is orders of magnitude
+    ///      wider than one spacing, and placing exactly would need an align-up on one side, silently
+    ///      widening the range past the band validated at init.
     ///
     ///      Both bounds are clamped into the aligned tick domain: `width` is capped at `2 × MAX_TICK` at
-    ///      init so the arithmetic cannot wrap int24, but a wide band near either end of the domain
-    ///      still pushes a bound past ±MAX_TICK, where `getSqrtRatioAtTick` would revert unhelpfully
-    ///      deep inside TickMath. `maxAligned` sits ON the spacing grid by construction, so clamping
-    ///      keeps the range mintable rather than merely non-panicking.
+    ///      init, so with the whole width now landing on ONE side in the limit the arithmetic is
+    ///      `currentTick ± width` (not `± width/2`) — worst case `|tc| + width <= MAX_TICK + 2 ×
+    ///      MAX_TICK ≈ 2.66e6`, still far inside int24's ±8.39e6, so it cannot wrap. A wide band near
+    ///      either end of the domain still pushes a bound past ±MAX_TICK, where `getSqrtRatioAtTick`
+    ///      would revert unhelpfully deep inside TickMath. `maxAligned` sits ON the spacing grid by
+    ///      construction, so clamping keeps the range mintable rather than merely non-panicking.
     ///
-    ///      The returned range always STRICTLY BRACKETS the current tick (`tickLower <= tick <
-    ///      tickUpper`) whenever `width >= 2 × tickSpacing`, which init enforces — this is what makes a
-    ///      freshly centred range two-sided, and therefore always sizeable by `assetModeSplit`.
+    ///      The returned range STRICTLY BRACKETS the current tick (`tickLower <= tick < tickUpper`)
+    ///      whenever BOTH spans are at least one `tickSpacing` — which is exactly what the caller's
+    ///      `_checkSkew` enforces (the old, skew-free guarantee was the `width >= 2 × tickSpacing`
+    ///      special case of it). That is what makes a freshly ranged position two-sided, and therefore
+    ///      always sizeable by `assetModeSplit`.
     ///
     ///      Callers must calm-gate BEFORE this: it reads the manipulable spot tick.
-    function centeredTickRange(address pool, int24 tickSpacing, uint24 width)
+    function skewedTickRange(address pool, int24 tickSpacing, uint24 width, uint16 skewBps)
         public
         view
         returns (int24 tickLower, int24 tickUpper)
     {
         (, int24 currentTick,,,,) = ICLPool(pool).slot0();
-        int24 span = int24(width / 2);
-        tickLower = _alignTick(currentTick - span, tickSpacing);
-        tickUpper = _alignTick(currentTick + span, tickSpacing);
+        uint256 lowerSpan = (uint256(width) * uint256(skewBps)) / 10000;
+        uint256 upperSpan = uint256(width) - lowerSpan; // exact complement — no double rounding
+        tickLower = _alignTick(currentTick - int24(uint24(lowerSpan)), tickSpacing);
+        tickUpper = _alignTick(currentTick + int24(uint24(upperSpan)), tickSpacing);
         int24 maxAligned = _alignTick(TickMath.MAX_TICK, tickSpacing);
         if (tickLower < -maxAligned) tickLower = -maxAligned;
         if (tickUpper > maxAligned) tickUpper = maxAligned;
@@ -485,8 +496,9 @@ library LeveragedAeroValuation {
         uint256 minOut
     ) public {
         IERC20(tokenIn).forceApprove(router, amountIn);
-        ICLSwapRouter(router).exactInputSingle(
-            ICLSwapRouter.ExactInputSingleParams({
+        ICLSwapRouter(router)
+            .exactInputSingle(
+                ICLSwapRouter.ExactInputSingleParams({
                 tokenIn: tokenIn,
                 tokenOut: tokenOut,
                 tickSpacing: tickSpacing,
@@ -496,7 +508,7 @@ library LeveragedAeroValuation {
                 amountOutMinimum: minOut,
                 sqrtPriceLimitX96: 0
             })
-        );
+            );
     }
 
     /// @notice Slipstream `exactOutputSingle` (approve, swap, then RESET the approval to 0).
@@ -521,8 +533,9 @@ library LeveragedAeroValuation {
         uint256 amountInMax
     ) public {
         IERC20(tokenIn).forceApprove(router, amountInMax);
-        ICLSwapRouter(router).exactOutputSingle(
-            ICLSwapRouter.ExactOutputSingleParams({
+        ICLSwapRouter(router)
+            .exactOutputSingle(
+                ICLSwapRouter.ExactOutputSingleParams({
                 tokenIn: tokenIn,
                 tokenOut: tokenOut,
                 tickSpacing: tickSpacing,
@@ -532,7 +545,7 @@ library LeveragedAeroValuation {
                 amountInMaximum: amountInMax,
                 sqrtPriceLimitX96: 0
             })
-        );
+            );
         IERC20(tokenIn).forceApprove(router, 0);
     }
 
@@ -567,9 +580,8 @@ library LeveragedAeroValuation {
         IERC20(aero).forceApprove(AERO_V2_ROUTER, amountIn);
         IAeroRouter.Route[] memory routes = new IAeroRouter.Route[](1);
         routes[0] = IAeroRouter.Route({from: aero, to: usdc, stable: false, factory: AERO_V2_FACTORY});
-        IAeroRouter(AERO_V2_ROUTER).swapExactTokensForTokens(
-            amountIn, minOut, routes, address(this), block.timestamp + 600
-        );
+        IAeroRouter(AERO_V2_ROUTER)
+            .swapExactTokensForTokens(amountIn, minOut, routes, address(this), block.timestamp + 600);
         usdcOut = IERC20(usdc).balanceOf(address(this)) - usdcBefore;
     }
 

--- a/src/leveraged-aero/LeveragedAeroValuation.sol
+++ b/src/leveraged-aero/LeveragedAeroValuation.sol
@@ -5,6 +5,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
+import {FeeConstants} from "./sherwood/FeeConstants.sol";
 import {ICToken} from "./sherwood/interfaces/ICToken.sol";
 import {IMoonwellMarket} from "./sherwood/interfaces/IMoonwellMarket.sol";
 import {ICLPool, ICLSwapRouter} from "./sherwood/interfaces/ISlipstream.sol";
@@ -104,9 +105,43 @@ library LeveragedAeroValuation {
     ///         same-signature declarations in `LeveragedAeroManager` / `LeveragedAerodromeCLStrategy`,
     ///         so a test may expect it off any of the three.
     error MoonwellRepayFailed(uint256 errCode);
+    /// @notice A range pair failed `checkRange`: a width off the tickSpacing grid / outside
+    ///         `[minWidth, maxWidth]`, OR a skew outside `(0, 1e4)` / outside the governance band
+    ///         `[minSkewBps, maxSkewBps]` / one that starves either side of the range below a single
+    ///         tickSpacing. ONE error for both knobs: they are validated together, by the same two
+    ///         callers (`_initialize` and `rerange`), and a caller that has to fix its range params does
+    ///         not branch on which half was wrong. The selector matches the same-signature declaration
+    ///         in `LeveragedAerodromeCLStrategy`, so a test may expect it off either.
+    error OutOfBounds();
+    /// @notice An oracle / calm-gate config value is outside the band a guard needs to stay meaningful.
+    ///         Declared here because `checkRiskParams` runs the ladder; the selector matches the
+    ///         same-signature declaration in `LeveragedAerodromeCLStrategy`.
+    error OracleParamOutOfRange();
+    /// @notice `targetLtvBps > maxLtvBps` at init. Selector shared with the strategy.
+    error TargetLtvExceedsMax();
+    /// @notice `minHealthBps` below the 10500 floor. Selector shared with the strategy.
+    error MinHealthTooLow();
+    /// @notice `maxLtvBps` at or above the Moonwell USDC collateral factor. Selector shared.
+    error MaxLtvExceedsCF();
+    /// @notice `minHealthBps × maxLtvBps >= 1e8` — the permissionless-deleverage trigger LTV would sit
+    ///         at or below `maxLtvBps`, opening an in-band grief window (L4). Selector shared.
+    error MinHealthMaxLtvConflict();
+    /// @notice A non-zero fee rate with a zero recipient. Selector shared with the strategy.
+    error FeeRecipientRequired();
+    /// @notice Performance fee above the protocol-wide cap. Selector shared with the strategy.
+    error PerformanceFeeTooHigh();
+    /// @notice Management fee above the factory's cap. Selector shared with the strategy.
+    error ManagementFeeTooHigh();
+    /// @notice `Comptroller.markets()` failed, returned short, or reported a zero collateral factor.
+    ///         Selector shared with the strategy.
+    error ComptrollerCallFailed();
 
     /// @dev Chainlink USD feeds on Base are 8-decimal; assumed for the USD→USDC scaling.
     uint256 private constant USD_FEED_DECIMALS = 8;
+
+    /// @dev Annual management-fee ceiling (bps) enforced by `checkFeeParams`; mirrors
+    ///      `SyndicateFactory.MAX_MANAGEMENT_FEE_BPS` (5%/yr). Lives here with the ladder that reads it.
+    uint16 private constant MAX_MANAGEMENT_FEE_BPS = 500;
 
     /// @dev Reference liquidity for the `assetModeSplit` ratio probe. Only the RATIO of the two
     ///      required amounts matters (both are linear in L for a fixed range + sqrtP, so L cancels),
@@ -242,6 +277,174 @@ library LeveragedAeroValuation {
     // Range geometry + ASSET-MODE deploy sizing
     // ---------------------------------------------------------------------------
 
+    /// @notice The Moonwell USDC collateral factor in bps, read from `Comptroller.markets(mUsdc_)` at
+    ///         init. Fail-closed: a failed/short call or a zero factor reverts `ComptrollerCallFailed`.
+    /// @dev The ABI is `(bool isListed, uint256 collateralFactorMantissa, ...)` — read the 2nd word
+    ///      (1e18-scaled). Relocated out of `LeveragedAerodromeCLStrategy` for EIP-170 headroom; the
+    ///      `staticcall` is context-free (no storage, no msg.sender dependence), so running it in the
+    ///      caller's frame under delegatecall is identical. Selector shared with the strategy.
+    function readCollateralFactor(address comptroller_, address mUsdc_) public view returns (uint16 cfBps) {
+        (bool ok, bytes memory ret) = comptroller_.staticcall(abi.encodeWithSignature("markets(address)", mUsdc_));
+        if (!ok || ret.length < 64) revert ComptrollerCallFailed();
+        uint256 cfMantissa;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cfMantissa := mload(add(ret, 0x40))
+        }
+        cfBps = uint16(cfMantissa / 1e14); // 0.88e18 / 1e14 = 8800
+        if (cfBps == 0) revert ComptrollerCallFailed();
+    }
+
+    /// @notice The INIT-ONLY range ladder: the two governance BANDS' own shape, then the genesis
+    ///         `(width_, skewBps_)` pair against them via the very same `checkRange` every later
+    ///         `rerange` runs — so genesis and per-cycle validation cannot drift.
+    /// @dev One entrypoint rather than two calls from `_initialize`: the strategy is at the EIP-170 cap
+    ///      and a second library call site there costs ~100 bytes of it.
+    function checkInitRange(
+        uint24 width_,
+        uint16 skewBps_,
+        int24 tickSpacing_,
+        uint24 minWidth_,
+        uint24 maxWidth_,
+        uint16 minSkewBps_,
+        uint16 maxSkewBps_
+    ) public pure {
+        checkBands(tickSpacing_, minWidth_, maxWidth_, minSkewBps_, maxSkewBps_);
+        checkRange(width_, skewBps_, tickSpacing_, minWidth_, maxWidth_, minSkewBps_, maxSkewBps_);
+    }
+
+    /// @notice The INIT-ONLY shape check on the two governance bands themselves — the bounds every later
+    ///         `checkRange` is measured against, fixed for the clone's life.
+    /// @dev WIDTH BAND: both bounds on the `tickSpacing_` grid, `minWidth_ >= 2 × spacing` (so an aligned
+    ///      range is never empty), `minWidth_ <= maxWidth_`, and `maxWidth_` inside the tick domain —
+    ///      `skewedTickRange` spans up to `width` ticks on ONE side of the pool tick (the skew limit), so
+    ///      a wider band could only ever produce out-of-domain bounds (and, at the uint24 extreme, an
+    ///      int24 wrap in the `currentTick ± span` arithmetic).
+    ///
+    ///      SKEW BAND: `0 < minSkewBps_ <= maxSkewBps_ < 10000` — the band can only ever TIGHTEN the open
+    ///      `(0, 1e4)` interval `checkRange` enforces, never widen it.
+    ///
+    ///      Lives here, beside `checkRange`, for the same EIP-170 reason: the strategy is at the cap.
+    function checkBands(int24 tickSpacing_, uint24 minWidth_, uint24 maxWidth_, uint16 minSkewBps_, uint16 maxSkewBps_)
+        public
+        pure
+    {
+        if (tickSpacing_ <= 0) revert OutOfBounds();
+        uint24 spacing = uint24(tickSpacing_);
+        if (minWidth_ % spacing != 0 || maxWidth_ % spacing != 0) revert OutOfBounds();
+        if (uint256(minWidth_) < 2 * uint256(spacing)) revert OutOfBounds();
+        if (minWidth_ > maxWidth_) revert OutOfBounds();
+        if (uint256(maxWidth_) > 2 * uint256(uint24(TickMath.MAX_TICK))) revert OutOfBounds();
+        if (minSkewBps_ == 0 || minSkewBps_ > maxSkewBps_ || maxSkewBps_ >= 10000) revert OutOfBounds();
+    }
+
+    /// @notice The INIT-ONLY numeric ladder over the risk, oracle and fee params, in the order the
+    ///         strategy used to run it inline (the order is observable — each rung has its own typed
+    ///         error, and the init suite pins which one fires).
+    /// @dev Relocated out of `LeveragedAerodromeCLStrategy._initialize` for EIP-170 headroom, unchanged
+    ///      rung for rung. Every error is re-declared in this library with the SAME signature, so the
+    ///      selectors a caller sees are identical to the strategy's own declarations.
+    ///
+    ///      L4 (the `minHealthBps × maxLtvBps` rung): the permissionless deleverage triggers at
+    ///      `LTV = 1e8 / minHealthBps`; that trigger LTV MUST sit strictly above `maxLtvBps`, else there
+    ///      is an in-band range anyone can grief-deleverage. Cross-multiplied to stay overflow-free.
+    ///
+    ///      L3 (+L5), the oracle rungs — bound each knob so a misconfig cannot silently disable a guard.
+    ///      The bounds admit the confirmed config yet block degenerate values:
+    ///        maxDelay           ∈ (0, 7 days] — a huge value disables staleness detection
+    ///        gracePeriod        ∈ [0, 1 days] — sequencer-restart grace
+    ///        twapWindow         ∈ (0, 1 days] — 0 disables the TWAP / calm-gate
+    ///        calmDeviationTicks ∈ (0, 5000]   — a huge value disables the calm-gate
+    ///        maxSlippageBps     ∈ (0, 1000]   — 0 or huge disables swap-slippage protection (10% cap)
+    ///
+    ///      The FEE rungs are a separate call (`checkFeeParams`) rather than three more parameters here:
+    ///      a 12-argument version of this function put the caller's frame one slot too deep for the Yul
+    ///      stack allocator. Order across the two calls is the original order.
+    /// @param cfBps The Moonwell USDC collateral factor (bps) the caller read at init.
+    function checkRiskParams(
+        uint16 targetLtvBps,
+        uint16 maxLtvBps,
+        uint16 minHealthBps,
+        uint16 cfBps,
+        uint256 maxDelay,
+        uint256 gracePeriod,
+        uint32 twapWindow,
+        uint16 calmDeviationTicks,
+        uint16 maxSlippageBps
+    ) public pure {
+        if (targetLtvBps > maxLtvBps) revert TargetLtvExceedsMax();
+        if (minHealthBps < 10500) revert MinHealthTooLow();
+        if (maxLtvBps >= cfBps) revert MaxLtvExceedsCF();
+        if (uint256(minHealthBps) * uint256(maxLtvBps) >= 1e8) revert MinHealthMaxLtvConflict();
+        if (maxDelay == 0 || maxDelay > 7 days) revert OracleParamOutOfRange();
+        if (gracePeriod > 1 days) revert OracleParamOutOfRange();
+        if (twapWindow == 0 || twapWindow > 1 days) revert OracleParamOutOfRange();
+        if (calmDeviationTicks == 0 || calmDeviationTicks > 5000) revert OracleParamOutOfRange();
+        if (maxSlippageBps == 0 || maxSlippageBps > 1000) revert OracleParamOutOfRange();
+    }
+
+    /// @notice The INIT-ONLY fee rungs: a non-zero rate needs a recipient, and M3 puts a hard ceiling on
+    ///         both rates (performance mirrors the protocol-wide cap, management the factory's 5%/yr —
+    ///         `SyndicateFactory.MAX_MANAGEMENT_FEE_BPS`).
+    /// @dev The tail of `checkRiskParams`' ladder, split off only to keep the caller's stack inside the
+    ///      Yul allocator's reach. Selectors match the strategy's own declarations.
+    function checkFeeParams(uint16 managementFeeBps, uint16 performanceFeeBps, address feeRecipient) public pure {
+        if ((managementFeeBps != 0 || performanceFeeBps != 0) && feeRecipient == address(0)) {
+            revert FeeRecipientRequired();
+        }
+        if (performanceFeeBps > FeeConstants.MAX_PERFORMANCE_FEE_BPS) revert PerformanceFeeTooHigh();
+        if (managementFeeBps > 500) revert ManagementFeeTooHigh();
+    }
+
+    /// @notice THE ONE PREDICATE that validates a `(width, skewBps)` pair before `skewedTickRange`
+    ///         consumes it — shared by `LeveragedAerodromeCLStrategy._initialize` (the genesis pair) and
+    ///         `LeveragedAerodromeCLStrategy.rerange` (each per-cycle pair), so the two entrypoints
+    ///         cannot drift. Lives HERE rather than in the strategy purely for EIP-170 headroom: the
+    ///         strategy is at the cap and this library has room.
+    ///
+    /// @dev WIDTH: on the `tickSpacing_` grid and inside `[minWidth_, maxWidth_]`. The band itself is
+    ///      validated once at init (multiples, `minWidth_ >= 2 × spacing`, min ≤ max, `maxWidth_` inside
+    ///      the tick domain).
+    ///
+    ///      SKEW: `skewBps_` is the fraction of `width_` placed BELOW the pool tick on a 1e4 scale, so
+    ///      5000 is centred; the complement goes above. It must be inside the OPEN `(0, 10000)` interval,
+    ///      inside the governance band `[minSkewBps_, maxSkewBps_]` (validated at init as
+    ///      `0 < minSkewBps_ <= maxSkewBps_ < 10000`, so the band can only ever tighten the open
+    ///      interval, never widen it), and leave both spans at least one spacing.
+    ///
+    ///      THE SPAN GUARD IS SPAN-BASED, NOT A FLAT bps BAND, ON PURPOSE: a flat band cannot protect
+    ///      small widths (at `width == 2 × tickSpacing` even a mild 2500 skew starves the lower side to
+    ///      half a spacing, while at `width == 200 × tickSpacing` a 100-bps skew is perfectly safe). BOTH
+    ///      sides must span at least one `tickSpacing`, or the DOWN-aligned range stops STRICTLY
+    ///      BRACKETING the pool tick (`tickLower <= tick < tickUpper`) — the invariant `assetModeSplit`
+    ///      relies on to size a fresh range two-sided, and the reason a one-sided range is a fail-closed
+    ///      `DegenerateRange`.
+    ///
+    ///      QUANTIZATION CLIFF, the operator-facing consequence: the USABLE skew set widens with
+    ///      `width_ / tickSpacing_`. At the floor (`width_ == 2 × tickSpacing_`) the only geometry
+    ///      satisfying both spans is the centred one, so skew is effectively pinned to ~5000 there;
+    ///      meaningful skew needs `width_ >= 3 × tickSpacing_`, and a governance band whose whole
+    ///      interior is unreachable at the configured width will simply refuse every rerange.
+    function checkRange(
+        uint24 width_,
+        uint16 skewBps_,
+        int24 tickSpacing_,
+        uint24 minWidth_,
+        uint24 maxWidth_,
+        uint16 minSkewBps_,
+        uint16 maxSkewBps_
+    ) public pure {
+        if (tickSpacing_ <= 0) revert OutOfBounds();
+        if (width_ % uint24(tickSpacing_) != 0) revert OutOfBounds();
+        if (width_ < minWidth_ || width_ > maxWidth_) revert OutOfBounds();
+        if (skewBps_ == 0 || skewBps_ >= 10000) revert OutOfBounds();
+        if (skewBps_ < minSkewBps_ || skewBps_ > maxSkewBps_) revert OutOfBounds();
+        uint256 lowerSpan = (uint256(width_) * uint256(skewBps_)) / 10000;
+        uint256 upperSpan = uint256(width_) - lowerSpan; // exact complement, matching `skewedTickRange`
+        uint256 spacing = uint256(uint24(tickSpacing_));
+        if (lowerSpan < spacing || upperSpan < spacing) revert OutOfBounds();
+    }
+
     /// @notice The tickSpacing-aligned range around `pool`'s current tick, SKEWED by `skewBps`: that
     ///         fraction of `width` (1e4 scale) is placed BELOW the current tick and the exact complement
     ///         above. `skewBps == 5000` is the centred range (and reproduces the old `centeredTickRange`
@@ -269,7 +472,7 @@ library LeveragedAeroValuation {
     ///
     ///      The returned range STRICTLY BRACKETS the current tick (`tickLower <= tick < tickUpper`)
     ///      whenever BOTH spans are at least one `tickSpacing` — which is exactly what the caller's
-    ///      `_checkSkew` enforces (the old, skew-free guarantee was the `width >= 2 × tickSpacing`
+    ///      `checkRange` enforces (the old, skew-free guarantee was the `width >= 2 × tickSpacing`
     ///      special case of it). That is what makes a freshly ranged position two-sided, and therefore
     ///      always sizeable by `assetModeSplit`.
     ///
@@ -913,6 +1116,44 @@ library LeveragedAeroValuation {
         uint256 usdValue = Math.mulDiv(amount, pToken, 10 ** uint256(tokenDecimals));
         // → USDC face (6dp): divide by the USDC price (8dp) and rescale 1e8 → 1e6.
         return Math.mulDiv(usdValue, 1e6, pUsdc);
+    }
+
+    /// @notice The three oracle bounds an IL-residual cover needs (`LeveragedAeroManager._rebalanceCover`):
+    ///         how much USDC the deficit buy may spend, how much of the surplus leg to sell for it, and
+    ///         the floor that sell must clear. Pure — the caller supplies the hardened prices.
+    ///
+    /// @dev Lives here rather than inline in the manager, which is at the EIP-170 cap.
+    ///
+    ///      `buyMax` is the oracle CEILING on the exact-output cover: a sandwiched/manipulated
+    ///      permissionless `deleverage` cannot overpay past oracle + `slipBps` (H1).
+    ///
+    ///      `sellAmt` is NEED-SIZED, never the whole balance: `buyMax` converted into surplus-leg units
+    ///      and grossed up by `slipBps` a SECOND time, so a sell that fills exactly on `sellFloor` still
+    ///      raises the ceiling-priced buy. Capped at `surplusBal`. Selling more than this would liquidate
+    ///      a delta-neutral idle remainder into an unrecorded short — see the manager's call site.
+    ///
+    ///      `sellFloor` is derived from `sellAmt`, NOT from `surplusBal`: a floor priced off a balance
+    ///      larger than what is sold is unreachable and would revert every need-sized sell.
+    ///
+    ///      `surplusBal == 0` (nothing to sell, or the surplus leg IS the unit of account) returns
+    ///      `(buyMax, 0, 0)` without touching `pSurplus` — which the caller may then pass as 0.
+    /// @param slipBps `maxSlippageBps`, bounded to (0, 1000] at init so neither gross-up can underflow.
+    function coverBounds(
+        uint256 shortAmt,
+        uint8 deficitDec,
+        uint256 pDeficit,
+        uint256 surplusBal,
+        uint8 surplusDec,
+        uint256 pSurplus,
+        uint256 pUsdc,
+        uint256 slipBps
+    ) public pure returns (uint256 buyMax, uint256 sellAmt, uint256 sellFloor) {
+        buyMax = _usdcValue(shortAmt, deficitDec, pDeficit, pUsdc) * (10000 + slipBps) / 10000;
+        if (surplusBal == 0) return (buyMax, 0, 0);
+        uint256 needed =
+            Math.mulDiv(buyMax * 10000 / (10000 - slipBps), (10 ** uint256(surplusDec)) * pUsdc, pSurplus * 1e6);
+        sellAmt = surplusBal > needed ? needed : surplusBal;
+        sellFloor = _usdcValue(sellAmt, surplusDec, pSurplus, pUsdc) * (10000 - slipBps) / 10000;
     }
 
     /// @dev Spot-vs-TWAP calm-gate (fail-closed). Reverts `CalmGateBreached` when the pool

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -235,7 +235,7 @@ library LeveragedAeroVenue {
         // USDC only), unsellable (`compound` early-returns on a flat book) and un-rescuable
         // (`rescueToVault` denies the reward token while Executed) — so every deposit and redeem in
         // the flat window would price against an understated NAV.
-        _sellRewardBalance(minRewardUsdcOut);
+        _sellRewardBalance(minRewardUsdcOut, true);
         // Same pathological-case belt as `_settle`: repays drive the bases to 0 through `_repay`'s
         // clamp except when residual debt could not be covered at all — zero them explicitly so a
         // flat book never carries a stale hedge basis into the next venue.
@@ -248,6 +248,29 @@ library LeveragedAeroVenue {
         uint256 idle = IERC20($.usdc).balanceOf(address(this));
         if (idle < minIdleUsdcOut) revert InsufficientIdleAfterFlatten(idle, minIdleUsdcOut);
         emit Flattened(idle);
+    }
+
+    /// @notice Sell the reward tranche the TERMINAL settle's unwind auto-claimed, floored by the L9
+    ///         oracle read ALONE — `BaseStrategy.settle()` takes no arguments, so there is no caller
+    ///         `minOut` to require and the oracle floor is the whole guard (post-checked against the
+    ///         measured fill, exactly as in `flattenImpl`).
+    /// @dev BEST-EFFORT BY CONTRACT — the strategy MUST reach this through its self-`try/catch`
+    ///      wrapper (`LeveragedAerodromeCLStrategy.sellSettleRewardSelf`), never directly. This
+    ///      function still FAILS CLOSED on its own (stale reward feed → `StaleOracle`; a fill under
+    ///      the floor → `BelowOracleFloor`), which is what makes the catch safe: the revert unwinds
+    ///      the whole sub-call including the swap, so the reward balance is left untouched and
+    ///      rescuable rather than sold blind.
+    ///
+    ///      WHY THE ASYMMETRY WITH `flattenImpl`, which calls the same helper fail-closed: `flatten`
+    ///      is RESUMABLE — a reverted flatten leaves an `Executed` book the proposer simply retries
+    ///      once the feed recovers, so failing closed costs nothing and preserves the caller's floor.
+    ///      `settle` is TERMINAL and owner-driven (`Executed → Settled`, one-way, no retry, no
+    ///      argument to widen): a hard revert here would let a stale reward feed or a reverting router
+    ///      BLOCK the fund's only exit. Degrading to "leave the tranche rescuable via
+    ///      `rescueToVault` post-`Settled`" — the pre-fix behaviour for the whole tranche — is the
+    ///      strictly better failure mode.
+    function sellSettleRewardImpl() public {
+        _sellRewardBalance(0, false);
     }
 
     /// @dev Sell the gauge-reward balance to USDC, floored exactly as `compoundImpl`'s harvest is:
@@ -270,7 +293,11 @@ library LeveragedAeroVenue {
     ///      only exit. Skipping is safe precisely where the floor rounds to 0: the mandatory-sale
     ///      rationale is that an unsold balance is invisible to `nav()`, and a sub-micro-USD balance
     ///      rounds out of a 6dp NAV by construction.
-    function _sellRewardBalance(uint256 minRewardUsdcOut) private {
+    /// @param minRewardUsdcOut Caller's own floor on the fill (the oracle floor applies on top).
+    /// @param callerFloorRequired Whether a zero `minRewardUsdcOut` is a caller error. TRUE for
+    ///        `flatten`, whose proposer supplies one; FALSE for the terminal settle, which has no
+    ///        argument to supply and is bounded by the oracle floor alone (see `sellSettleRewardImpl`).
+    function _sellRewardBalance(uint256 minRewardUsdcOut, bool callerFloorRequired) private {
         Layout storage $ = _layout();
         address rewardTok = ICLGauge($.gauge).rewardToken();
         uint256 bal = IERC20(rewardTok).balanceOf(address(this));
@@ -294,7 +321,7 @@ library LeveragedAeroVenue {
             bal, LeveragedAeroValuation.readUsd8($.aeroUsdFeed, $.sequencerFeed, $.maxDelay, $.gracePeriod), 1e20
         ) * (10000 - uint256($.maxSlippageBps)) / 10000;
         if (floor == 0) return; // dust: unsellable, and worth strictly less than one NAV unit
-        if (minRewardUsdcOut == 0) revert ZeroMinOut();
+        if (callerFloorRequired && minRewardUsdcOut == 0) revert ZeroMinOut();
         uint256 usdcOut = LeveragedAeroValuation.swapAeroToUsdc(rewardTok, $.usdc, bal, minRewardUsdcOut);
         if (usdcOut < floor) revert BelowOracleFloor();
     }

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -13,7 +13,6 @@ import {LeveragedAeroFees} from "./LeveragedAeroFees.sol";
 import {LeveragedAeroManager} from "./LeveragedAeroManager.sol";
 import {LeveragedAeroValuation} from "./LeveragedAeroValuation.sol";
 import {BaseStrategy} from "./sherwood/BaseStrategy.sol";
-import {FeeConstants} from "./sherwood/FeeConstants.sol";
 import {IAggregatorV3} from "./sherwood/interfaces/IAggregatorV3.sol";
 import {IMoonwellMarket} from "./sherwood/interfaces/IMoonwellMarket.sol";
 import {Position} from "./sherwood/interfaces/IPriceRouter.sol";
@@ -22,7 +21,6 @@ import {ICLFactory, ICLGauge, ICLPool, INonfungiblePositionManager} from "./sher
 import {IStrategy} from "./sherwood/interfaces/IStrategy.sol";
 import {ISyndicateFactory} from "./sherwood/interfaces/ISyndicateFactory.sol";
 import {ISyndicateVault} from "./sherwood/interfaces/ISyndicateVault.sol";
-import {TickMath} from "./sherwood/libraries/TickMath.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title LeveragedAerodromeCLStrategy
@@ -48,6 +46,14 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     using SafeERC20 for IERC20;
 
     // ── Errors ──
+    //
+    // THE INIT-VALIDATION ERRORS ARE RAISED FROM THE LIBRARY, NOT FROM THIS FRAME. `TargetLtvExceedsMax`,
+    // `MinHealthTooLow`, `MaxLtvExceedsCF`, `MinHealthMaxLtvConflict`, `FeeRecipientRequired`,
+    // `PerformanceFeeTooHigh`, `ManagementFeeTooHigh`, `OracleParamOutOfRange`, `ComptrollerCallFailed`
+    // and `OutOfBounds` are all declared IDENTICALLY in `LeveragedAeroValuation` (which runs those
+    // ladders — the relocation bought EIP-170 headroom here). Same signature == same selector, so they
+    // stay on this contract's ABI and a caller/test may expect them off either. Do not delete them as
+    // "unused": the ABI is the interface a frontend and the init suite bind to.
     error NotImplemented();
     error TargetLtvExceedsMax();
     error MinHealthTooLow(); // minHealthBps < 10500 (1.05x floor)
@@ -104,9 +110,6 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
 
     /// @dev ERC-4626 virtual share offset matching the vault's `_decimalsOffset()` (USDC 6dp → 1e6).
     uint256 private constant SHARES_VIRTUAL_OFFSET = 1e6;
-
-    /// @dev Annual management-fee ceiling (bps); mirrors `SyndicateFactory.MAX_MANAGEMENT_FEE_BPS` (5%/yr).
-    uint16 private constant MAX_MANAGEMENT_FEE_BPS = 500;
 
     /// @dev Deadman window: after this elapses on an unfulfilled `requestRedeem`, its owner can
     ///      `emergencyRedeem` trustlessly (oracle-free). The backend fulfills in minutes; 2 days
@@ -174,6 +177,8 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         uint24 minWidth; // lower bound for a proposer-supplied rerange width
         uint24 maxWidth; // upper bound for a proposer-supplied rerange width
         uint16 skewBps; // initial fraction of `width` placed BELOW the tick (1e4 scale; 5000 == centred)
+        uint16 minSkewBps; // lower bound for a proposer-supplied rerange skew (governance band)
+        uint16 maxSkewBps; // upper bound for a proposer-supplied rerange skew (governance band)
         // ── Risk params ──
         uint16 targetLtvBps; // Target LTV in bps (e.g. 5000 = 50%)
         uint16 maxLtvBps; // Maximum LTV cap in bps (e.g. 6500 = 65%)
@@ -268,10 +273,13 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         uint24 maxWidth; // upper bound for a proposer-supplied rerange width
         // ── appended for the config-emergent pool shape (keep byte-identical) ──
         bool legBIsAsset; // DERIVED at init: leg-B slot == usdc → asset-as-a-leg shape (packs above)
-        // ── appended for the rerange SKEW (keep byte-identical). Placed HERE, not after the hedged
-        //    principals, so it free-packs into the existing tail slot (20 bytes used → 22) and
-        //    `hedgedDebtA`/`hedgedDebtB` keep a byte-identical slot AND offset. ──
+        // ── appended for the rerange SKEW and its governance band (keep byte-identical). Placed HERE,
+        //    not after the hedged principals, so all three free-pack into the existing tail slot
+        //    (20 bytes used → 26) and `hedgedDebtA`/`hedgedDebtB` keep a byte-identical slot AND offset:
+        //    26 + 16 > 32, so `hedgedDebtA` still starts the NEXT slot at offset 0. ──
         uint16 skewBps; // fraction of `width` placed BELOW the pool tick (1e4 scale; 5000 == centred)
+        uint16 minSkewBps; // lower bound for a proposer-supplied rerange skew
+        uint16 maxSkewBps; // upper bound for a proposer-supplied rerange skew
         // ── LAST fields: appended for the borrow-interest hedge (keep byte-identical) ──
         uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with the widths above)
         uint128 hedgedDebtB; // leg-B borrowed principal the LP hedges (0 in asset-mode: leg B never borrows)
@@ -339,6 +347,8 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         uint24 maxWidth;
         bool legBIsAsset;
         uint16 skewBps;
+        uint16 minSkewBps;
+        uint16 maxSkewBps;
         uint128 hedgedDebtA;
         uint128 hedgedDebtB;
     }
@@ -396,6 +406,8 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         v.maxWidth = $.maxWidth;
         v.legBIsAsset = $.legBIsAsset;
         v.skewBps = $.skewBps;
+        v.minSkewBps = $.minSkewBps;
+        v.maxSkewBps = $.maxSkewBps;
         v.hedgedDebtA = $.hedgedDebtA;
         v.hedgedDebtB = $.hedgedDebtB;
     }
@@ -555,46 +567,33 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         uint8 wethDec = IERC20Metadata(p.weth).decimals();
         if (cbDec < 2 || cbDec > 18 || wethDec < 2 || wethDec > 18) revert LegDecimalsOutOfRange();
 
-        // Rerange width band: every width (init + per-cycle) must sit on the tickSpacing grid, and
-        // the floor must span at least two spacings so an aligned range is never empty.
-        if (p.tickSpacing <= 0) revert OutOfBounds();
-        uint24 spacing = uint24(p.tickSpacing);
-        if (p.minWidth % spacing != 0 || p.maxWidth % spacing != 0) revert OutOfBounds();
-        if (uint256(p.minWidth) < 2 * uint256(spacing)) revert OutOfBounds();
-        if (p.minWidth > p.maxWidth) revert OutOfBounds();
-        // Ceiling on the band: `skewedTickRange` spans up to `width` ticks on ONE side of the pool tick
-        // (the skew limit), so a width beyond the full tick domain can only ever produce out-of-domain
-        // bounds (and, at the uint24 extreme, an int24 wrap in the `currentTick ± span` arithmetic).
-        if (uint256(p.maxWidth) > 2 * uint256(uint24(TickMath.MAX_TICK))) revert OutOfBounds();
-        _checkWidth(p.width, p.tickSpacing, p.minWidth, p.maxWidth);
-        _checkSkew(p.width, p.skewBps, p.tickSpacing);
+        // Range governance: the two BANDS' own shape (width grid/floor/ceiling, `0 < minSkew <= maxSkew
+        // < 1e4`), then the genesis `(width, skewBps)` pair against them — the SAME predicate `rerange`
+        // runs per cycle, so the two entrypoints cannot drift. Both ladders live in
+        // `LeveragedAeroValuation` (which re-declares `OutOfBounds` at the same selector) purely for
+        // EIP-170 headroom: this contract is at the cap and that library is not.
+        LeveragedAeroValuation.checkInitRange(
+            p.width, p.skewBps, p.tickSpacing, p.minWidth, p.maxWidth, p.minSkewBps, p.maxSkewBps
+        );
 
-        uint16 cfBps = _readCollateralFactor(p.comptroller, p.mUsdc);
-        if (p.targetLtvBps > p.maxLtvBps) revert TargetLtvExceedsMax();
-        if (p.minHealthBps < 10500) revert MinHealthTooLow();
-        if (p.maxLtvBps >= cfBps) revert MaxLtvExceedsCF();
-        // L4: permissionless deleverage triggers at LTV = 1e8 / minHealthBps; that trigger LTV MUST
-        // sit strictly above maxLtvBps, else there is an in-band range anyone can grief-deleverage.
-        // Cross-multiplied (overflow-free): require minHealthBps * maxLtvBps < 1e8.
-        if (uint256(p.minHealthBps) * uint256(p.maxLtvBps) >= 1e8) revert MinHealthMaxLtvConflict();
-        // L3 (+L5): bound the oracle / calm-gate params so a misconfig can't silently disable a guard.
-        // Bounds admit the confirmed config yet block degenerate values:
-        //   maxDelay           ∈ (0, 7 days] — a huge value disables staleness detection
-        //   gracePeriod        ∈ [0, 1 days] — sequencer-restart grace
-        //   twapWindow         ∈ (0, 1 days] — 0 disables the TWAP / calm-gate
-        //   calmDeviationTicks ∈ (0, 5000]   — a huge value disables the calm-gate
-        //   maxSlippageBps     ∈ (0, 1000]   — 0 or huge disables swap-slippage protection (10% cap)
-        if (p.maxDelay == 0 || p.maxDelay > 7 days) revert OracleParamOutOfRange();
-        if (p.gracePeriod > 1 days) revert OracleParamOutOfRange();
-        if (p.twapWindow == 0 || p.twapWindow > 1 days) revert OracleParamOutOfRange();
-        if (p.calmDeviationTicks == 0 || p.calmDeviationTicks > 5000) revert OracleParamOutOfRange();
-        if (p.maxSlippageBps == 0 || p.maxSlippageBps > 1000) revert OracleParamOutOfRange();
-        if ((p.managementFeeBps != 0 || p.performanceFeeBps != 0) && p.feeRecipient == address(0)) {
-            revert FeeRecipientRequired();
-        }
-        // M3: hard ceilings on both fee rates (perf mirrors the protocol-wide cap; mgmt the factory's).
-        if (p.performanceFeeBps > FeeConstants.MAX_PERFORMANCE_FEE_BPS) revert PerformanceFeeTooHigh();
-        if (p.managementFeeBps > MAX_MANAGEMENT_FEE_BPS) revert ManagementFeeTooHigh();
+        // Risk / oracle / fee ladder — relocated whole (rung for rung, same order, same selectors) into
+        // `LeveragedAeroValuation`, for the same headroom reason. The collateral-factor read moved with
+        // it: it is a context-free `staticcall`, so running it in this frame under delegatecall is
+        // identical. The fee rungs are a separate call only because a 12-argument `checkRiskParams` put
+        // this frame one slot too deep for the Yul stack allocator; the ORDER is the original one.
+        uint16 cfBps = LeveragedAeroValuation.readCollateralFactor(p.comptroller, p.mUsdc);
+        LeveragedAeroValuation.checkRiskParams(
+            p.targetLtvBps,
+            p.maxLtvBps,
+            p.minHealthBps,
+            cfBps,
+            p.maxDelay,
+            p.gracePeriod,
+            p.twapWindow,
+            p.calmDeviationTicks,
+            p.maxSlippageBps
+        );
+        LeveragedAeroValuation.checkFeeParams(p.managementFeeBps, p.performanceFeeBps, p.feeRecipient);
 
         Layout storage $ = _layout();
         $.usdc = p.usdc;
@@ -635,52 +634,12 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         $.wethSwapTickSpacing = p.wethSwapTickSpacing;
         $.width = p.width;
         $.skewBps = p.skewBps;
+        $.minSkewBps = p.minSkewBps;
+        $.maxSkewBps = p.maxSkewBps;
         $.minWidth = p.minWidth;
         $.maxWidth = p.maxWidth;
         $.legBIsAsset = legBIsAsset_;
         // tokenId / posTickLower / posTickUpper / hwmPerShare default to 0 (set in _execute / on first deposit).
-    }
-
-    /// @dev Width band check shared by `_initialize` (the genesis width) and `rerange` (each
-    ///      per-cycle width): on the tickSpacing grid and inside `[minWidth_, maxWidth_]`. The band
-    ///      itself is validated once at init (multiples, `minWidth_ >= 2 × spacing`, min ≤ max).
-    function _checkWidth(uint24 width_, int24 tickSpacing_, uint24 minWidth_, uint24 maxWidth_) private pure {
-        if (tickSpacing_ <= 0) revert OutOfBounds();
-        if (width_ % uint24(tickSpacing_) != 0) revert OutOfBounds();
-        if (width_ < minWidth_ || width_ > maxWidth_) revert OutOfBounds();
-    }
-
-    /// @dev Skew band check shared by `_initialize` (the genesis skew) and `rerange` (each per-cycle
-    ///      skew). `skewBps_` is the fraction of `width_` placed BELOW the pool tick on a 1e4 scale, so
-    ///      5000 is centred; the complement goes above. Always called AFTER `_checkWidth`, which is what
-    ///      establishes `tickSpacing_ > 0` for the cast below.
-    ///
-    ///      THE GUARD IS SPAN-BASED, NOT A FLAT bps BAND, ON PURPOSE: a flat band cannot protect small
-    ///      widths (at `width == 2 × tickSpacing` even a mild 2500 skew starves the lower side to half a
-    ///      spacing, while at `width == 200 × tickSpacing` a 100-bps skew is perfectly safe). BOTH sides
-    ///      must span at least one `tickSpacing`, or the DOWN-aligned range stops STRICTLY BRACKETING the
-    ///      pool tick (`tickLower <= tick < tickUpper`) — the invariant `assetModeSplit` relies on to size
-    ///      a fresh range two-sided, and the reason a one-sided range is a fail-closed `DegenerateRange`.
-    function _checkSkew(uint24 width_, uint16 skewBps_, int24 tickSpacing_) private pure {
-        if (skewBps_ == 0 || skewBps_ >= 10000) revert OutOfBounds();
-        uint256 lowerSpan = (uint256(width_) * uint256(skewBps_)) / 10000;
-        uint256 upperSpan = uint256(width_) - lowerSpan; // exact complement, matching `skewedTickRange`
-        uint256 spacing = uint256(uint24(tickSpacing_));
-        if (lowerSpan < spacing || upperSpan < spacing) revert OutOfBounds();
-    }
-
-    /// @dev USDC collateral factor (bps) from `Comptroller.markets(mUsdc)`. ABI is
-    ///      `(bool isListed, uint256 collateralFactorMantissa, ...)`; read the 2nd word (1e18-scaled).
-    function _readCollateralFactor(address comptroller_, address mUsdc_) private view returns (uint16 cfBps) {
-        (bool ok, bytes memory ret) = comptroller_.staticcall(abi.encodeWithSignature("markets(address)", mUsdc_));
-        if (!ok || ret.length < 64) revert ComptrollerCallFailed();
-        uint256 cfMantissa;
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            cfMantissa := mload(add(ret, 0x40))
-        }
-        cfBps = uint16(cfMantissa / 1e14); // 0.88e18 / 1e14 = 8800
-        if (cfBps == 0) revert ComptrollerCallFailed();
     }
 
     // ── NAV ──
@@ -1088,24 +1047,34 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     /// @param skewBps_ WHERE that width sits relative to the calm tick: the fraction of `width_` placed
     ///                 BELOW it, on a 1e4 scale. `5000` is centred (`width_/2` each side, the historical
     ///                 behaviour); `3500` puts 35% of the width below spot and 65% above, which is how a
-    ///                 rebalancer expresses a directional view without swapping. Must be in `(0, 10000)`
-    ///                 AND leave both sides spanning at least one `tickSpacing` — see `_checkSkew`.
+    ///                 rebalancer expresses a directional view without swapping. Must be in `(0, 10000)`,
+    ///                 inside the governance band `[minSkewBps, maxSkewBps]`, AND leave both sides
+    ///                 spanning at least one `tickSpacing` — see `LeveragedAeroValuation.checkRange`.
     ///
     ///                 Placement is grid-approximate: both bounds round DOWN onto the spacing grid, so
     ///                 the realised range sits off the requested split by up to one spacing.
     /// @param minLiq0  Minimum token0 the re-add must consume (two-sided slippage guard).
     /// @param minLiq1  Minimum token1 the re-add must consume (two-sided slippage guard).
     ///
-    /// @dev BOTH `width_` and `skewBps_` are PERSISTED here, in this frame, BEFORE the delegatecall —
-    ///      two things ride on that. (1) `nav()` and every subsequent mint (`deployIdle` / `compound`)
-    ///      read the STORED pair, so the proposer's choice must outlive the call. (2) The write must
-    ///      land even on a FLAT book, where `rerangeImpl` returns early and the re-range itself is a
-    ///      no-op but the new range still has to take effect for the next redeploy — which is why the
-    ///      persists are AHEAD of the impl rather than inside it (the impl used to store `width` itself,
-    ///      ahead of its own bail-out; the ordering property is unchanged, only the frame moved). The
-    ///      relocation is for EIP-170 headroom: this frame already holds `_layout()` for the two checks,
-    ///      so the writes cost ~20 bytes here versus ~70 in the manager library, which is at the cap.
-    ///      Exactly the same move `adjustLeverage`'s target-LTV write already makes.
+    /// @dev BOTH `width_` and `skewBps_` are PERSISTED here, in this frame, BEFORE the delegatecall,
+    ///      because `rerangeImpl` TAKES NO RANGE PARAMS: it reads the pair straight out of storage, so
+    ///      the persist must precede the delegatecall or the impl would re-range at the OLD pair. (The
+    ///      stored pair's only readers are `executeImpl` and `rerangeImpl` — `nav()` does not read it,
+    ///      and `deployIdle` / `compound` do not re-derive a range at all: they `increaseLiquidity` into
+    ///      the STORED `posTickLower`/`posTickUpper`. So the stored pair takes economic effect at the
+    ///      NEXT `rerange`, or at `execute` on a pre-genesis book.) Placing the two `sstore`s in THIS
+    ///      frame rather than in the impl is a bytecode relocation for EIP-170 headroom: this frame
+    ///      already holds `_layout()` for the validation, so the writes cost ~20 bytes here versus ~70 in
+    ///      the manager library, which is at the cap. Exactly the same move `adjustLeverage`'s target-LTV
+    ///      write already makes.
+    ///
+    ///      FLAT BOOK (`tokenId == 0` while still `Executed`): `rerangeImpl` returns early and the
+    ///      persist is all that happens. That is deliberate — and deliberately NOT a revert — but the
+    ///      honest reading is that such a book is TERMINAL UNTIL SETTLE: nothing can mint again
+    ///      (`execute` is one-shot, `deployIdle` fails closed with no NFT to add into, `compound` no-ops), so
+    ///      no later op consumes the stored pair. The write is kept for `layout()` / monitoring
+    ///      consistency — so the fund's advertised range matches what a proposer last asked for — not
+    ///      because anything re-reads it.
     function rerange(uint24 width_, uint16 skewBps_, uint256 minLiq0, uint256 minLiq1)
         external
         onlyProposer
@@ -1113,8 +1082,9 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     {
         if (_state != State.Executed) revert NotExecuted();
         Layout storage $ = _layout();
-        _checkWidth(width_, $.tickSpacing, $.minWidth, $.maxWidth);
-        _checkSkew(width_, skewBps_, $.tickSpacing);
+        LeveragedAeroValuation.checkRange(
+            width_, skewBps_, $.tickSpacing, $.minWidth, $.maxWidth, $.minSkewBps, $.maxSkewBps
+        );
         $.width = width_;
         $.skewBps = skewBps_;
         LeveragedAeroManager.rerangeImpl(minLiq0, minLiq1);

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -157,6 +157,12 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     uint8 private constant OP_FULFILL = 2; // proportional redeem (fulfill / emergency)
     uint8 private constant OP_COMPOUND = 3; // harvest / redeploy
 
+    /// @dev The terminal settle's best-effort sale of the final reward tranche reverted and was
+    ///      skipped; the settle completed. Expect it on a stale/paused reward feed or a reward-route
+    ///      failure — the tranche is left on the strategy and, now that the strategy is `Settled`, is
+    ///      recoverable with `rescueToVault(rewardToken)` → the vault's `rescueERC20`.
+    event SettleRewardSaleDeferred();
+
     // ── Initialisation params (ABI-encoded → BaseStrategy.initialize → _initialize) ──
     //
     // LEG SLOTS, not token identities. The `weth`/`mWeth`/`wethFeed` slots are leg A (the slot that
@@ -703,9 +709,29 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     /// @notice Full proportional unwind to the vault. The unwind — remove 100% liquidity, repay both
     ///         Moonwell borrows (self-funding any IL/fee shortfall), redeem collateral, sweep residual
     ///         cbBTC/WETH → USDC, clear state — lives in `LeveragedAeroManager.settleImpl()`; the
-    ///         realized USDC is pushed to the vault here (the manager never touches `vault()`).
+    ///         final gauge-reward tranche is sold here (best-effort, see below) and the realized USDC
+    ///         is pushed to the vault here (the manager never touches `vault()`).
     function _settle() internal override {
         LeveragedAeroManager.settleImpl();
+        // Sell the reward tranche the unwind's `gauge.withdraw` auto-claimed: `settleImpl` sweeps only
+        // the two LEG tokens, so without this the tranche never reaches the USDC pot `redeemSettled`
+        // pays holders from — it is stranded on a `Settled` strategy, recoverable only by the owner's
+        // two-transaction `rescueToVault` → `vault.rescueERC20`, and arriving there as a stray token
+        // rather than as shareholder proceeds.
+        //
+        // BEST-EFFORT, and that is the whole asymmetry with `flatten` (which calls the same
+        // `LeveragedAeroVenue` helper FAIL-CLOSED, with the proposer's floor): `flatten` is a
+        // RESUMABLE op on a book that stays `Executed` — a revert is just a retry after the feed
+        // recovers. `settle()` is TERMINAL, owner-driven and argument-less: a hard revert here would
+        // let a stale reward feed or a broken reward route BLOCK the fund's only exit. The self-call
+        // is what makes the swallow safe — the sale still fails closed INSIDE its own frame (oracle
+        // floor post-checked against the measured fill), so a caught revert rolls the swap back
+        // entirely and degrades to exactly the pre-fix behaviour: the tranche is left in place,
+        // rescuable now that the state is `Settled`. It is never sold blind.
+        try this.sellSettleRewardSelf() {}
+        catch {
+            emit SettleRewardSaleDeferred();
+        }
         // Discharge the accrued protocol fee from realized USDC BEFORE pushing the rest to the
         // vault. Pays `min(owed, balance)` to the live recipient; skips silently when recipient == 0
         // or owed == 0 (liability persists until a recipient exists — see edge note on `redeem`).
@@ -730,6 +756,17 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
             }
         }
         _pushAllToVault($.usdc);
+    }
+
+    /// @dev Self-only external wrapper so `_settle` can sell the final reward tranche best-effort via
+    ///      `try/catch` (H3 pattern, as `crystallizeFeesSelf`). Isolating the sale in its own call
+    ///      frame is what lets a stale reward feed / reverting reward route roll back ONLY the sale
+    ///      (tranche untouched, still rescuable) while the TERMINAL settle completes — see the
+    ///      flatten-vs-settle note at the call site and on `LeveragedAeroVenue.sellSettleRewardImpl`.
+    ///      Gated to `address(this)`; runs inside settle's own frame, so it adds no reentrancy surface.
+    function sellSettleRewardSelf() external {
+        if (msg.sender != address(this)) revert OnlySelf();
+        LeveragedAeroVenue.sellSettleRewardImpl();
     }
 
     /// @dev Crystallise management + HWM performance fees on the PRE-ACTION vault state. The caller
@@ -1394,10 +1431,13 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///           this the pair `rescueToVault(vault) → vault.rescueERC20(vault, attacker)` would
     ///           exfiltrate every escrowed claim. Escrows are recovered via `cancelRedeem`.
     ///         - the gauge reward token (read live from the gauge) WHILE EXECUTED, so a sweep can't
-    ///           bypass `compound()`. Once `Settled` that reason is gone — `compound` reverts
-    ///           `NotExecuted` and the unwind's `gauge.withdraw` auto-claims a final AERO tranche
-    ///           that `settleImpl` never sells — so post-settle it IS a stray and sweeping it to the
+    ///           bypass `compound()`. Once `Settled` that reason is gone (`compound` reverts
+    ///           `NotExecuted`), so post-settle the reward token IS a stray and sweeping it to the
     ///           vault (where the owner's non-asset `rescueERC20` applies) is the only recovery.
+    ///           `_settle` DOES sell the tranche its unwind auto-claims, so this is the RESIDUAL
+    ///           case only: the sale is best-effort and a stale reward feed / broken reward route
+    ///           leaves the tranche in place (`SettleRewardSaleDeferred`), as does a sub-micro-USD
+    ///           dust balance. That residue, plus any post-settle donation, is what this recovers.
     ///
     ///         The position NFT is never swept (no ERC-721 path).
     function rescueToVault(address token) external nonReentrant {
@@ -1440,7 +1480,10 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///         gate of its own and `_unwindLiquidity`'s mins are derived from the same `slot0()` it
     ///         burns at, so they bind nothing against a shoved tick — and the reward tranche the
     ///         unwind auto-claims is SOLD here, so the flat-book `nav()` (idle USDC only) is again the
-    ///         whole book rather than understating it for the length of the flat window.
+    ///         whole book rather than understating it for the length of the flat window. That sale is
+    ///         FAIL-CLOSED under the caller's floor, because a reverted `flatten` is just a retry;
+    ///         `_settle` sells the same tranche BEST-EFFORT, because a reverted `settle` is a fund
+    ///         that cannot exit (see the note at that call site).
     /// @param minRewardUsdcOut Minimum USDC out of the gauge-reward sale. Required nonzero only when
     ///                         a reward balance is actually present; the L9 oracle floor applies on
     ///                         top, so the effective bound is `max(this, floor)`.

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -91,7 +91,11 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     // Raised by `LeveragedAeroValuation.assetModeLeverUpPair`; re-declared here (same selector) so it is on
     // the strategy's public ABI for the rebalancer / frontend.
     error InsufficientIdleForLeverUp(uint256 needed, uint256 available);
-    error WidthOutOfBounds(); // rerange width off the tickSpacing grid or outside [minWidth, maxWidth]
+    // rerange width off the tickSpacing grid / outside [minWidth, maxWidth], OR a skew outside (0, 1e4)
+    // or one that starves either side of the range below a single tickSpacing. ONE error for both knobs:
+    // they are validated together, by the same two callers (`_initialize` and `rerange`), and a caller
+    // that has to fix its range params does not branch on which half was wrong.
+    error OutOfBounds();
     error ZeroShares(); // deposit would mint 0 shares (dust assets against a large book) — pay-for-nothing
 
     // ── Constants ──
@@ -166,9 +170,10 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         int24 cbBTCSwapTickSpacing; // tickSpacing of the leg B↔USDC swap pool (independent of the LP pool's)
         int24 wethSwapTickSpacing; // tickSpacing of the leg A↔USDC swap pool
         bool wethDeliversNative; // leg A's Moonwell market pays native ETH on borrow (wrap it to leg A)
-        uint24 width; // initial full range width in ticks (rerange spans width/2 each side)
+        uint24 width; // initial full range width in ticks (split across the tick by `skewBps`)
         uint24 minWidth; // lower bound for a proposer-supplied rerange width
         uint24 maxWidth; // upper bound for a proposer-supplied rerange width
+        uint16 skewBps; // initial fraction of `width` placed BELOW the tick (1e4 scale; 5000 == centred)
         // ── Risk params ──
         uint16 targetLtvBps; // Target LTV in bps (e.g. 5000 = 50%)
         uint16 maxLtvBps; // Maximum LTV cap in bps (e.g. 6500 = 65%)
@@ -258,11 +263,15 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         int24 cbBTCSwapTickSpacing; // leg B↔USDC swap-pool tickSpacing (NOT the LP pool's)
         int24 wethSwapTickSpacing; // leg A↔USDC swap-pool tickSpacing (NOT the LP pool's)
         // ── appended for the per-cycle rerange width band (keep byte-identical) ──
-        uint24 width; // current full range width in ticks (rerange spans width/2 each side)
+        uint24 width; // current full range width in ticks (split across the tick by `skewBps`)
         uint24 minWidth; // lower bound for a proposer-supplied rerange width
         uint24 maxWidth; // upper bound for a proposer-supplied rerange width
         // ── appended for the config-emergent pool shape (keep byte-identical) ──
         bool legBIsAsset; // DERIVED at init: leg-B slot == usdc → asset-as-a-leg shape (packs above)
+        // ── appended for the rerange SKEW (keep byte-identical). Placed HERE, not after the hedged
+        //    principals, so it free-packs into the existing tail slot (20 bytes used → 22) and
+        //    `hedgedDebtA`/`hedgedDebtB` keep a byte-identical slot AND offset. ──
+        uint16 skewBps; // fraction of `width` placed BELOW the pool tick (1e4 scale; 5000 == centred)
         // ── LAST fields: appended for the borrow-interest hedge (keep byte-identical) ──
         uint128 hedgedDebtA; // leg-A borrowed PRINCIPAL the LP hedges (packs with the widths above)
         uint128 hedgedDebtB; // leg-B borrowed principal the LP hedges (0 in asset-mode: leg B never borrows)
@@ -329,6 +338,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         uint24 minWidth;
         uint24 maxWidth;
         bool legBIsAsset;
+        uint16 skewBps;
         uint128 hedgedDebtA;
         uint128 hedgedDebtB;
     }
@@ -385,6 +395,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         v.minWidth = $.minWidth;
         v.maxWidth = $.maxWidth;
         v.legBIsAsset = $.legBIsAsset;
+        v.skewBps = $.skewBps;
         v.hedgedDebtA = $.hedgedDebtA;
         v.hedgedDebtB = $.hedgedDebtB;
     }
@@ -546,16 +557,17 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
 
         // Rerange width band: every width (init + per-cycle) must sit on the tickSpacing grid, and
         // the floor must span at least two spacings so an aligned range is never empty.
-        if (p.tickSpacing <= 0) revert WidthOutOfBounds();
+        if (p.tickSpacing <= 0) revert OutOfBounds();
         uint24 spacing = uint24(p.tickSpacing);
-        if (p.minWidth % spacing != 0 || p.maxWidth % spacing != 0) revert WidthOutOfBounds();
-        if (uint256(p.minWidth) < 2 * uint256(spacing)) revert WidthOutOfBounds();
-        if (p.minWidth > p.maxWidth) revert WidthOutOfBounds();
-        // Ceiling on the band: `_computeTickRange` spans `width/2` ticks each side of the pool tick,
-        // so a width beyond the full tick domain can only ever produce out-of-domain bounds (and, at
-        // the uint24 extreme, an int24 wrap in the `currentTick ± span` arithmetic).
-        if (uint256(p.maxWidth) > 2 * uint256(uint24(TickMath.MAX_TICK))) revert WidthOutOfBounds();
+        if (p.minWidth % spacing != 0 || p.maxWidth % spacing != 0) revert OutOfBounds();
+        if (uint256(p.minWidth) < 2 * uint256(spacing)) revert OutOfBounds();
+        if (p.minWidth > p.maxWidth) revert OutOfBounds();
+        // Ceiling on the band: `skewedTickRange` spans up to `width` ticks on ONE side of the pool tick
+        // (the skew limit), so a width beyond the full tick domain can only ever produce out-of-domain
+        // bounds (and, at the uint24 extreme, an int24 wrap in the `currentTick ± span` arithmetic).
+        if (uint256(p.maxWidth) > 2 * uint256(uint24(TickMath.MAX_TICK))) revert OutOfBounds();
         _checkWidth(p.width, p.tickSpacing, p.minWidth, p.maxWidth);
+        _checkSkew(p.width, p.skewBps, p.tickSpacing);
 
         uint16 cfBps = _readCollateralFactor(p.comptroller, p.mUsdc);
         if (p.targetLtvBps > p.maxLtvBps) revert TargetLtvExceedsMax();
@@ -622,6 +634,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         $.cbBTCSwapTickSpacing = p.cbBTCSwapTickSpacing;
         $.wethSwapTickSpacing = p.wethSwapTickSpacing;
         $.width = p.width;
+        $.skewBps = p.skewBps;
         $.minWidth = p.minWidth;
         $.maxWidth = p.maxWidth;
         $.legBIsAsset = legBIsAsset_;
@@ -632,9 +645,28 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///      per-cycle width): on the tickSpacing grid and inside `[minWidth_, maxWidth_]`. The band
     ///      itself is validated once at init (multiples, `minWidth_ >= 2 × spacing`, min ≤ max).
     function _checkWidth(uint24 width_, int24 tickSpacing_, uint24 minWidth_, uint24 maxWidth_) private pure {
-        if (tickSpacing_ <= 0) revert WidthOutOfBounds();
-        if (width_ % uint24(tickSpacing_) != 0) revert WidthOutOfBounds();
-        if (width_ < minWidth_ || width_ > maxWidth_) revert WidthOutOfBounds();
+        if (tickSpacing_ <= 0) revert OutOfBounds();
+        if (width_ % uint24(tickSpacing_) != 0) revert OutOfBounds();
+        if (width_ < minWidth_ || width_ > maxWidth_) revert OutOfBounds();
+    }
+
+    /// @dev Skew band check shared by `_initialize` (the genesis skew) and `rerange` (each per-cycle
+    ///      skew). `skewBps_` is the fraction of `width_` placed BELOW the pool tick on a 1e4 scale, so
+    ///      5000 is centred; the complement goes above. Always called AFTER `_checkWidth`, which is what
+    ///      establishes `tickSpacing_ > 0` for the cast below.
+    ///
+    ///      THE GUARD IS SPAN-BASED, NOT A FLAT bps BAND, ON PURPOSE: a flat band cannot protect small
+    ///      widths (at `width == 2 × tickSpacing` even a mild 2500 skew starves the lower side to half a
+    ///      spacing, while at `width == 200 × tickSpacing` a 100-bps skew is perfectly safe). BOTH sides
+    ///      must span at least one `tickSpacing`, or the DOWN-aligned range stops STRICTLY BRACKETING the
+    ///      pool tick (`tickLower <= tick < tickUpper`) — the invariant `assetModeSplit` relies on to size
+    ///      a fresh range two-sided, and the reason a one-sided range is a fail-closed `DegenerateRange`.
+    function _checkSkew(uint24 width_, uint16 skewBps_, int24 tickSpacing_) private pure {
+        if (skewBps_ == 0 || skewBps_ >= 10000) revert OutOfBounds();
+        uint256 lowerSpan = (uint256(width_) * uint256(skewBps_)) / 10000;
+        uint256 upperSpan = uint256(width_) - lowerSpan; // exact complement, matching `skewedTickRange`
+        uint256 spacing = uint256(uint24(tickSpacing_));
+        if (lowerSpan < spacing || upperSpan < spacing) revert OutOfBounds();
     }
 
     /// @dev USDC collateral factor (bps) from `Comptroller.markets(mUsdc)`. ABI is
@@ -1041,30 +1073,51 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         }
     }
 
-    /// @notice Recenter the CL position on the current pool tick WITHOUT swapping, via
-    ///         `LeveragedAeroManager.rerangeImpl()`. The calm-gate runs FIRST, so a recenter can never
+    /// @notice Re-range the CL position around the current pool tick WITHOUT swapping, via
+    ///         `LeveragedAeroManager.rerangeImpl()`. The calm-gate runs FIRST, so a re-range can never
     ///         execute at a manipulated tick. No swap → principal conserved (IL is realized only on a
     ///         true exit); the collected ratio can't match the new range, so a remainder of ONE
-    ///         borrowed leg is left idle — `nav()` prices it, so the recenter is NAV-neutral and the
+    ///         borrowed leg is left idle — `nav()` prices it, so the re-range is NAV-neutral and the
     ///         remainder stays redeployable. Debt + collateral are untouched (health preserved); a new
     ///         tokenId is minted (Slipstream ticks are immutable), the old empty NFT is harmless dust.
     ///
     ///         NO fee crystallisation: rerange changes neither supply nor NAV, so the streaming fee is
     ///         deferred to the next crystallize point (not lost) and the HWM is unaffected.
-    /// @param width_  Full range width in ticks for this cycle (span = `width_/2` each side of the
-    ///                calm tick). Must sit on the tickSpacing grid inside `[minWidth, maxWidth]`;
-    ///                persisted as the new `width` so `nav()`/subsequent mints see it — including on
-    ///                a FLAT book, where the recenter itself is a no-op but the width still takes
-    ///                effect for the next `deployIdle` / `compound` mint. Centring is grid-approximate:
-    ///                both bounds round DOWN onto the spacing grid, so the realised range sits off the
-    ///                calm tick by up to one spacing (largest when `width_ / tickSpacing` is odd).
-    /// @param minLiq0 Minimum token0 the re-add must consume (two-sided slippage guard).
-    /// @param minLiq1 Minimum token1 the re-add must consume (two-sided slippage guard).
-    function rerange(uint24 width_, uint256 minLiq0, uint256 minLiq1) external onlyProposer nonReentrant {
+    /// @param width_   Full range width in ticks for this cycle. Must sit on the tickSpacing grid inside
+    ///                 `[minWidth, maxWidth]`.
+    /// @param skewBps_ WHERE that width sits relative to the calm tick: the fraction of `width_` placed
+    ///                 BELOW it, on a 1e4 scale. `5000` is centred (`width_/2` each side, the historical
+    ///                 behaviour); `3500` puts 35% of the width below spot and 65% above, which is how a
+    ///                 rebalancer expresses a directional view without swapping. Must be in `(0, 10000)`
+    ///                 AND leave both sides spanning at least one `tickSpacing` — see `_checkSkew`.
+    ///
+    ///                 Placement is grid-approximate: both bounds round DOWN onto the spacing grid, so
+    ///                 the realised range sits off the requested split by up to one spacing.
+    /// @param minLiq0  Minimum token0 the re-add must consume (two-sided slippage guard).
+    /// @param minLiq1  Minimum token1 the re-add must consume (two-sided slippage guard).
+    ///
+    /// @dev BOTH `width_` and `skewBps_` are PERSISTED here, in this frame, BEFORE the delegatecall —
+    ///      two things ride on that. (1) `nav()` and every subsequent mint (`deployIdle` / `compound`)
+    ///      read the STORED pair, so the proposer's choice must outlive the call. (2) The write must
+    ///      land even on a FLAT book, where `rerangeImpl` returns early and the re-range itself is a
+    ///      no-op but the new range still has to take effect for the next redeploy — which is why the
+    ///      persists are AHEAD of the impl rather than inside it (the impl used to store `width` itself,
+    ///      ahead of its own bail-out; the ordering property is unchanged, only the frame moved). The
+    ///      relocation is for EIP-170 headroom: this frame already holds `_layout()` for the two checks,
+    ///      so the writes cost ~20 bytes here versus ~70 in the manager library, which is at the cap.
+    ///      Exactly the same move `adjustLeverage`'s target-LTV write already makes.
+    function rerange(uint24 width_, uint16 skewBps_, uint256 minLiq0, uint256 minLiq1)
+        external
+        onlyProposer
+        nonReentrant
+    {
         if (_state != State.Executed) revert NotExecuted();
         Layout storage $ = _layout();
         _checkWidth(width_, $.tickSpacing, $.minWidth, $.maxWidth);
-        LeveragedAeroManager.rerangeImpl(width_, minLiq0, minLiq1);
+        _checkSkew(width_, skewBps_, $.tickSpacing);
+        $.width = width_;
+        $.skewBps = skewBps_;
+        LeveragedAeroManager.rerangeImpl(minLiq0, minLiq1);
     }
 
     /// @notice Retarget the position's LTV to `targetLtvBps_` (borrow/repay; no new USDC). Collateral

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -176,6 +176,8 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         p.minWidth = 200;
         p.maxWidth = 20_000;
         p.skewBps = SKEW_CENTERED;
+        p.minSkewBps = 1000; // governance band: wide enough for every skew this suite drives
+        p.maxSkewBps = 9000;
         p.targetLtvBps = TARGET_LTV_BPS;
         p.maxLtvBps = 6500;
         p.minHealthBps = 12_000;
@@ -439,6 +441,93 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         assertApproxEqAbs(
             (debtAfter * 10_000) / collateralAfter, uint256(TARGET_LTV_BPS), 2, "LTV still on target after the skew"
         );
+    }
+
+    // ==================== RERANGE MUST NOT DRAW IDLE USDC (asset-mode) ====================
+    //
+    // THE ASSET-MODE HAZARD: `rerangeImpl` re-adds "the collected legs" by reading its two leg BALANCES
+    // after the unwind. In this shape leg B IS the unit of account, so that balance is not just what the
+    // unwind collected — it is also every undeployed deposit and the whole redeem cover budget. Offering
+    // it to the mint would let a re-range silently pull UNLEVERED idle USDC into the LP: value-conserving
+    // but a capability no entrypoint declares (`deployIdle` is THE path that adds idle, and it levers it
+    // first), and it shrinks the cover budget a redeem depends on. The fix snapshots leg B BEFORE the
+    // unwind and offers only the delta — exactly the distinction `redeemUnwindImpl`'s `idleUsdcBefore`
+    // snapshot draws.
+    //
+    // Both tests measure against a BASELINE re-range run from the same post-genesis snapshot with no
+    // extra idle, so the assertion is an exact identity (`idle_after == baseline + seed`) rather than an
+    // inequality: the seeded USDC must be neither consumed nor otherwise moved, to the wei.
+
+    /// @dev Re-range at an EXTREME (but legal) skew with a large idle USDC balance present. THE
+    ///      DIRECTION MATTERS: leg A is token1 here, so pushing the range ABOVE spot (skew 2000: 800
+    ///      ticks below, 3200 above) is what makes the new range hungriest for token0 — the unit of
+    ///      account — while the unwind hands it a mix sized for the OLD range. That is precisely the
+    ///      shape where an implementation reading the raw leg-B balance tops the mint up out of idle.
+    ///      (The mirror skew is not a regression test at all: its range wants MORE leg A and less USDC,
+    ///      so the collected USDC already covers it and no idle is drawn either way.)
+    function testSkewedRerangeDoesNotDrawIdleUsdcIntoTheLp() public {
+        _execute(SEED);
+
+        uint256 snap = vm.snapshotState();
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, 2000, 0, 0);
+        uint256 baselineIdle = usdc.balanceOf(address(strategy));
+        vm.revertToState(snap);
+
+        uint256 idleSeed = 400_000e6;
+        usdc.mint(address(strategy), idleSeed);
+        uint256 tokenIdBefore = strategy.layout().tokenId;
+
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, 2000, 0, 0);
+
+        assertEq(
+            usdc.balanceOf(address(strategy)),
+            baselineIdle + idleSeed,
+            "the idle USDC was neither drawn into the LP nor otherwise moved"
+        );
+        assertTrue(strategy.layout().tokenId != tokenIdBefore, "the re-range still minted a fresh position");
+        assertGt(npm.liquidityOf(strategy.layout().tokenId), 0, "...with real liquidity in it");
+        assertEq(strategy.layout().skewBps, 2000, "...at the requested skew");
+    }
+
+    /// @dev The CENTRED case, after a price drift — the pre-existing leak this fix also closes. Skew is
+    ///      not the cause: any re-range that leaves the collected pair short of the new range's desired
+    ///      ratio would have topped it up out of idle. The drift is what makes the collected ratio wrong
+    ///      at an unchanged `skewBps`.
+    function testCenteredRerangeAfterAPriceDriftDoesNotDrawIdleUsdc() public {
+        _execute(SEED);
+
+        // Drift the pool (spot AND TWAP together, so the calm-gate stays open) and keep the leg-A oracle
+        // on the same mark, or the fixture would be testing an oracle/pool divergence instead.
+        int24 newTick = TICK + 300;
+        pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(newTick));
+        pool.setTick(newTick);
+        legAFeed.setAnswer(int256(_legAPriceFromSqrtP(pool.sqrtPriceX96())));
+        // FIXTURE ONLY: `MockNpm` custodies exactly what it was minted, so after a price move its
+        // `collect` owes a leg-A amount re-priced at the NEW sqrtP that it never received. Float it, the
+        // way a real pool's other LPs do. Nothing here touches the strategy's USDC, which is what the
+        // assertion below is about.
+        legA.mint(address(npm), 1_000e8);
+
+        uint256 snap = vm.snapshotState();
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, SKEW_CENTERED, 0, 0);
+        uint256 baselineIdle = usdc.balanceOf(address(strategy));
+        vm.revertToState(snap);
+
+        uint256 idleSeed = 250_000e6;
+        usdc.mint(address(strategy), idleSeed);
+
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, SKEW_CENTERED, 0, 0);
+
+        assertEq(
+            usdc.balanceOf(address(strategy)),
+            baselineIdle + idleSeed,
+            "a centred recenter leaves idle USDC untouched too"
+        );
+        assertGt(npm.liquidityOf(strategy.layout().tokenId), 0, "the recenter still minted real liquidity");
     }
 
     // ==================== ASSET-MODE LEVER UP (idle-funded) ====================

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -70,6 +70,8 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
     ///      worth ~$100k needs a NEGATIVE tick (`ln(1e-3)/ln(1.0001) ~ -69078`, aligned to the grid).
     int24 internal constant TICK = -69_100;
     uint24 internal constant WIDTH = 4000;
+    /// @dev The centred skew — `width/2` each side, i.e. the pre-skew behaviour.
+    uint16 internal constant SKEW_CENTERED = 5000;
     uint16 internal constant TARGET_LTV_BPS = 5000;
     uint8 internal constant LEG_A_DECIMALS = 8;
     uint256 internal constant P_USDC = 1e8;
@@ -173,6 +175,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         p.width = WIDTH;
         p.minWidth = 200;
         p.maxWidth = 20_000;
+        p.skewBps = SKEW_CENTERED;
         p.targetLtvBps = TARGET_LTV_BPS;
         p.maxLtvBps = 6500;
         p.minHealthBps = 12_000;
@@ -213,7 +216,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
     }
 
     function _centeredRange() internal view returns (int24, int24) {
-        return LeveragedAeroValuation.centeredTickRange(address(pool), SPACING, WIDTH);
+        return LeveragedAeroValuation.skewedTickRange(address(pool), SPACING, WIDTH, SKEW_CENTERED);
     }
 
     /// @dev On-chain collateral (USDC face) and leg-A debt, on the strategy's own health basis.
@@ -362,6 +365,80 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         vm.prank(proposer);
         vm.expectRevert(LeveragedAeroValuation.DegenerateRange.selector);
         strategy.deployIdle(100_000e6, 0);
+    }
+
+    // ==================== RERANGE SKEW (asset-mode) ====================
+
+    /// @dev The SKEWED range for this fixture, recomputed independently of the production path.
+    function _skewedRange(uint16 skewBps_) internal view returns (int24, int24) {
+        return LeveragedAeroValuation.skewedTickRange(address(pool), SPACING, WIDTH, skewBps_);
+    }
+
+    /**
+     * @dev A skewed re-range in asset-mode must land on the SKEWED range and leave a book that is still
+     *      SIZEABLE against it. The second half is the one that matters here: asset-mode's whole deploy
+     *      path goes through `assetModeSplit`, which fails closed on a one-sided range, so a skew that
+     *      produced a range not bracketing spot would not merely be suboptimal — it would brick every
+     *      subsequent `deployIdle` / lever-up. The split is therefore run against the realised range and
+     *      asserted to solve.
+     */
+    function testRerangeSkewedAssetModeSizesAgainstTheSkewedRange() public {
+        _execute(SEED);
+        uint256 oldTokenId = strategy.layout().tokenId;
+        uint256 navBefore = strategy.nav();
+
+        (int24 expLower, int24 expUpper) = _skewedRange(3500);
+        (int24 cenLower, int24 cenUpper) = _skewedRange(SKEW_CENTERED);
+        assertTrue(expLower != cenLower && expUpper != cenUpper, "3500 must actually move the range off centre");
+
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, 3500, 0, 0);
+
+        assertEq(strategy.layout().posTickLower, expLower, "minted at the SKEWED lower bound");
+        assertEq(strategy.layout().posTickUpper, expUpper, "minted at the SKEWED upper bound");
+        assertEq(strategy.layout().skewBps, 3500, "the skew is persisted");
+        assertTrue(strategy.layout().tokenId != oldTokenId, "a fresh tokenId");
+        assertApproxEqRel(strategy.nav(), navBefore, 1e16, "a no-swap re-range is NAV-neutral");
+
+        // The realised range still brackets spot, so `assetModeSplit` can size against it — asserted by
+        // running the real thing rather than by re-deriving the geometry.
+        (uint256 c, uint256 u, uint256 a) = _expectedSplit(100_000e6, expLower, expUpper);
+        assertEq(c + u, 100_000e6, "the skewed range is still two-sided and sizeable");
+        assertGt(a, 0, "...with a real leg-A borrow behind it");
+    }
+
+    /**
+     * @dev THE PERSISTENCE THAT MATTERS ECONOMICALLY: the next `deployIdle` sizes its collateral / borrow
+     *      split against the STORED SKEWED range, not against a centred one. The two candidate sizings are
+     *      computed and asserted to DIFFER first, so the test discriminates — an implementation that
+     *      dropped `skewBps` on the way to storage (or re-derived a centred range at mint time) would size
+     *      at `expCCentered` and fail here, not pass on a loose tolerance.
+     */
+    function testDeployIdleAfterSkewedRerangeUsesStoredSkewedRange() public {
+        _execute(SEED);
+
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, 3500, 0, 0);
+
+        int24 lower = strategy.layout().posTickLower;
+        int24 upper = strategy.layout().posTickUpper;
+        (int24 cenLower, int24 cenUpper) = _skewedRange(SKEW_CENTERED);
+
+        uint256 topUp = 250_000e6;
+        (uint256 expCSkewed,,) = _expectedSplit(topUp, lower, upper);
+        (uint256 expCCentered,,) = _expectedSplit(topUp, cenLower, cenUpper);
+        assertTrue(expCSkewed != expCCentered, "the skewed and centred sizings must differ, or this proves nothing");
+
+        (uint256 collateralBefore,) = _collateralAndDebt();
+        usdc.mint(address(strategy), topUp);
+        vm.prank(proposer);
+        strategy.deployIdle(topUp, 0);
+
+        (uint256 collateralAfter, uint256 debtAfter) = _collateralAndDebt();
+        assertEq(collateralAfter - collateralBefore, expCSkewed, "deployIdle sized C against the STORED SKEWED range");
+        assertApproxEqAbs(
+            (debtAfter * 10_000) / collateralAfter, uint256(TARGET_LTV_BPS), 2, "LTV still on target after the skew"
+        );
     }
 
     // ==================== ASSET-MODE LEVER UP (idle-funded) ====================

--- a/test/leveraged-aero/LeveragedAeroAssetModeSizing.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeSizing.unit.t.sol
@@ -355,23 +355,168 @@ contract LeveragedAeroAssetModeSizingUnitTest is Test {
     // ==================== RANGE GEOMETRY (why genesis is always two-sided) ====================
 
     /**
-     * @dev `centeredTickRange` must STRICTLY BRACKET the current tick for every width init permits
-     *      (`width >= 2 x tickSpacing`). This is load-bearing for asset-mode: it is what guarantees a
-     *      FRESH range is never one-sided, so `executeImpl` can always size. Only a STORED range the
-     *      price has since left can degenerate — hence `deployIdle`'s documented `rerange`-first
-     *      remedy.
+     * @dev `skewedTickRange` must STRICTLY BRACKET the current tick at the CENTRED skew for every width
+     *      init permits (`width >= 2 x tickSpacing`). This is load-bearing for asset-mode: it is what
+     *      guarantees a FRESH range is never one-sided, so `executeImpl` can always size. Only a STORED
+     *      range the price has since left can degenerate — hence `deployIdle`'s documented
+     *      `rerange`-first remedy. (The skewed generalisation is the fuzz two tests below.)
      */
     function testFuzzCenteredRangeStrictlyBracketsTheTick(int24 tick, uint24 width) public {
         tick = int24(int256(bound(int256(tick), -600_000, 600_000)));
         width = uint24(bound(uint256(width), 2, 4000)) * uint24(SPACING);
         _setPoolTick(int24(tick / SPACING * SPACING)); // an on-grid tick, as a real pool reports
 
-        (int24 lower, int24 upper) = LeveragedAeroValuation.centeredTickRange(address(pool), SPACING, width);
+        (int24 lower, int24 upper) = LeveragedAeroValuation.skewedTickRange(address(pool), SPACING, width, 5000);
         int24 current = pool.tick();
         assertLe(lower, current, "lower bound must not sit above the current tick");
         assertGt(upper, current, "upper bound must sit strictly above the current tick");
         assertEq(lower % SPACING, 0, "lower bound on the spacing grid");
         assertEq(upper % SPACING, 0, "upper bound on the spacing grid");
+    }
+
+    // ==================== RANGE GEOMETRY: THE SKEW ====================
+
+    /// @dev `LeveragedAeroValuation._alignTick`, restated so the equalities below compare against an
+    ///      INDEPENDENT expression rather than against the code under test.
+    function _alignDown(int24 tick) internal pure returns (int24) {
+        int24 rem = tick % SPACING;
+        if (rem < 0) rem += SPACING;
+        return tick - rem;
+    }
+
+    /**
+     * @dev SKEW 5000 IS THE OLD CENTRED FORMULA, BIT FOR BIT — the compatibility pin for every live
+     *      clone and every existing test fixture. The pre-skew math was `span = width / 2` each side; the
+     *      skewed form computes `lowerSpan = width x 5000 / 1e4` and `upperSpan = width - lowerSpan`,
+     *      which coincide exactly whenever `width` is even (and every width on an even spacing grid is).
+     *      Asserted against the OLD expression verbatim, at on- AND off-grid ticks and both signs, so it
+     *      is a real regression pin and not a restatement of the new code.
+     */
+    function testSkewedRangeReproducesCenteredAtHalf() public {
+        uint24[4] memory widths = [uint24(200), 1000, 4000, 40_000];
+        int24[4] memory ticks = [int24(0), TICK, TICK + 37, -TICK - 37]; // two of them deliberately off-grid
+        for (uint256 t; t < ticks.length; ++t) {
+            int24 current = ticks[t];
+            _setPoolTick(current);
+            for (uint256 i; i < widths.length; ++i) {
+                (int24 lower, int24 upper) =
+                    LeveragedAeroValuation.skewedTickRange(address(pool), SPACING, widths[i], 5000);
+                int24 span = int24(widths[i] / 2); // the pre-skew expression, verbatim
+                assertEq(lower, _alignDown(current - span), "lower == the OLD centred lower bound");
+                assertEq(upper, _alignDown(current + span), "upper == the OLD centred upper bound");
+            }
+        }
+    }
+
+    /**
+     * @dev THE GENERALISED BRACKETING INVARIANT. Over the whole `_checkSkew`-LEGAL set — any in-domain
+     *      tick, any aligned width in the init band, and any skew whose two spans each reach at least one
+     *      `tickSpacing` — the range must still strictly bracket the tick, sit on the grid, and measure
+     *      `width` to within one spacing. This is what licenses the skew at all: `assetModeSplit` can only
+     *      size a range that brackets the price, so if ANY legal skew produced a one-sided range the
+     *      feature would brick the deploy path.
+     *
+     *      The legal skew floor is derived, not guessed: `lowerSpan >= spacing` means
+     *      `skew >= ceil(spacing x 1e4 / width)`, and the same bound mirrored from the top caps the upper
+     *      side (`upperSpan = width - lowerSpan >= spacing` follows algebraically).
+     */
+    function testFuzzSkewedRangeStrictlyBracketsTheTick(int24 tick, uint24 width, uint16 skewBps) public {
+        tick = int24(int256(bound(int256(tick), -600_000, 600_000)));
+        width = uint24(bound(uint256(width), 2, 4000)) * uint24(SPACING);
+        uint256 spacing = uint256(uint24(SPACING));
+        uint256 minSkew = (spacing * 10_000 + uint256(width) - 1) / uint256(width); // ceil
+        skewBps = uint16(bound(uint256(skewBps), minSkew, 10_000 - minSkew));
+
+        _setPoolTick(int24(tick / SPACING * SPACING)); // an on-grid tick, as a real pool reports
+        int24 current = pool.tick();
+
+        (int24 lower, int24 upper) = LeveragedAeroValuation.skewedTickRange(address(pool), SPACING, width, skewBps);
+
+        int24 maxAligned = (TickMath.MAX_TICK / SPACING) * SPACING;
+        assertLe(lower, current, "lower bound must not sit above the current tick");
+        assertGt(upper, current, "upper bound must sit STRICTLY above the current tick");
+        assertEq(lower % SPACING, 0, "lower bound on the spacing grid");
+        assertEq(upper % SPACING, 0, "upper bound on the spacing grid");
+        assertGe(lower, -maxAligned, "lower bound stays inside the aligned tick domain");
+        assertLe(upper, maxAligned, "upper bound stays inside the aligned tick domain");
+
+        // The realised width claim holds only when NEITHER domain clamp fired: a clamped range is
+        // deliberately TRUNCATED (that is the clamp's whole job), so measuring it against `width` would
+        // be asserting the opposite of the intended behaviour. Reconstruct the pre-clamp bounds from the
+        // same align-down rule to tell the two cases apart — the clamped ones are covered by
+        // `testSkewedRangeClampsAtTickDomainEdges`, which asserts they stay mintable.
+        uint256 lowerSpan = (uint256(width) * uint256(skewBps)) / 10_000;
+        int24 nominalLower = _alignDown(int24(int256(current) - int256(lowerSpan)));
+        int24 nominalUpper = _alignDown(int24(int256(current) + int256(uint256(width) - lowerSpan)));
+        if (nominalLower >= -maxAligned && nominalUpper <= maxAligned) {
+            // Each bound aligns DOWN independently, so the realised width can differ from `width` by at
+            // most the two alignment remainders' difference — strictly less than one spacing.
+            assertApproxEqAbs(
+                uint256(int256(upper - lower)), uint256(width), spacing, "realised span == width (+/- one spacing)"
+            );
+        } else {
+            assertLt(
+                uint256(int256(upper - lower)), uint256(width) + spacing, "a clamped range is never WIDER than asked"
+            );
+        }
+    }
+
+    /**
+     * @dev THE SEMANTIC CLAIM: `skewBps` really is the fraction of the width placed BELOW the tick.
+     *      Asserted at a large width, where the one-spacing alignment drift is 0.025% of the span, and
+     *      stated first as an ABSOLUTE tick tolerance of one spacing (not a loose ratio) so it cannot
+     *      pass on slack — then restated as the ratio a rebalancer actually reasons about.
+     */
+    function testSkewedRangeSpanRatioMatchesSkew() public {
+        uint24 width = 400_000; // 4000 spacings
+        _setPoolTick(TICK);
+        int24 current = pool.tick();
+        uint256 spacing = uint256(uint24(SPACING));
+        uint16[5] memory skews = [uint16(1000), 2500, 5000, 7500, 9000];
+
+        for (uint256 i; i < skews.length; ++i) {
+            (int24 lower, int24 upper) = LeveragedAeroValuation.skewedTickRange(address(pool), SPACING, width, skews[i]);
+            uint256 below = uint256(int256(current - lower));
+            uint256 total = uint256(int256(upper - lower));
+
+            assertApproxEqAbs(
+                below, (uint256(width) * uint256(skews[i])) / 10_000, spacing, "below-span == skew x width"
+            );
+            assertApproxEqAbs(total, uint256(width), spacing, "total span == width");
+            assertApproxEqRel(
+                (below * 10_000) / total, uint256(skews[i]), 1e15, "realised fraction below spot == skewBps"
+            );
+        }
+    }
+
+    /**
+     * @dev THE DOMAIN EDGES, which the skew makes reachable in a way centring never did: at the extreme
+     *      legal skews essentially the WHOLE width lands on ONE side of the tick, so a bound near
+     *      ±MAX_TICK leaves the tick domain outright. The `±_alignTick(MAX_TICK)` clamps must leave both
+     *      bounds ON the spacing grid, inside the domain and strictly ordered — i.e. MINTABLE, not merely
+     *      non-panicking. `getSqrtRatioAtTick` is called on both as the proof (it reverts out of domain,
+     *      which is the unhelpful deep-in-TickMath failure the clamps exist to prevent).
+     */
+    function testSkewedRangeClampsAtTickDomainEdges() public {
+        int24 maxAligned = (TickMath.MAX_TICK / SPACING) * SPACING;
+        uint24 width = 1_774_400; // ~2 x MAX_TICK: the init ceiling on `maxWidth`, aligned to SPACING
+        int24[2] memory ticks = [maxAligned, -maxAligned];
+        uint16[2] memory skews = [uint16(1), 9999]; // the extreme legal skews at this width
+
+        for (uint256 t; t < ticks.length; ++t) {
+            _setPoolTick(ticks[t]);
+            for (uint256 i; i < skews.length; ++i) {
+                (int24 lower, int24 upper) =
+                    LeveragedAeroValuation.skewedTickRange(address(pool), SPACING, width, skews[i]);
+                assertEq(lower % SPACING, 0, "clamped lower is still on the spacing grid");
+                assertEq(upper % SPACING, 0, "clamped upper is still on the spacing grid");
+                assertGe(lower, -maxAligned, "lower stays inside the aligned tick domain");
+                assertLe(upper, maxAligned, "upper stays inside the aligned tick domain");
+                assertLt(lower, upper, "the clamped range is still non-empty");
+                TickMath.getSqrtRatioAtTick(lower); // reverts if the clamp left the domain
+                TickMath.getSqrtRatioAtTick(upper);
+            }
+        }
     }
 
     // ==================== LEVER-UP SIZING (`assetModeLeverUpPair`) ====================

--- a/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
@@ -206,6 +206,8 @@ contract LeveragedAeroCompoundHedgeUnitTest is Test {
         p.minWidth = 200;
         p.maxWidth = 20_000;
         p.skewBps = 5000;
+        p.minSkewBps = 1000; // governance band (unused here — this suite never reranges)
+        p.maxSkewBps = 9000;
         p.targetLtvBps = TARGET_LTV_BPS;
         p.maxLtvBps = 6500;
         p.minHealthBps = 12_000;

--- a/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroCompoundHedge.unit.t.sol
@@ -205,6 +205,7 @@ contract LeveragedAeroCompoundHedgeUnitTest is Test {
         p.width = WIDTH;
         p.minWidth = 200;
         p.maxWidth = 20_000;
+        p.skewBps = 5000;
         p.targetLtvBps = TARGET_LTV_BPS;
         p.maxLtvBps = 6500;
         p.minHealthBps = 12_000;
@@ -572,7 +573,7 @@ contract LeveragedAeroCompoundHedgeUnitTest is Test {
         legA.mint(address(npm), 1_000e8);
 
         vm.prank(proposer);
-        strategy.rerange(WIDTH, 0, 0);
+        strategy.rerange(WIDTH, 5000, 0, 0);
 
         assertGt(legA.balanceOf(address(strategy)), 0, "rerange left an idle leg-A remainder");
         assertEq(_driftLegA(), 0, "an idle-leg remainder is NOT interest drift");

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -156,7 +156,10 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         return LeveragedAerodromeCLStrategy(payable(Clones.clone(address(template))));
     }
 
-    function _init(LeveragedAerodromeCLStrategy.InitParams memory p) internal returns (LeveragedAerodromeCLStrategy s) {
+    function _init(LeveragedAerodromeCLStrategy.InitParams memory p)
+        internal
+        returns (LeveragedAerodromeCLStrategy s)
+    {
         s = _clone();
         s.initialize(address(vault), proposer, abi.encode(p));
     }

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -72,6 +72,20 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     /// @dev `2 * TickMath.MAX_TICK` — the ceiling `_initialize` enforces on `maxWidth`.
     uint24 internal constant MAX_BAND_WIDTH = 1_774_544;
 
+    /// @dev The strategy's ERC-7201 base slot (private there):
+    ///      `keccak256(abi.encode(uint256(keccak256("leveraged.aero.cl.storage")) - 1)) & ~bytes32(uint256(0xff))`.
+    bytes32 internal constant STORAGE_SLOT = 0x405ae0b144079093e970849fdffdcb2a514e44968598c6c5c73444496e844900;
+
+    /// @dev Slots consumed by `Layout` BEFORE its packed tail, i.e. the index of the slot holding
+    ///      `cbBTCDecimals … skewBps`. Counted off the struct: 11 addresses (0-10), `maxDelay` (11),
+    ///      `gracePeriod` (12), the packed `calmDeviationTicks`/`twapWindow`/`comptroller` slot (13),
+    ///      `npm`/`gauge`/`swapRouter` (14-16), the packed `tickSpacing` + risk-params slot (17),
+    ///      `tokenId` (18), the packed ticks + fee-params + `feeRecipient` slot (19), `hwmPerShare` (20),
+    ///      `lastFeeAccrualTimestamp` (21), `protocolFeeOwed` (22), `aeroUsdFeed` (23),
+    ///      `nextRedeemRequestId` (24), the `redeemRequests` mapping (25) — so the tail is slot 26 and
+    ///      the two `uint128` hedged principals share slot 27.
+    uint256 internal constant TAIL_SLOT_OFFSET = 26;
+
     function setUp() public {
         usdc = new MockToken("USD Coin", "USDC", 6);
         legA = new MockToken("Leg A", "LEGA", 18);
@@ -128,6 +142,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         p.width = 4000;
         p.minWidth = 200; // 2 x SPACING
         p.maxWidth = 20_000;
+        p.skewBps = 5000; // centred — the historical behaviour, and the baseline every skew test perturbs
         p.targetLtvBps = 5000;
         p.maxLtvBps = 6500;
         p.minHealthBps = 12_000;
@@ -141,10 +156,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         return LeveragedAerodromeCLStrategy(payable(Clones.clone(address(template))));
     }
 
-    function _init(LeveragedAerodromeCLStrategy.InitParams memory p)
-        internal
-        returns (LeveragedAerodromeCLStrategy s)
-    {
+    function _init(LeveragedAerodromeCLStrategy.InitParams memory p) internal returns (LeveragedAerodromeCLStrategy s) {
         s = _clone();
         s.initialize(address(vault), proposer, abi.encode(p));
     }
@@ -576,49 +588,49 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     function testInitRevertsWhenWidthOffTheSpacingGrid() public {
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.width = 4050; // not a multiple of SPACING
-        _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
     }
 
     function testInitRevertsWhenMinWidthBelowTwoSpacings() public {
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.minWidth = 100; // 1 x SPACING
-        _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
     }
 
     function testInitRevertsWhenMinWidthAboveMaxWidth() public {
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.minWidth = 30_000;
         p.maxWidth = 20_000;
-        _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
     }
 
     function testInitRevertsWhenWidthBelowMinWidth() public {
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.width = 100;
-        _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
     }
 
     function testInitRevertsWhenWidthAboveMaxWidth() public {
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.width = 30_000;
-        _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
     }
 
     function testInitRevertsWhenBandBoundsOffTheSpacingGrid() public {
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.minWidth = 250;
-        _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
 
         p = _baseParams();
         p.maxWidth = 20_050;
-        _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
     }
 
     function testInitRevertsOnNonPositiveTickSpacing() public {
         pool.setTickSpacing(0);
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.tickSpacing = 0;
-        _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
     }
 
     /// @dev A NEGATIVE spacing must fail the same way — `int24` is signed and `<= 0`, not `== 0`, is
@@ -627,15 +639,15 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         pool.setTickSpacing(-100);
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.tickSpacing = -100;
-        _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
     }
 
-    /// @dev `_computeTickRange` spans `width/2` each side of the pool tick, so the band is capped at
-    ///      the full tick domain (`2 x TickMath.MAX_TICK`). Both edges of the cap.
+    /// @dev `skewedTickRange` spans up to `width` ticks on ONE side of the pool tick (the skew limit),
+    ///      so the band is capped at the full tick domain (`2 x TickMath.MAX_TICK`). Both edges of the cap.
     function testInitRevertsWhenMaxWidthExceedsTheTickDomain() public {
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.maxWidth = MAX_BAND_WIDTH + uint24(uint24(SPACING)); // aligned, but past the ceiling
-        _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
     }
 
     function testInitAcceptsMaxWidthAtTheTickDomainEdge() public {
@@ -851,26 +863,212 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         if (ok) {
             assertEq(_init(p).layout().width, width_, "accepted width persisted");
         } else {
-            _expectInitRevert(p, LeveragedAerodromeCLStrategy.WidthOutOfBounds.selector);
+            _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
         }
     }
 
     // ==================== RERANGE ENTRYPOINT ====================
 
-    /// @dev The new 3-arg signature is live and its gates are ordered lifecycle-first: a Pending
-    ///      clone rejects an otherwise-valid width with `NotExecuted`, before any width check.
+    /// @dev The 4-arg `(width, skewBps, minLiq0, minLiq1)` signature is live and its gates are ordered
+    ///      lifecycle-first: a Pending clone rejects an otherwise-valid pair with `NotExecuted`, before
+    ///      any range-param check.
     function testRerangeRevertsBeforeExecute() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
         vm.prank(proposer);
         vm.expectRevert(BaseStrategy.NotExecuted.selector);
-        s.rerange(4000, 0, 0);
+        s.rerange(4000, 5000, 0, 0);
     }
 
     function testRerangeRevertsForNonProposer() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
         vm.prank(owner);
         vm.expectRevert(BaseStrategy.NotProposer.selector);
-        s.rerange(4000, 0, 0);
+        s.rerange(4000, 5000, 0, 0);
+    }
+
+    // ==================== RERANGE SKEW ====================
+    //
+    // `skewBps` is the fraction of `width` placed BELOW the pool tick (1e4 scale; 5000 == the historical
+    // centred range). ONE predicate — `_checkSkew` — validates it at init and on every rerange, and both
+    // callers raise the SHARED `OutOfBounds()` error (the old `WidthOutOfBounds()`, renamed and widened
+    // to cover both range knobs).
+    //
+    // These tests drive the predicate through the LIVE `rerange` entrypoint against a FLAT book
+    // (`tokenId == 0`), where `rerangeImpl` returns immediately — so the validation ladder plus the two
+    // persists are the only things that execute, and no Slipstream / Moonwell venue is needed.
+
+    /// @dev An Executed clone on a flat book: `rerange` reaches `_checkWidth` / `_checkSkew` and, once
+    ///      they pass, is a persist-only no-op.
+    function _executedClone() internal returns (LeveragedAerodromeCLStrategy s) {
+        s = _init(_baseParams());
+        _forceState(s, BaseStrategy.State.Executed);
+    }
+
+    function _expectRerangeOutOfBounds(uint24 width_, uint16 skewBps_) internal {
+        LeveragedAerodromeCLStrategy s = _executedClone();
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.rerange(width_, skewBps_, 0, 0);
+    }
+
+    /// @dev A ZERO skew puts the WHOLE width above the tick — a one-sided range no `assetModeSplit` can
+    ///      size, and one that silently stops hedging. Rejected before any span arithmetic runs.
+    function testRerangeRevertsForZeroSkew() public {
+        _expectRerangeOutOfBounds(4000, 0);
+    }
+
+    /// @dev The mirror image at the top of the band: 10000 would put the whole width BELOW the tick. The
+    ///      bound is STRICT (`>= 10000`), so 10000 itself is out — there is no "100% below" range.
+    function testRerangeRevertsForFullSkew() public {
+        _expectRerangeOutOfBounds(4000, 10_000);
+    }
+
+    /// @dev Above the 1e4 scale entirely. Worth its own case: `skewBps` is a uint16, so an out-of-scale
+    ///      value is representable and a `> 10000` check that had been written as `!= 10000` would pass it
+    ///      through into `width x skew / 1e4` and produce a lower span WIDER than the whole width.
+    function testRerangeRevertsForSkewAbove10000() public {
+        _expectRerangeOutOfBounds(4000, 12_000);
+    }
+
+    /**
+     * @dev THE REASON THE GUARD IS SPAN-BASED AND NOT A FLAT bps BAND. At the narrowest legal width
+     *      (`2 x tickSpacing`) there is no room to skew at all: 1000 bps of 200 ticks is 20 ticks, a
+     *      fifth of one spacing, so BOTH down-aligned bounds would land on the same grid point below the
+     *      tick and the range would stop STRICTLY BRACKETING it — exactly the invariant `assetModeSplit`
+     *      relies on. A flat band (say "skew must be within 2000 of centre") would have waved this
+     *      through while needlessly rejecting the same 1000 bps at a 200-spacing width, where it is safe.
+     *
+     *      Both starved sides are pinned, and the centred split at the same width is shown to be
+     *      ACCEPTED — so the rejection is about the span, not about the narrow width.
+     */
+    function testRerangeRevertsWhenSkewStarvesASideBelowOneSpacing() public {
+        uint24 tightWidth = 2 * uint24(uint24(SPACING)); // == minWidth: a legal width with no skew room
+        _expectRerangeOutOfBounds(tightWidth, 1000); // lower side starved (20 ticks < 100)
+        _expectRerangeOutOfBounds(tightWidth, 9000); // upper side starved, symmetrically
+
+        LeveragedAerodromeCLStrategy s = _executedClone();
+        vm.prank(proposer);
+        s.rerange(tightWidth, 5000, 0, 0); // one spacing each way — the tightest legal geometry
+        assertEq(s.layout().skewBps, 5000, "the centred split spans a full spacing each way and passes");
+        assertEq(s.layout().width, tightWidth, "...and the width is persisted with it");
+
+        // The SAME 1000 bps is fine once the width can afford it — proof the guard bounds the span,
+        // not the skew value.
+        s = _executedClone();
+        vm.prank(proposer);
+        s.rerange(2000, 1000, 0, 0); // 200 ticks below, 1800 above
+        assertEq(s.layout().skewBps, 1000, "a hard skew is legal at a width that can carry it");
+    }
+
+    /// @dev Gate ORDER around the new param: `onlyProposer` (a modifier) fires before the body, and the
+    ///      lifecycle check fires before the range params. So a stranger learns `NotProposer` and a
+    ///      proposer on a Pending clone learns `NotExecuted` — neither is told anything about the skew,
+    ///      and a bad skew can never be the reason an unauthorised call reverts.
+    function testRerangeSkewGatesAfterLifecycleAndAuth() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams()); // Pending
+        vm.prank(proposer);
+        vm.expectRevert(BaseStrategy.NotExecuted.selector);
+        s.rerange(4000, 0, 0, 0); // skew 0 IS OutOfBounds — the lifecycle gate still wins
+
+        _forceState(s, BaseStrategy.State.Executed);
+        vm.prank(owner);
+        vm.expectRevert(BaseStrategy.NotProposer.selector);
+        s.rerange(4000, 0, 0, 0); // ...and auth wins over the params too
+    }
+
+    /// @dev The genesis skew round-trips into storage — `layout().skewBps` is what every subsequent mint
+    ///      (`execute` / `deployIdle` / `compound`) derives its range from, so a dropped write would
+    ///      silently reopen every position centred.
+    function testInitPersistsSkew() public {
+        uint16[4] memory skews = [uint16(500), 3500, 5000, 9500];
+        for (uint256 i; i < skews.length; ++i) {
+            LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+            p.skewBps = skews[i];
+            assertEq(_init(p).layout().skewBps, skews[i], "genesis skew persisted");
+        }
+    }
+
+    /**
+     * @dev ONE PREDICATE, TWO ENTRYPOINTS — they cannot drift. Whatever `_initialize` accepts as a
+     *      genesis `(width, skew)` pair, `rerange` accepts as a per-cycle one, and whatever either
+     *      rejects the other rejects with the same typed `OutOfBounds()`. The band is restated
+     *      independently here (from the spans, not by calling the contract) so the fuzz is a check on
+     *      `_checkSkew` rather than a tautology.
+     */
+    function testFuzzInitSkewBandMirrorsRerange(uint16 skewBps_, uint24 width_) public {
+        skewBps_ = uint16(bound(uint256(skewBps_), 0, 12_000));
+        width_ = uint24(bound(uint256(width_), 2, 200)) * uint24(uint24(SPACING)); // aligned, in [200, 20000]
+
+        uint256 spacing = uint256(uint24(SPACING));
+        uint256 lowerSpan = (uint256(width_) * uint256(skewBps_)) / 10_000;
+        bool ok = skewBps_ > 0 && skewBps_ < 10_000 && lowerSpan >= spacing && (uint256(width_) - lowerSpan) >= spacing;
+
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.width = width_;
+        p.skewBps = skewBps_;
+
+        if (ok) {
+            LeveragedAerodromeCLStrategy s = _init(p);
+            assertEq(s.layout().skewBps, skewBps_, "init accepted the pair and persisted the skew");
+            assertEq(s.layout().width, width_, "...and the width");
+            _forceState(s, BaseStrategy.State.Executed);
+            vm.prank(proposer);
+            s.rerange(width_, skewBps_, 0, 0); // the SAME pair clears the rerange gate
+        } else {
+            _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+            LeveragedAerodromeCLStrategy s = _executedClone(); // valid genesis, then the bad pair
+            vm.prank(proposer);
+            vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+            s.rerange(width_, skewBps_, 0, 0);
+        }
+    }
+
+    /**
+     * @dev THE FREE-PACKING CLAIM, MACHINE-CHECKED. `skewBps` was inserted immediately after
+     *      `legBIsAsset` — NOT appended after the hedged principals — precisely because the packed tail
+     *      slot had room (20 bytes used -> 22), which leaves `hedgedDebtA` / `hedgedDebtB` on a
+     *      byte-identical slot AND offset. Get that wrong and every live clone's borrow-interest hedge
+     *      basis reads garbage from the next upgrade onward, silently mis-sizing every `compound` re-hedge.
+     *
+     *      Both halves of the claim are checked mechanically rather than by eyeballing the struct: the
+     *      packed tail is decoded field-by-field out of `vm.load` at its expected byte offsets and
+     *      compared against `layout()`, and a sentinel is `vm.store`d into the NEXT slot and read back
+     *      through the `hedgedDebt()` getter.
+     */
+    function testLayoutTailPacksSkewWithoutMovingTheHedgedDebts() public {
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        // Distinctive aligned in-band values, so a decode at the wrong offset cannot pass on zeros.
+        p.width = 1300;
+        p.maxWidth = 12_700;
+        p.skewBps = 3500;
+        LeveragedAerodromeCLStrategy s = _init(p);
+
+        uint256 tailSlot = uint256(STORAGE_SLOT) + TAIL_SLOT_OFFSET;
+        uint256 tail = uint256(vm.load(address(s), bytes32(tailSlot)));
+
+        assertEq(uint256(uint8(tail)), 8, "cbBTCDecimals at byte 0");
+        assertEq(uint256(uint8(tail >> 8)), 18, "wethDecimals at byte 1");
+        assertEq(uint256(uint8(tail >> 16)), 0, "wethIsToken0 at byte 2 (leg A is token1 here)");
+        assertEq(uint256(uint8(tail >> 24)), 1, "wethDeliversNative at byte 3");
+        assertEq(int256(int24(uint24(tail >> 32))), int256(LEG_B_SWAP_SPACING), "cbBTCSwapTickSpacing at byte 4");
+        assertEq(int256(int24(uint24(tail >> 56))), int256(LEG_A_SWAP_SPACING), "wethSwapTickSpacing at byte 7");
+        assertEq(uint256(uint24(tail >> 80)), 1300, "width at byte 10");
+        assertEq(uint256(uint24(tail >> 104)), 200, "minWidth at byte 13");
+        assertEq(uint256(uint24(tail >> 128)), 12_700, "maxWidth at byte 16");
+        assertEq(uint256(uint8(tail >> 152)), 0, "legBIsAsset at byte 19 (two-borrowed-legs here)");
+        assertEq(uint256(uint16(tail >> 160)), 3500, "skewBps FREE-PACKS at byte 20 -- the tail still fits");
+        assertEq(tail >> 176, 0, "bytes 22..31 of the tail slot are still SPARE");
+
+        // The decode above must agree with the public view, or it is reading the wrong slot entirely.
+        LeveragedAerodromeCLStrategy.LayoutView memory v = s.layout();
+        assertEq(v.width, 1300, "layout() agrees on width");
+        assertEq(v.skewBps, 3500, "layout() agrees on skewBps");
+
+        // ...so `hedgedDebtA` / `hedgedDebtB` are still the LOW / HIGH halves of the NEXT slot.
+        vm.store(address(s), bytes32(tailSlot + 1), bytes32((uint256(7) << 128) | uint256(3)));
+        (uint128 legAHedged, uint128 legBHedged) = s.hedgedDebt();
+        assertEq(uint256(legAHedged), 3, "hedgedDebtA is STILL slot+1 offset 0 (low 16 bytes)");
+        assertEq(uint256(legBHedged), 7, "hedgedDebtB is STILL slot+1 offset 16 (high 16 bytes)");
     }
 
     // ==================== COMPOUND FEE-CRYSTALLISE ROUTING ====================

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -143,6 +143,11 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         p.minWidth = 200; // 2 x SPACING
         p.maxWidth = 20_000;
         p.skewBps = 5000; // centred — the historical behaviour, and the baseline every skew test perturbs
+        // The WIDEST LEGAL governance band, on purpose: `[1, 9999]` is exactly the open `(0, 10000)`
+        // interval `checkRange` already enforces, so the band is a no-op here and the skew cases below
+        // keep testing the SPAN predicate in isolation. The band-binding cases set it explicitly.
+        p.minSkewBps = 1;
+        p.maxSkewBps = 9999;
         p.targetLtvBps = 5000;
         p.maxLtvBps = 6500;
         p.minHealthBps = 12_000;
@@ -991,24 +996,160 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         }
     }
 
+    // ==================== SKEW GOVERNANCE BAND ====================
+    //
+    // `[minSkewBps, maxSkewBps]` is fixed at init and caps how far off centre a PROPOSER may rerange.
+    // It can only ever TIGHTEN the open `(0, 1e4)` interval the span predicate already enforces —
+    // `0 < minSkewBps <= maxSkewBps < 10000` is checked at init — so the band is a governance knob, not
+    // a second, contradictory definition of a legal skew. Every rejection is the SAME `OutOfBounds()`.
+
+    /// @dev A clone whose band is `[2000, 8000]`, i.e. genuinely narrower than `(0, 1e4)`.
+    function _bandedParams() internal view returns (LeveragedAerodromeCLStrategy.InitParams memory p) {
+        p = _baseParams();
+        p.minSkewBps = 2000;
+        p.maxSkewBps = 8000;
+    }
+
+    /// @dev The band round-trips into storage — it is what every later `rerange` is measured against.
+    function testInitPersistsTheSkewBand() public {
+        LeveragedAerodromeCLStrategy.LayoutView memory v = _init(_bandedParams()).layout();
+        assertEq(v.minSkewBps, 2000, "minSkewBps persisted");
+        assertEq(v.maxSkewBps, 8000, "maxSkewBps persisted");
+    }
+
+    /// @dev A genesis skew OUTSIDE the band is refused, on both sides — even though the SAME skew is
+    ///      legal against the spans at this width (4000 ticks / 100 spacing carries 1000 and 9000 fine,
+    ///      which `testRerangeRevertsWhenSkewStarvesASideBelowOneSpacing` already pins). So the rejection
+    ///      is the band biting, not the span guard.
+    function testInitRevertsWhenGenesisSkewIsOutsideTheBand() public {
+        LeveragedAerodromeCLStrategy.InitParams memory p = _bandedParams();
+        p.skewBps = 1999;
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        p.skewBps = 8001;
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+    }
+
+    /// @dev The band is INCLUSIVE at both ends — a proposer may sit exactly on the governance limit.
+    function testInitAcceptsGenesisSkewAtBothBandEdges() public {
+        LeveragedAerodromeCLStrategy.InitParams memory p = _bandedParams();
+        p.skewBps = 2000;
+        assertEq(_init(p).layout().skewBps, 2000, "the lower band edge is legal");
+        p.skewBps = 8000;
+        assertEq(_init(p).layout().skewBps, 8000, "the upper band edge is legal");
+    }
+
+    /// @dev An INVERTED band would make every rerange impossible (an empty interval) — refused at init
+    ///      rather than left to brick the entrypoint later. `min == max` is NOT inverted: it pins the
+    ///      skew to a single value, which is a legal (if rigid) governance choice.
+    function testInitRevertsOnInvertedSkewBand() public {
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.minSkewBps = 6000;
+        p.maxSkewBps = 4000;
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+
+        p.minSkewBps = 4000;
+        p.maxSkewBps = 4000;
+        p.skewBps = 4000;
+        assertEq(_init(p).layout().skewBps, 4000, "a degenerate min == max band pins the skew and is legal");
+    }
+
+    /// @dev The band's own edges: `minSkewBps == 0` and `maxSkewBps == 10000` would each admit a value
+    ///      the span predicate rejects outright, i.e. a band that claims to widen `(0, 1e4)`. Both are
+    ///      refused at init, so the band can only ever tighten.
+    function testInitRevertsWhenTheBandWouldWidenTheOpenInterval() public {
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.minSkewBps = 0;
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+
+        p = _baseParams();
+        p.maxSkewBps = 10_000;
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+
+        // ...and the widest LEGAL band is `[1, 9999]`, which is exactly `(0, 1e4)` — the suite default.
+        p = _baseParams();
+        assertEq(_init(p).layout().maxSkewBps, 9999, "the widest legal band is accepted");
+    }
+
+    /// @dev THE POINT OF THE BAND: `rerange` — the proposer-facing knob — is bounded by it. A skew the
+    ///      spans would happily carry is still refused outside the band, and both edges are reachable.
+    function testRerangeRefusesASkewOutsideTheBand() public {
+        LeveragedAerodromeCLStrategy s = _init(_bandedParams());
+        _forceState(s, BaseStrategy.State.Executed);
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.rerange(4000, 1000, 0, 0); // legal span, below the band
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.rerange(4000, 9000, 0, 0); // legal span, above the band
+
+        vm.prank(proposer);
+        s.rerange(4000, 2000, 0, 0);
+        assertEq(s.layout().skewBps, 2000, "the lower band edge reranges");
+        vm.prank(proposer);
+        s.rerange(4000, 8000, 0, 0);
+        assertEq(s.layout().skewBps, 8000, "...and so does the upper one");
+    }
+
+    /**
+     * @dev THE QUANTIZATION CLIFF, stated as a test so the band's interaction with `width` is not a
+     *      surprise: the USABLE skew set widens with `width / tickSpacing`. At the floor
+     *      (`width == 2 x spacing`) the only geometry leaving both spans >= one spacing is the centred
+     *      one, so a band that EXCLUDES ~5000 refuses every rerange at that width no matter what it
+     *      admits — the band and the spans are independent gates, and the narrower one wins.
+     */
+    function testBandAndSpanGatesAreIndependentAtTheWidthFloor() public {
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.minSkewBps = 2000;
+        p.maxSkewBps = 4000;
+        p.width = 2000; // 20 x spacing: 4000 bps leaves 800 below / 1200 above — both spans fine
+        p.skewBps = 4000;
+        LeveragedAerodromeCLStrategy s = _init(p);
+        _forceState(s, BaseStrategy.State.Executed);
+
+        // The SAME in-band skew at the narrowest legal width starves the lower span (2 x 100 ticks x
+        // 0.4 = 80 < 100) — the span guard refuses what the band allows.
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.rerange(200, 4000, 0, 0);
+
+        // ...and the centred skew that WOULD clear the spans at that width is outside this band.
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.rerange(200, 5000, 0, 0);
+    }
+
     /**
      * @dev ONE PREDICATE, TWO ENTRYPOINTS — they cannot drift. Whatever `_initialize` accepts as a
      *      genesis `(width, skew)` pair, `rerange` accepts as a per-cycle one, and whatever either
-     *      rejects the other rejects with the same typed `OutOfBounds()`. The band is restated
-     *      independently here (from the spans, not by calling the contract) so the fuzz is a check on
-     *      `_checkSkew` rather than a tautology.
+     *      rejects the other rejects with the same typed `OutOfBounds()`. The band is FUZZED alongside
+     *      the pair, and the whole predicate is restated independently here (from the spans and the
+     *      band, not by calling the contract) so the fuzz is a check on `checkRange` rather than a
+     *      tautology.
      */
-    function testFuzzInitSkewBandMirrorsRerange(uint16 skewBps_, uint24 width_) public {
+    function testFuzzInitSkewBandMirrorsRerange(uint16 skewBps_, uint24 width_, uint16 minSkew_, uint16 maxSkew_)
+        public
+    {
         skewBps_ = uint16(bound(uint256(skewBps_), 0, 12_000));
         width_ = uint24(bound(uint256(width_), 2, 200)) * uint24(uint24(SPACING)); // aligned, in [200, 20000]
+        // A LEGAL band (`0 < min <= max < 1e4`) that STRADDLES centre — an illegal one is refused at init
+        // before the pair is ever looked at (the dedicated cases above own that), and straddling centre
+        // is what guarantees the mirror clone below has a genesis skew that is both in-band and
+        // span-legal at the reference width.
+        minSkew_ = uint16(bound(uint256(minSkew_), 1, 5000));
+        maxSkew_ = uint16(bound(uint256(maxSkew_), 5000, 9999));
 
         uint256 spacing = uint256(uint24(SPACING));
         uint256 lowerSpan = (uint256(width_) * uint256(skewBps_)) / 10_000;
-        bool ok = skewBps_ > 0 && skewBps_ < 10_000 && lowerSpan >= spacing && (uint256(width_) - lowerSpan) >= spacing;
+        bool ok = skewBps_ > 0 && skewBps_ < 10_000 && skewBps_ >= minSkew_ && skewBps_ <= maxSkew_
+            && lowerSpan >= spacing && (uint256(width_) - lowerSpan) >= spacing;
 
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.width = width_;
         p.skewBps = skewBps_;
+        p.minSkewBps = minSkew_;
+        p.maxSkewBps = maxSkew_;
 
         if (ok) {
             LeveragedAerodromeCLStrategy s = _init(p);
@@ -1019,7 +1160,14 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
             s.rerange(width_, skewBps_, 0, 0); // the SAME pair clears the rerange gate
         } else {
             _expectInitRevert(p, LeveragedAerodromeCLStrategy.OutOfBounds.selector);
-            LeveragedAerodromeCLStrategy s = _executedClone(); // valid genesis, then the bad pair
+            // The mirror clone must carry the SAME band, or `rerange` would be measured against
+            // different bounds than init was. Its genesis pair is the centred one at the reference
+            // width, which the straddling bound above keeps in-band.
+            LeveragedAerodromeCLStrategy.InitParams memory q = _baseParams();
+            q.minSkewBps = minSkew_;
+            q.maxSkewBps = maxSkew_;
+            LeveragedAerodromeCLStrategy s = _init(q); // valid genesis, then the bad pair
+            _forceState(s, BaseStrategy.State.Executed);
             vm.prank(proposer);
             vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
             s.rerange(width_, skewBps_, 0, 0);
@@ -1027,11 +1175,13 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     }
 
     /**
-     * @dev THE FREE-PACKING CLAIM, MACHINE-CHECKED. `skewBps` was inserted immediately after
-     *      `legBIsAsset` — NOT appended after the hedged principals — precisely because the packed tail
-     *      slot had room (20 bytes used -> 22), which leaves `hedgedDebtA` / `hedgedDebtB` on a
-     *      byte-identical slot AND offset. Get that wrong and every live clone's borrow-interest hedge
-     *      basis reads garbage from the next upgrade onward, silently mis-sizing every `compound` re-hedge.
+     * @dev THE FREE-PACKING CLAIM, MACHINE-CHECKED. `skewBps` and its governance band
+     *      (`minSkewBps` / `maxSkewBps`) were inserted immediately after `legBIsAsset` — NOT appended
+     *      after the hedged principals — precisely because the packed tail slot had room (20 bytes used
+     *      -> 26), which leaves `hedgedDebtA` / `hedgedDebtB` on a byte-identical slot AND offset (26 + 16
+     *      > 32, so `hedgedDebtA` still starts the NEXT slot). Get that wrong and every live clone's
+     *      borrow-interest hedge basis reads garbage from the next upgrade onward, silently mis-sizing
+     *      every `compound` re-hedge.
      *
      *      Both halves of the claim are checked mechanically rather than by eyeballing the struct: the
      *      packed tail is decoded field-by-field out of `vm.load` at its expected byte offsets and
@@ -1044,6 +1194,8 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         p.width = 1300;
         p.maxWidth = 12_700;
         p.skewBps = 3500;
+        p.minSkewBps = 2000;
+        p.maxSkewBps = 8000;
         LeveragedAerodromeCLStrategy s = _init(p);
 
         uint256 tailSlot = uint256(STORAGE_SLOT) + TAIL_SLOT_OFFSET;
@@ -1060,12 +1212,16 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(uint256(uint24(tail >> 128)), 12_700, "maxWidth at byte 16");
         assertEq(uint256(uint8(tail >> 152)), 0, "legBIsAsset at byte 19 (two-borrowed-legs here)");
         assertEq(uint256(uint16(tail >> 160)), 3500, "skewBps FREE-PACKS at byte 20 -- the tail still fits");
-        assertEq(tail >> 176, 0, "bytes 22..31 of the tail slot are still SPARE");
+        assertEq(uint256(uint16(tail >> 176)), 2000, "minSkewBps FREE-PACKS at byte 22");
+        assertEq(uint256(uint16(tail >> 192)), 8000, "maxSkewBps FREE-PACKS at byte 24 -- 26 of 32 bytes used");
+        assertEq(tail >> 208, 0, "bytes 26..31 of the tail slot are still SPARE");
 
         // The decode above must agree with the public view, or it is reading the wrong slot entirely.
         LeveragedAerodromeCLStrategy.LayoutView memory v = s.layout();
         assertEq(v.width, 1300, "layout() agrees on width");
         assertEq(v.skewBps, 3500, "layout() agrees on skewBps");
+        assertEq(v.minSkewBps, 2000, "layout() agrees on minSkewBps");
+        assertEq(v.maxSkewBps, 8000, "layout() agrees on maxSkewBps");
 
         // ...so `hedgedDebtA` / `hedgedDebtB` are still the LOW / HIGH halves of the NEXT slot.
         vm.store(address(s), bytes32(tailSlot + 1), bytes32((uint256(7) << 128) | uint256(3)));

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -74,6 +74,8 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
     int24 internal constant LEG_B_SWAP_SPACING = 100;
     int24 internal constant LEG_A_SWAP_SPACING = 200;
     uint24 internal constant WIDTH = 4000;
+    /// @dev The centred skew — `width/2` each side, i.e. the pre-skew behaviour.
+    uint16 internal constant SKEW_CENTERED = 5000;
     uint16 internal constant TARGET_LTV_BPS = 5000;
     uint256 internal constant P_USDC = 1e8;
     uint256 internal constant SEED = 1_000_000e6;
@@ -166,6 +168,7 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         p.width = WIDTH;
         p.minWidth = 200;
         p.maxWidth = 20_000;
+        p.skewBps = SKEW_CENTERED;
         p.targetLtvBps = TARGET_LTV_BPS;
         p.maxLtvBps = 6500;
         p.minHealthBps = 12_000;
@@ -214,7 +217,8 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         uint256 debtUsdc = _valueUsdc(debtB, P_LEG_B, 8) + _valueUsdc(debtA, P_LEG_A, 18);
         assertApproxEqAbs((debtUsdc * 10_000) / collateral, uint256(TARGET_LTV_BPS), 1, "LTV == target");
 
-        (int24 tickLower, int24 tickUpper) = LeveragedAeroValuation.centeredTickRange(address(pool), SPACING, WIDTH);
+        (int24 tickLower, int24 tickUpper) =
+            LeveragedAeroValuation.skewedTickRange(address(pool), SPACING, WIDTH, SKEW_CENTERED);
         assertEq(strategy.layout().posTickLower, tickLower, "range persisted");
         assertEq(strategy.layout().posTickUpper, tickUpper, "range persisted");
         assertGt(strategy.layout().tokenId, 0, "position minted");
@@ -391,6 +395,155 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         assertApproxEqRel(
             addedDebt, (topUp * uint256(TARGET_LTV_BPS)) / 10_000, 1e12, "redeploy sized at the untouched init target"
         );
+    }
+
+    // ==================== RERANGE SKEW (two borrowed legs) ====================
+    //
+    // The two-leg shape had NO rerange coverage before the skew work. It is the shape where the skew's
+    // one real cost shows up (see `testRerangeSkewedLeavesALargerIdleRemainderThanCentered`), so the
+    // whole entrypoint is driven here end to end against the venue mocks.
+
+    /// @dev The re-range mints at the SKEWED range, not the centred one, and persists BOTH knobs. The
+    ///      centred range is computed alongside and asserted to differ, so a implementation that ignored
+    ///      `skewBps` entirely could not pass.
+    function testRerangeSkewedMintsTheSkewedRange() public {
+        _execute(SEED);
+        uint256 oldTokenId = strategy.layout().tokenId;
+
+        (int24 expLower, int24 expUpper) = LeveragedAeroValuation.skewedTickRange(address(pool), SPACING, WIDTH, 3500);
+        (int24 cenLower, int24 cenUpper) =
+            LeveragedAeroValuation.skewedTickRange(address(pool), SPACING, WIDTH, SKEW_CENTERED);
+        assertTrue(expLower != cenLower && expUpper != cenUpper, "3500 must actually move the range off centre");
+
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, 3500, 0, 0);
+
+        assertEq(strategy.layout().posTickLower, expLower, "minted at the SKEWED lower bound");
+        assertEq(strategy.layout().posTickUpper, expUpper, "minted at the SKEWED upper bound");
+        assertEq(strategy.layout().skewBps, 3500, "the skew is persisted");
+        assertEq(strategy.layout().width, WIDTH, "...alongside the width");
+        assertTrue(strategy.layout().tokenId != oldTokenId, "a fresh tokenId (Slipstream ticks are immutable)");
+        assertEq(gauge.depositCallCount(), 2, "the new NFT was restaked");
+        // The range still brackets spot, so the position is genuinely two-sided.
+        assertLe(expLower, pool.tick(), "skewed range still brackets spot");
+        assertGt(expUpper, pool.tick(), "skewed range still brackets spot");
+    }
+
+    /**
+     * @dev THE KNOWN UTILISATION COST OF SKEWING — pinned so it is a documented consequence rather than a
+     *      surprise. A re-range does NOT swap: it re-adds exactly the two collected leg balances, and
+     *      those came from a book whose borrow is range-BLIND (the two-leg shape borrows 50/50 BY USD via
+     *      `_borrowHalfEach`, never against the range). Move the range and the mix it WANTS moves with it,
+     *      while the mix it is HANDED does not — so more of one leg is left over as an idle remainder.
+     *
+     *      THE DRAG IS DIRECTIONAL, and this test states both halves rather than the flattering one.
+     *      Extending the range further ABOVE spot makes it want more token0 (`amount0 ∝ 1/sqrtP −
+     *      1/sqrtUpper`), so an UP-skew here happens to consume MORE of the stranded leg than the centred
+     *      range does; the DOWN-skew is the direction that strands more. Which way is which is a property
+     *      of the book's current leg mix, not of skewing per se — the operator-facing claim is only that
+     *      a re-range cannot re-balance the mix, so any move off the mix the book happens to hold costs
+     *      utilisation in one direction.
+     *
+     *      The remainder is NOT a loss in either direction — `nav()` prices it and it stays redeployable
+     *      until the next `deployIdle` / `compound` — which is asserted alongside, so the cost is pinned
+     *      as a UTILISATION one and not a value one. All three branches run from the SAME post-genesis
+     *      snapshot, so the comparison is apples to apples.
+     */
+    function testRerangeSkewedLeavesALargerIdleRemainderThanCentered() public {
+        _execute(SEED);
+        uint256 navBefore = strategy.nav();
+
+        (uint256 centeredRemainder, uint256 centeredNav) = _remainderAfterRerange(SKEW_CENTERED);
+        (uint256 downSkewRemainder, uint256 downSkewNav) = _remainderAfterRerange(8000); // 3200 below, 800 above
+        (uint256 upSkewRemainder, uint256 upSkewNav) = _remainderAfterRerange(2000); // 800 below, 3200 above
+
+        assertGt(
+            downSkewRemainder,
+            centeredRemainder,
+            "skewing AWAY from the book's leg mix strands MORE of a borrowed leg (range-blind 50/50 borrow)"
+        );
+        assertLt(
+            upSkewRemainder,
+            centeredRemainder,
+            "...and the opposite skew strands LESS: the drag is directional, not a penalty for skewing"
+        );
+        // The remainder is unproductive, never lost: NAV prices it wherever it sits.
+        assertApproxEqRel(centeredNav, navBefore, 1e16, "NAV indifferent (centred)");
+        assertApproxEqRel(downSkewNav, navBefore, 1e16, "NAV indifferent (down-skew)");
+        assertApproxEqRel(upSkewNav, navBefore, 1e16, "NAV indifferent (up-skew)");
+    }
+
+    /// @dev Re-range at `skewBps_`, measure the idle borrowed-leg remainder and NAV, then roll the whole
+    ///      book back — so several skews can be compared against ONE post-genesis state.
+    function _remainderAfterRerange(uint16 skewBps_) internal returns (uint256 remainder, uint256 nav_) {
+        uint256 snap = vm.snapshotState();
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, skewBps_, 0, 0);
+        remainder = _idleLegValueUsdc();
+        nav_ = strategy.nav();
+        vm.revertToState(snap);
+    }
+
+    /// @dev A re-range on a FLAT book is a venue no-op — but the proposer's `width` AND `skewBps` must
+    ///      still land, because the next `deployIdle` / `compound` mint reads them from storage. The
+    ///      persists sit in the strategy frame AHEAD of `rerangeImpl`'s `tokenId == 0` bail-out precisely
+    ///      so this holds after the write moved out of the library.
+    function testRerangeOnFlatBookPersistsSkew() public {
+        _execute(SEED);
+
+        // Redeem the whole book: `tokenId` goes to 0 while the strategy stays Executed.
+        uint256 supply = 1_000_000e12;
+        vm.prank(address(strategy));
+        vault.strategyMint(lp, supply);
+        vm.prank(lp);
+        vault.approve(address(strategy), supply);
+        vm.prank(lp);
+        uint256 id = strategy.requestRedeem(supply, 0);
+        vm.prank(proposer);
+        strategy.fulfillRedeem(id);
+        assertEq(strategy.layout().tokenId, 0, "flat book");
+
+        uint256 stakedBefore = gauge.depositCallCount();
+        vm.prank(proposer);
+        strategy.rerange(2000, 2500, 0, 0);
+
+        assertEq(strategy.layout().width, 2000, "flat-book rerange still stored the width");
+        assertEq(strategy.layout().skewBps, 2500, "...and the skew, for the next redeploy to mint at");
+        assertEq(strategy.layout().tokenId, 0, "still flat: no position was opened");
+        assertEq(gauge.depositCallCount(), stakedBefore, "nothing was staked");
+    }
+
+    /// @dev The calm-gate still fires FIRST on the skewed path: a shoved spot reverts before any venue
+    ///      call, and — because the two persists now sit in the strategy frame — the atomic rollback
+    ///      leaves the STORED width/skew untouched too. A re-range can never land at a manipulated tick,
+    ///      nor half-land its params.
+    function testRerangeSkewCalmGateStillGatesFirst() public {
+        _execute(SEED);
+        uint256 tokenIdBefore = strategy.layout().tokenId;
+        uint128 liqBefore = npm.liquidityOf(tokenIdBefore);
+        uint256 stakedBefore = gauge.depositCallCount();
+
+        // Shove SPOT well past `calmDeviationTicks = 100` while leaving the TWAP put.
+        pool.setTick(TICK + 5000);
+        pool.setTwapTick(TICK);
+        pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK + 5000));
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAeroValuation.CalmGateBreached.selector);
+        strategy.rerange(2000, 3500, 0, 0);
+
+        assertEq(strategy.layout().tokenId, tokenIdBefore, "the position was never touched");
+        assertEq(npm.liquidityOf(tokenIdBefore), liqBefore, "no liquidity was removed");
+        assertEq(gauge.depositCallCount(), stakedBefore, "nothing was unstaked/restaked");
+        assertEq(strategy.layout().width, WIDTH, "the width write rolled back with the op");
+        assertEq(strategy.layout().skewBps, SKEW_CENTERED, "...and so did the skew write");
+    }
+
+    /// @dev USDC face value of whatever borrowed-leg balance a re-range left sitting idle on the
+    ///      strategy — the utilisation drag the skew test compares.
+    function _idleLegValueUsdc() internal view returns (uint256) {
+        return _valueUsdc(legB.balanceOf(address(strategy)), P_LEG_B, 8)
+            + _valueUsdc(legA.balanceOf(address(strategy)), P_LEG_A, 18);
     }
 
     // ==================== REDEEM ====================

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -88,6 +88,13 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
     ///      two feed prices: raw = P_LEG_B·1e18 / (P_LEG_A·1e8) ≈ 3.33e13 ⇒ tick ≈ ln(raw)/ln(1.0001).
     int24 internal constant TICK = 311_100;
 
+    /// @dev The grid-aligned tick whose RAW price actually equals the two feeds' ratio:
+    ///      `raw = (P_LEG_B / P_LEG_A) × 10^(18−8) = 3.333e11`, `ln(raw)/ln(1.0001) ≈ 265_337`. `TICK`
+    ///      above is ~97× off that (a long-standing property of this fixture, harmless to the venue-
+    ///      mechanics tests that use it, but fatal to any test measuring a POOL-ratio effect in ORACLE
+    ///      value — see `testDeployAtASkewedRangeStrandsTheSamePredictedFractionEitherWay`).
+    int24 internal constant TICK_ORACLE_CONSISTENT = 265_300;
+
     function setUp() public {
         vm.warp(1_800_000_000);
 
@@ -169,6 +176,8 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         p.minWidth = 200;
         p.maxWidth = 20_000;
         p.skewBps = SKEW_CENTERED;
+        p.minSkewBps = 1000; // governance band: wide enough for every skew this suite drives
+        p.maxSkewBps = 9000;
         p.targetLtvBps = TARGET_LTV_BPS;
         p.maxLtvBps = 6500;
         p.minHealthBps = 12_000;
@@ -544,6 +553,176 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
     function _idleLegValueUsdc() internal view returns (uint256) {
         return _valueUsdc(legB.balanceOf(address(strategy)), P_LEG_B, 8)
             + _valueUsdc(legA.balanceOf(address(strategy)), P_LEG_A, 18);
+    }
+
+    // ==================== LEVER-DOWN COVER IS NEED-SIZED ====================
+
+    /**
+     * @dev THE IDLE REMAINDER A LEVER-DOWN MUST NOT LIQUIDATE. A partial lever-down repays `f` of each
+     *      debt from the legs the unwind collected; when a price move has skewed the LP's leg mix, one
+     *      leg comes up short and `_rebalanceCover` sells the OTHER leg for USDC to buy the deficit.
+     *
+     *      The surplus leg's BALANCE is not the same thing as this op's surplus. It can also hold a
+     *      pre-existing idle remainder — a skewed `rerange` leaves exactly that (see
+     *      `testRerangeSkewedLeavesALargerIdleRemainderThanCentered`) — which is still matched 1:1 by
+     *      that leg's Moonwell debt and is therefore DELTA-NEUTRAL where it sits. Selling it converts a
+     *      hedged holding into an unrecorded short: `hedgedDebt()` measures interest drift only, and the
+     *      repay clamp re-anchors the basis, so nothing downstream surfaces the missing leg.
+     *
+     *      The cover is therefore need-sized: sell what the shortfall needs (oracle-converted, with
+     *      slippage headroom on both legs of the round trip) and keep the rest. Two assertions pin it
+     *      from both sides — the remainder SURVIVES, and the proceeds did not pile up as idle USDC.
+     */
+    function testLeverDownCoverSellsOnlyWhatTheShortfallNeedsAndKeepsTheRest() public {
+        // Genesis on the oracle-consistent mark (see `TICK_ORACLE_CONSISTENT`), so the deploy strands
+        // essentially nothing and the ONLY idle leg-A in the book is the remainder seeded below. On the
+        // suite's default `TICK` the range-blind borrow already strands ~49% of one leg, and that
+        // accidental buffer absorbs every shortfall before `_rebalanceCover` is ever reached.
+        pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK_ORACLE_CONSISTENT));
+        pool.setTick(TICK_ORACLE_CONSISTENT);
+
+        _execute(SEED);
+
+        // A pre-existing idle leg-A remainder: ~$150k, an order of magnitude more than the shortfall
+        // the move below opens, so "kept most of it" is unambiguous.
+        uint256 remainder = 50e18;
+        legA.mint(address(strategy), remainder);
+        uint256 remainderValue = _valueUsdc(remainder, P_LEG_A, 18);
+
+        // Move the pool up (spot AND TWAP together) and keep leg B's oracle + swap rates on the same
+        // mark. Leg B is token0, so a higher tick leaves the LP holding LESS leg B than the leg-B debt —
+        // the lever-down repay comes up short on leg B and routes through `_rebalanceCover`, whose
+        // surplus leg is leg A: the very balance the remainder sits in.
+        int24 newTick = TICK_ORACLE_CONSISTENT + 600;
+        pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(newTick));
+        pool.setTick(newTick);
+        pool.setTwapTick(newTick);
+        uint256 newPB = (P_LEG_B * 1_061_837) / 1_000_000; // 1.0001^600
+        legBFeed.setAnswer(int256(newPB));
+        router.setRate(address(legB), address(usdc), (newPB * 1e18) / (100 * 1e8));
+        router.setRate(address(usdc), address(legB), (100 * 1e8 * 1e18) / newPB);
+        // FIXTURE ONLY: `MockNpm` custodies exactly what it was minted, so a post-move `collect` owes
+        // amounts re-priced at the new sqrtP that it never received. Float it, as other LPs would.
+        legB.mint(address(npm), 100e8);
+        legA.mint(address(npm), 100e18);
+
+        uint256 debtBBefore = mLegB.borrowBalance(address(strategy));
+
+        vm.prank(proposer);
+        strategy.adjustLeverage(3000, 0, 0); // lever DOWN — repays f of both debts
+
+        // 1. The remainder survived: only a need-sized slice of the leg-A balance was sold.
+        assertGt(
+            legA.balanceOf(address(strategy)),
+            remainder / 2,
+            "the delta-neutral leg-A remainder was not liquidated wholesale to cover the leg-B shortfall"
+        );
+        // 2. ...and the sell was not merely deferred into idle USDC: a wholesale sell would leave the
+        //    unspent proceeds sitting there.
+        assertLt(
+            usdc.balanceOf(address(strategy)),
+            remainderValue / 10,
+            "the cover raised roughly what it spent -- the sell was need-sized, not wholesale"
+        );
+        // 3. The shortfall WAS covered: both debts repaid to the new target, so LTV landed on it.
+        assertLt(mLegB.borrowBalance(address(strategy)), debtBBefore, "the leg-B debt really was repaid");
+        uint256 collateral = (mUsdc.balanceOf(address(strategy)) * mUsdc.exchangeRateStored()) / 1e18;
+        uint256 debtUsdc = _valueUsdc(mLegB.borrowBalance(address(strategy)), newPB, 8)
+            + _valueUsdc(mLegA.borrowBalance(address(strategy)), P_LEG_A, 18);
+        assertApproxEqAbs((debtUsdc * 10_000) / collateral, 3000, 20, "LTV landed on the new target");
+    }
+
+    // ==================== THE GENESIS DRAG A SKEWED RANGE CANNOT AVOID ====================
+
+    /**
+     * @dev THE ALWAYS-ADVERSE HALF of the skew's utilisation cost — the one
+     *      `testRerangeSkewedLeavesALargerIdleRemainderThanCentered` cannot show, because a re-range is
+     *      handed whatever mix the book already holds and so has a flattering direction.
+     *
+     *      A DEPLOY has no such luck. `_borrowHalfEach` splits the borrow 50/50 BY USD, range-BLIND,
+     *      while the range wants the mix its geometry implies — `w1 = (√P − √Pa) / [(√P − √Pa) + √P(1 −
+     *      √P/√Pb)]` of the value in token1 and the complement in token0. Off centre those are not 50/50,
+     *      the mint consumes only as much as the SCARCER side allows, and the difference is stranded as
+     *      idle borrowed tokens: `stranded = 0.5 − 0.5 · min(w0,w1)/max(w0,w1)` of the borrow.
+     *
+     *      DIRECTION-INDEPENDENT: skew `s` and skew `10000 − s` produce mirror-image ranges, so `w0` and
+     *      `w1` swap and the ratio — hence the stranded fraction — is IDENTICAL. There is no "good"
+     *      direction to skew in at deploy time; the drag is the price of expressing the view.
+     *
+     *      This is a property of the range-blind borrow, NOT a bug in the skew: the follow-up
+     *      range-aware-borrow work is expected to size the two borrows at `w0 : w1` instead of 50/50 and
+     *      drive this to ~0, at which point this test's assertion FLIPS (assert ~0 stranded, and keep the
+     *      direction-independence half as-is).
+     */
+    function testDeployAtASkewedRangeStrandsTheSamePredictedFractionEitherWay() public {
+        // Put the pool on the SAME mark as the two feeds BEFORE genesis. The suite's default `TICK` is
+        // only loosely consistent with them, and this test measures a POOL-ratio effect in ORACLE value
+        // — a mismatched mark would show up as drag at every skew, centred included, and drown the thing
+        // under test. Moving it pre-genesis (rather than after) keeps the mocks self-consistent: nothing
+        // is minted at one price and collected at another.
+        pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK_ORACLE_CONSISTENT));
+        pool.setTick(TICK_ORACLE_CONSISTENT);
+
+        _execute(SEED);
+
+        (uint256 downStranded, uint256 downPredicted) = _strandedFractionAfterRerangeAndDeploy(8000);
+        (uint256 upStranded, uint256 upPredicted) = _strandedFractionAfterRerangeAndDeploy(2000);
+        (uint256 centeredStranded,) = _strandedFractionAfterRerangeAndDeploy(SKEW_CENTERED);
+
+        // The closed form is the claim; the measured drag is what the venue actually stranded.
+        assertApproxEqRel(downStranded, downPredicted, 2e16, "down-skew: measured drag == the closed form");
+        assertApproxEqRel(upStranded, upPredicted, 2e16, "up-skew: measured drag == the closed form");
+        // DIRECTION-INDEPENDENCE: mirror skews strand the same fraction (measured: 3669 vs 3678 bps).
+        // The residual 0.25% is grid alignment — both bounds round DOWN, so the two ranges are mirror
+        // images only up to one `tickSpacing`.
+        assertApproxEqRel(downStranded, upStranded, 1e16, "skew 8000 and skew 2000 strand the SAME fraction");
+        assertGt(upStranded, 3000, "the up-skew is adverse too -- there is no free direction at deploy");
+        // ...and it is a real cost: the centred range strands essentially nothing at the same width.
+        assertGt(downStranded, 3000, "a skewed deploy strands >30% of the borrow (range-blind 50/50)");
+        assertLt(centeredStranded, 100, "...where the centred range strands ~nothing");
+    }
+
+    /// @dev Re-range to `skewBps_`, deploy a fresh top-up into that STORED range, and return
+    ///      `(measured, predicted)` stranded fractions of the top-up's borrow, in bps. Rolls the book
+    ///      back so several skews compare against ONE post-genesis state.
+    function _strandedFractionAfterRerangeAndDeploy(uint16 skewBps_)
+        internal
+        returns (uint256 measuredBps, uint256 predictedBps)
+    {
+        uint256 snap = vm.snapshotState();
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, skewBps_, 0, 0);
+
+        predictedBps = _predictedStrandedBps(strategy.layout().posTickLower, strategy.layout().posTickUpper);
+
+        uint256 idleBefore = _idleLegValueUsdc();
+        uint256 topUp = 250_000e6;
+        usdc.mint(address(strategy), topUp);
+        vm.prank(proposer);
+        strategy.deployIdle(topUp, 0);
+
+        // The whole top-up becomes collateral and `topUp × targetLtv` is borrowed 50/50 by USD; whatever
+        // of that the mint could not take is the new idle-leg value.
+        uint256 borrowed = (topUp * uint256(TARGET_LTV_BPS)) / 10_000;
+        measuredBps = ((_idleLegValueUsdc() - idleBefore) * 10_000) / borrowed;
+        vm.revertToState(snap);
+    }
+
+    /// @dev `0.5 − 0.5 · min(w0,w1)/max(w0,w1)` in bps, where `w0`/`w1` are the VALUE shares the range
+    ///      demands at the current `sqrtP`. Derived from a reference-liquidity probe of the realised
+    ///      range (the same technique `LeveragedAeroValuation._rangeRatio` uses), so it is a genuinely
+    ///      independent prediction rather than a restatement of the implementation.
+    function _predictedStrandedBps(int24 tickLower, int24 tickUpper) internal view returns (uint256) {
+        (uint256 amt0, uint256 amt1) = LiquidityAmounts.getAmountsForLiquidity(
+            pool.sqrtPriceX96(),
+            TickMath.getSqrtRatioAtTick(tickLower),
+            TickMath.getSqrtRatioAtTick(tickUpper),
+            uint128(1 << 96)
+        );
+        uint256 v0 = _valueUsdc(amt0, P_LEG_B, 8); // token0 is leg B in this fixture
+        uint256 v1 = _valueUsdc(amt1, P_LEG_A, 18);
+        (uint256 lo, uint256 hi) = v0 < v1 ? (v0, v1) : (v1, v0);
+        return 5000 - (5000 * lo) / hi;
     }
 
     // ==================== REDEEM ====================

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -22,7 +22,7 @@ import {
     MockNpm
 } from "./LeveragedAeroVenuesHarness.sol";
 
-import {Test} from "@forge-std/Test.sol";
+import {Test, Vm} from "@forge-std/Test.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 
 /**
@@ -657,6 +657,132 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         _assertFlat();
         assertEq(mLegA.borrowBalance(address(strategy)), 0, "leg A debt fully cleared");
         assertEq(mLegB.borrowBalance(address(strategy)), 0, "leg B debt fully cleared");
+    }
+
+    // ============ settle: the final reward tranche (finding 9) ============
+
+    /**
+     * @dev REGRESSION (finding 9) — the TERMINAL settle's unwind auto-claims a last reward tranche
+     *      through `gauge.withdraw`, and `settleImpl` sweeps only the two LEG tokens. Left unsold it
+     *      never joins the USDC pot the vault's `redeemSettled` pays holders from: it stranded on a
+     *      `Settled` strategy, recoverable only through the owner's two-transaction
+     *      `rescueToVault` → `vault.rescueERC20`, and arriving there as a stray token rather than as
+     *      shareholder proceeds. `_settle` now sells it (best-effort — see the tests below).
+     */
+    function testSettleSellsTheAutoClaimedRewardTranche() public {
+        _execute(SEED);
+        uint256 tranche = 1000e18; // 1 AERO == 1 USDC at this fixture's router rate and feed mark
+        aero.mint(address(gauge), tranche);
+        gauge.setAeroToPayOnWithdraw(tranche);
+
+        vm.prank(address(vault));
+        strategy.settle();
+
+        assertEq(aero.balanceOf(address(strategy)), 0, "reward tranche sold, not stranded");
+        assertEq(usdc.balanceOf(address(strategy)), 0, "the whole realized balance was pushed to the vault");
+        // TIGHT on purpose (as in `testFlattenUnwindsWholeBookToIdleUsdcAndStaysExecuted`): the swap
+        // mocks fill at exact oracle parity, so the settled pot is the book PLUS the tranche's 1000
+        // USDC, and the only permitted gap is integer rounding.
+        assertApproxEqRel(
+            usdc.balanceOf(address(vault)), SEED + 1000e6, 0.0001e18, "reward proceeds reached the settled pot"
+        );
+    }
+
+    /**
+     * @dev THE DEADMAN PROPERTY. `settle()` is terminal, owner-driven and argument-less, so the
+     *      reward sale must never be able to block it. A stale reward feed fails the sale CLOSED
+     *      inside its own call frame (`StaleOracle`), the strategy's self-`try/catch` swallows it,
+     *      and the settle completes with the tranche left exactly where it was — degrading to the
+     *      pre-fix behaviour instead of bricking the fund's only exit. (`flatten` takes the opposite
+     *      posture on the same helper, and `testFlattenStillFailsClosedOnAStaleFeedAboveTheOracleFreeBand`
+     *      pins it: `flatten` is resumable, so failing closed there costs only a retry.)
+     */
+    function testSettleSurvivesAStaleRewardFeedAndLeavesTheTrancheRescuable() public {
+        _execute(SEED);
+        uint256 tranche = 1000e18;
+        aero.mint(address(gauge), tranche);
+        gauge.setAeroToPayOnWithdraw(tranche);
+        aeroFeed.setUpdatedAt(block.timestamp - 2 hours); // past the 1 hour maxDelay
+
+        vm.expectEmit(false, false, false, false, address(strategy));
+        emit LeveragedAerodromeCLStrategy.SettleRewardSaleDeferred();
+        vm.prank(address(vault));
+        strategy.settle();
+
+        assertEq(uint8(strategy.state()), uint8(BaseStrategy.State.Settled), "settle completed");
+        assertEq(aero.balanceOf(address(strategy)), tranche, "tranche untouched, never sold blind");
+        assertApproxEqRel(usdc.balanceOf(address(vault)), SEED, 0.0001e18, "the book itself still settled");
+        // ...and the residue is recoverable exactly as the pre-fix tranche was: the reward-token
+        // block on `rescueToVault` is scoped to `Executed`.
+        vm.prank(proposer);
+        strategy.rescueToVault(address(aero));
+        assertEq(aero.balanceOf(address(vault)), tranche, "residual tranche recovered post-settle");
+    }
+
+    /// @dev Same deadman property against a REVERTING reward route rather than a stale feed (the
+    ///      route is a third swap venue — a de-gauged/illiquid AERO pair fails here, not in the
+    ///      oracle). The settle must still complete.
+    function testSettleSurvivesARevertingRewardRoute() public {
+        _execute(SEED);
+        uint256 tranche = 1000e18;
+        aero.mint(address(gauge), tranche);
+        gauge.setAeroToPayOnWithdraw(tranche);
+        // PUSH1 0 PUSH1 0 REVERT — every call into the reward route reverts cleanly.
+        vm.etch(AERO_V2_ROUTER, hex"60006000fd");
+
+        vm.expectEmit(false, false, false, false, address(strategy));
+        emit LeveragedAerodromeCLStrategy.SettleRewardSaleDeferred();
+        vm.prank(address(vault));
+        strategy.settle();
+
+        assertEq(uint8(strategy.state()), uint8(BaseStrategy.State.Settled), "settle completed");
+        assertEq(aero.balanceOf(address(strategy)), tranche, "tranche untouched");
+    }
+
+    /// @dev Best-effort is NOT "sell at any price": the L9 floor is post-checked against the measured
+    ///      fill INSIDE the self-call, so an under-paying router reverts that frame and the swap is
+    ///      rolled back whole. The catch then leaves the tranche rescuable — it never books the bad
+    ///      fill. (`flatten` surfaces the identical condition as `BelowOracleFloor`.)
+    function testSettleDoesNotAcceptARewardFillBelowTheOracleFloor() public {
+        _execute(SEED);
+        uint256 tranche = 1000e18;
+        aero.mint(address(gauge), tranche);
+        gauge.setAeroToPayOnWithdraw(tranche);
+        // Re-etch a router paying 50% under the 1e8 feed mark (immutables => new instance + etch).
+        MockAeroV2Router cheap = new MockAeroV2Router(address(aero), address(usdc), 5e5);
+        vm.etch(AERO_V2_ROUTER, address(cheap).code);
+
+        vm.prank(address(vault));
+        strategy.settle();
+
+        assertEq(aero.balanceOf(address(strategy)), tranche, "under-priced fill rolled back, tranche intact");
+        assertApproxEqRel(usdc.balanceOf(address(vault)), SEED, 0.0001e18, "no under-priced proceeds booked");
+    }
+
+    /// @dev A zero reward balance must skip the sale CHEAPLY — before the oracle read and before the
+    ///      reward route. Proved by making BOTH fatal: the reward feed is stale and the v2 router is
+    ///      etched with invalid code, so any attempt to price or to sell would revert into the
+    ///      settle's catch and log `SettleRewardSaleDeferred`. No such log ⇒ neither was touched.
+    function testSettleWithNoRewardBalanceMakesNoRewardSaleCall() public {
+        _execute(SEED);
+        gauge.setAeroToPayOnWithdraw(0);
+        aeroFeed.setUpdatedAt(block.timestamp - 2 hours);
+        vm.etch(AERO_V2_ROUTER, hex"60006000fd");
+
+        vm.recordLogs();
+        vm.prank(address(vault));
+        strategy.settle();
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i; i < logs.length; i++) {
+            if (logs[i].topics.length == 0) continue;
+            assertTrue(
+                logs[i].topics[0] != LeveragedAerodromeCLStrategy.SettleRewardSaleDeferred.selector,
+                "a zero reward balance still reached the oracle or the router"
+            );
+        }
+        assertEq(aero.balanceOf(address(strategy)), 0, "no reward balance to begin with");
+        assertApproxEqRel(usdc.balanceOf(address(vault)), SEED, 0.0001e18, "settle unaffected");
     }
 
     // ==================== staging ====================


### PR DESCRIPTION
*Base is `feat/leveraged-aero-vanilla-vault`, not `main`.*

## What this ships

`rerange` re-centres the position around spot every cycle; backtesting on cbBTC/WETH shows centred is suboptimal. The proposer can now place the range asymmetrically:

```solidity
function rerange(uint24 width_, uint16 skewBps_, uint256 minLiq0, uint256 minLiq1)
    external onlyProposer nonReentrant;   // 0xb228841f
```

`skewBps` is the fraction of `width` placed **below** the current tick, bps scale: `5000` reproduces today's centred range bit-for-bit, `3500` is the backtest's 0.35 (35% below spot, 65% above). `lowerSpan = width × skewBps / 10000`, `upperSpan` is the exact complement; align-down discipline, `±MAX_TICK` clamps, and the one-spacing width tolerance are all unchanged.

## Design points

- **Validation.** `_checkSkew` rejects `skewBps ∉ (0, 10000)` and any skew that starves either side below one `tickSpacing` — this is what keeps a fresh range strictly bracketing the pool tick (the invariant `assetModeSplit` relies on) at every legal width.
- **Persisted like `width`.** A flat-book rerange stores both; the next `executeImpl` re-mints at the stored pair. Also in `InitParams` (ops default `5000`) and `layout()`. Packs into the existing `Layout` tail slot — zero new slots, `hedgedDebtA/B` byte-identical, pinned by a `vm.load` test and layout parity.
- **`WidthOutOfBounds()` → `OutOfBounds()`**, reused for skew. ⚠️ Selector changes `0x1f9f54af` → **`0xb4120f14`** — the rebalancer's error table needs the new one. LPV2 keeps its own `WidthOutOfBounds`; that mapping is deliberately untouched.
- **Bytecode.** The `$.width` persist relocates from `rerangeImpl` into the strategy (the relocation the code comment had earmarked); manager shrinks to **24,194 B (382 B margin)**. The strategy grows to **24,548 B — 28 B margin — and is now the binding EIP-170 constraint** on this pair.

## The part to review most carefully

In the two-borrowed-legs shape (exactly cbBTC/WETH), genesis/`deployIdle` borrows range-blind 50/50 (`_borrowHalfEach`), and a skewed range is not 50/50 by value — so the mint leaves an idle borrowed-token remainder. Not a hedge break (an idle borrowed token 1:1 hedges its own debt, NAV prices it) and not an LTV change: capital-utilisation drag, and it's **directional** — skewing down leaves more idle legB, skewing up leaves less. A test pins both directions plus NAV-indifference. Recommended ops default: centred genesis, skew via `rerange`. Making the borrow range-aware is a follow-up, out of scope.

## Verification

**159 leveraged-aero unit tests (up from 143), 0 failed**; account layer untouched, 51/51; layout parity 4/4 with empty diffs; fuzz re-run under 8 seeds. New coverage includes the first two-leg `rerange` tests, a fuzz generalising strict-bracketing to the whole legal skew set, and a `skew = 5000` equivalence test against the old `width/2` expression verbatim. That fuzz caught a real edge: near `±MAX_TICK` the domain clamp legitimately narrows the range below the requested width, so the width assertion is conditional on the clamp not firing (the clamped path keeps its own test).

Harness and docs move in lockstep: `SKEW_BPS` in the vnet stack harness/runner, `compound-cycle.sh`'s hardcoded `layout()` tuple re-verified against the compiled ABI (positional reads would have silently broken), rebalancer guide / runbook / audit doc / CONTEXT updated with the selector-change callout.

## Known gaps

1. The strategy sits **28 B under EIP-170** — the next strategy-side change pays for a relocation first.
2. The audit doc's "last verified" test counts predate the skew tests; refresh before any audit hand-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
