### PR TITLE
feat: split operator and policy roles — admin-only target LTV

### DIFF
--- a/docs/integrations/LEVERAGED_AERO_BACKEND.md
+++ b/docs/integrations/LEVERAGED_AERO_BACKEND.md
@@ -143,6 +143,34 @@ explicitly, and note that the two backend keys above are **different addresses**
 > backend.** The backend drives the account layer (`createStrategyForUser`, `depositIdle`); the rebalancer
 > drives the strategy (`compound`, `rerange`, `adjustLeverage`, `fulfillRedeem`). Confirm with
 > `strategy.proposer()` before wiring any keeper.
+>
+> ### The operations / policy split — `proposer` is operations only
+>
+> **The `proposer` role IS the rebalancer** (we deliberately did not rename it) and it covers
+> **operations** only. Fund **policy** sits behind a second, derived role: **`admin` ==
+> `Ownable(vault()).owner()`, the MAMO multisig** — no stored field, no setter, it simply follows the
+> vault owner. The gate is `onlyAdmin` → `NotAdmin()`.
+>
+> The principle: **the backend/keeper must not be capable of rugging you — RAISING fund risk is
+> multisig-only.** Admin-only entrypoints on the strategy are **`setTargetLtv(uint16)`** (the fund's
+> standing target LTV, either direction) and **`rescueToVault(address)`** (stray-token sweep; the
+> proposer could previously call this and can no longer). Neither is a backend touchpoint; both are
+> listed so the role model is unambiguous.
+>
+> ### The direction rule
+>
+> **The admin sets the target LTV in either direction; the proposer may only reduce it.** The proposer's
+> **`lowerTargetLtv(uint16)`** (`0xbd41b78c`) is monotonic down — it reverts `TargetLtvNotLower()`
+> (`0x4f3f9c5d`) unless the new value is *strictly* below the stored one, and it shares the same non-zero
+> floor (`TargetLtvZero()`). So a compromised keeper key can never raise leverage, never reach a zero
+> target, and never move tokens; it *can* ratchet the target down and destroy yield, which is bounded,
+> emits `TargetLtvUpdated` every step, and is reversible by the admin in one `setTargetLtv`. This is what
+> keeps the 2-day fulfil SLA off the multisig's critical path (see "SLA — the 2-day deadman" below).
+>
+> **ABI note for anyone remapping selectors:** `adjustLeverage` lost its target parameter —
+> `adjustLeverage(uint16,uint256,uint256)` (`0x9792419f`) → `adjustLeverage(uint256,uint256)`
+> (`0x4be1cadd`). Target LTV is now standing policy rather than a per-call argument. This is a
+> rebalancer-surface change; the account layer (`MamoLeveragedAeroStrategy`) is **unaffected**.
 
 ---
 
@@ -205,7 +233,7 @@ sequenceDiagram
 
     A-->>BE: WithdrawRequested(id, shares, minAssetsOut)   (account event — backend indexes it)
     A-->>RB: RedeemRequested(id, account, shares)          (strategy event — the keeper trigger)
-    Note over RB: optionally adjustLeverage down first so the unwind self-funds
+    Note over RB: if the unwind needs it, RB lowers policy ITSELF (lowerTargetLtv, down only) and runs adjustLeverage down — no multisig
     RB->>S: fulfillRedeem(id)                              (PROPOSER key = rebalancer)
     S-->>A: pays USDC to the account (idle) + RedeemFulfilled(id, account, assetsOut)
     Note over A: owner then sweeps via claimWithdrawnUsdc() → UsdcClaimed(amount)
@@ -214,8 +242,10 @@ sequenceDiagram
 
 1. The backend watches each account's `WithdrawRequested(id, shares, minAssetsOut)` (equivalently the
    strategy's `RedeemRequested(id, account, shares)`) for UX/product state — **not** to fulfil it.
-2. The rebalancer optionally levers down first (`adjustLeverage`) so the oracle-free proportional unwind
-   self-funds its IL, then calls `fulfillRedeem(id)` with the **proposer** key.
+2. The book is optionally levered **down** first so the oracle-free proportional unwind self-funds its IL
+   — a **single-actor** step: the rebalancer lowers the standing target itself with
+   `lowerTargetLtv(newTargetBps)` (proposer-only, strictly-lower) and runs `adjustLeverage(minLiq, minOut)`,
+   then calls `fulfillRedeem(id)` — all three with the **proposer** key, no multisig on the path.
 3. USDC lands on the account; the **owner** claims it with `claimWithdrawnUsdc()`.
 4. Confirm downstream via the account's `UsdcClaimed(amount)` (owner-initiated) or the strategy's
    `RedeemFulfilled`.
@@ -227,6 +257,10 @@ account, owner-gated) can trustlessly self-service via `emergencyWithdraw(id, mi
 `emergencyRedeem` (oracle-free proportional unwind). 2 days is the hard fulfillment SLA — it is the
 rebalancer's to meet, and the backend's to alert on: unfulfilled requests become user-executable and remove
 the operator from the loop.
+
+**No multisig signature sits inside that window.** The pre-fulfil de-risk is `lowerTargetLtv` +
+`adjustLeverage`, both proposer-only, so the SLA never depends on assembling multisig signers. The admin's
+`setTargetLtv` is needed only to **raise** the target back afterwards, which is off the critical path.
 
 ---
 

--- a/docs/integrations/LEVERAGED_AERO_REBALANCER.md
+++ b/docs/integrations/LEVERAGED_AERO_REBALANCER.md
@@ -80,13 +80,53 @@ Read `strategy.proposer()` off the clone you actually target before wiring a kee
 per-clone immutable, granted at `initialize`, and is unaffected by the removal of the Sherwood stack.
 Unless `FEE_RECIPIENT` overrides it at init, the proposer is also the strategy's fee recipient.
 
-Three authorization tiers appear on the strategy:
+> ### The **operations / policy split**: `proposer` ≠ `admin`
+>
+> **The `proposer` role IS the rebalancer.** We deliberately did **not** rename it — `proposer()` is the
+> keeper address and every operational entrypoint is `onlyProposer`.
+>
+> **`admin` is a second, derived role: `Ownable(vault()).owner()` — the MAMO multisig.** It is *not* a
+> stored field on the strategy and there is no setter; it simply follows whoever owns the vault, so a
+> vault-owner handover carries the strategy's admin rights with it. The gate is
+> `if (msg.sender != Ownable(vault()).owner()) revert NotAdmin();`.
+>
+> The split exists because **the backend/keeper must not be capable of rugging you: raising fund risk is
+> multisig-only.** The rebalancer moves the book toward the fund's standing policy and may **de-risk** it;
+> it cannot increase leverage and it cannot move tokens out of the strategy.
+>
+> ### 🧭 The direction rule — memorize this one line
+>
+> **The admin sets the target LTV in either direction; the proposer may only reduce it.**
+>
+> | Move | Who | Entrypoint |
+> |---|---|---|
+> | Raise the standing target (more leverage) | **admin only** | `setTargetLtv(uint16)` |
+> | Lower the standing target (de-risk) | admin **or** proposer | `setTargetLtv(uint16)` / `lowerTargetLtv(uint16)` |
+>
+> `lowerTargetLtv` is **monotonic down**: it reverts `TargetLtvNotLower()` unless the new value is
+> *strictly* below the stored one (equal is refused too), and it shares the non-zero floor. So a
+> compromised keeper key can never raise leverage, never reach a zero target, and never move tokens —
+> the split's premise survives intact, because levering *down* is not a rug.
+>
+> **Accepted residual, stated plainly:** a compromised or buggy keeper *can* ratchet the target toward the
+> floor and destroy yield. That harm is bounded (it cannot pass the non-zero floor), loud (every step
+> emits `TargetLtvUpdated` — monitor it), and reversible by the admin in **one** `setTargetLtv`.
+>
+> Three concrete consequences for keeper operators:
+> - **`adjustLeverage` no longer takes a target.** Target LTV is policy; `adjustLeverage(minLiq, minOut)`
+>   reads the stored `targetLtvBps()`.
+> - **The keeper can de-risk without a multisig.** `lowerTargetLtv` + `adjustLeverage` is a
+>   proposer-only sequence, which is what keeps the 2-day `FULFILL_WINDOW` off the multisig's critical
+>   path (§C).
+> - **`rescueToVault` is admin-only.** The proposer used to be able to call it. It can't any more.
+
+Four authorization tiers appear on the strategy:
 
 | Tier | Functions | Gate |
 |---|---|---|
-| Proposer-only | `deployIdle`, `compound`, `rerange`, `adjustLeverage`, `fulfillRedeem`, `updateParams` | `onlyProposer` (== `MAMO_REBALANCER`) |
+| Proposer-only (operations) | `deployIdle`, `compound`, `rerange`, `adjustLeverage`, `fulfillRedeem`, `updateParams`, **`lowerTargetLtv`** (policy, but **down only**) | `onlyProposer` (== `MAMO_REBALANCER`) |
+| **Admin-only (policy / custody)** | **`setTargetLtv`** (the only way to **raise** the target), `rescueToVault` | `onlyAdmin` — `Ownable(vault()).owner()`, the MAMO multisig → `NotAdmin()` |
 | Permissionless | `deleverage` | anyone (by design — safety backstop) |
-| Proposer **or** vault owner | `rescueToVault` | `proposer() \|\| Ownable(vault()).owner()` |
 | Vault-only (lifecycle) | `execute`, `settle` | `onlyVault` — the vault **owner** drives these, not the agent |
 
 - **State gate.** Every proposer op (and `deleverage`) opens with `if (_state != State.Executed) revert
@@ -100,9 +140,10 @@ Three authorization tiers appear on the strategy:
   deleverage is the user-safety backstop for an open-ended position (no fixed term, no scheduled unwind).
   It reverts `HealthyNoDeleverage` unless the position is genuinely unhealthy (conditions in §B). The
   agent should run it proactively, but anyone (a watcher bot, a user) can trigger it when health slips.
-- **`rescueToVault` always pays the vault.** The recovery target is hardcoded to `vault()`, never
-  caller-supplied, so neither the proposer nor the vault owner can exfiltrate; it only sweeps stray
-  (non-position) tokens.
+- **`rescueToVault` is ADMIN-ONLY and always pays the vault.** *(Behaviour change — the proposer could
+  previously call it; it now reverts `NotAdmin()` for the keeper.)* Moving tokens out of the strategy is
+  a custody action, not an operation. The recovery target is still hardcoded to `vault()`, never
+  caller-supplied, so even the admin cannot exfiltrate; it only sweeps stray (non-position) tokens.
 - **`updateParams(bytes)` is a no-op** here (`_updateParams` has an empty body — there are no tunable
   params). Listed for completeness; the agent never needs it.
 
@@ -256,26 +297,73 @@ a one-tick side is a lopsided range, and in asset-mode the next `deployIdle` / l
 > re-add). Making the borrow **range-aware** is the planned follow-up that removes the drag at source; it
 > is **out of scope** here.
 
-### `adjustLeverage` — move LTV toward a target
+### `setTargetLtv` — **ADMIN-ONLY**: set the fund's standing target LTV (either direction)
 
 ```solidity
-function adjustLeverage(uint16 targetLtvBps_, uint256 minLiq, uint256 minOut)
-    external onlyProposer nonReentrant;
+function setTargetLtv(uint16 targetLtvBps_) external onlyAdmin;   // selector 0x45325ee3
 ```
+
+**Not a rebalancer call.** Listed here because the rebalancer must *read* what it writes, and because it
+is **the only way to RAISE the target** — the keeper's `lowerTargetLtv` (below) covers the down
+direction. Only `Ownable(vault()).owner()` (the MAMO multisig) may call it; anyone else reverts
+`NotAdmin()` (`0x7bfa4b9f`) — including the proposer.
 
 | | |
 |---|---|
-| `targetLtvBps_` | Desired LTV in bps. **Checked at the entrypoint**: `targetLtvBps_ > maxLtvBps` reverts `TargetLtvExceedsMax()`. |
+| `targetLtvBps_` | The new **standing** target in bps. Must be **non-zero** → `TargetLtvZero()` (`0xcc7b6172`), and `≤ maxLtvBps` → `TargetLtvExceedsMax()`. A rejected value stores nothing and emits nothing. |
+| Why zero is refused | A zero standing target is not a brick — it borrows nothing, so `debtUsdc == 0`, `adjustLeverage`'s two branches both skip, and `_leverDown` guards the full-unwind case anyway (`FullUnwindNotSupported`). What it *is* is a fund that can silently never lever. Refused on **all three** write paths: the two setters, and `migrateVenue` (the guard sits in `LeveragedAeroVenue.applyVenue`, the route `_initialize` and `migrateVenue` share). |
+| Position effect | **None.** This is policy only; it moves nothing on chain. The value takes effect on the next `adjustLeverage` (retargets the live position to it) or the next `deployIdle` / `compound` / `execute` (sizes its collateral/borrow split at it). |
+| State gate | **None** — legal in `Pending` as well as `Executed`, so the multisig can correct an init-time target before the genesis `execute` without redeploying the clone. |
+| Events | `TargetLtvUpdated(uint16 previousBps, uint16 newBps)` — topic0 `0x74a1eafe22c602fe09147945eeb780f3482d293fefdceaa3ff058fd31134093e`. The only leverage-policy event on the contract; monitor it as a multisig-signed risk change. **Three emitters, one topic**: this setter, `lowerTargetLtv`, and `migrateVenue` — a migration's staged params carry their own `targetLtvBps`, and `applyVenue` announces it when it differs from the stored one (it stays quiet when it does not, and it also fires once at init, `previousBps == 0`). So the log stream is the complete history of the stored target, with no per-path special case. |
+| Read-back | `targetLtvBps()` or `layout().targetLtvBps` (§E) — the same storage read. |
+
+### `lowerTargetLtv` — **PROPOSER-ONLY, DOWN ONLY**: de-risk without a multisig
+
+```solidity
+function lowerTargetLtv(uint16 newTargetBps) external onlyProposer;   // selector 0xbd41b78c
+```
+
+**This one IS a rebalancer call.** It exists so the pre-`fulfillRedeem` lever-down does not need a
+multisig signature inside the 2-day `FULFILL_WINDOW` (§C): the keeper lowers policy itself, then runs
+`adjustLeverage` and `fulfillRedeem` — all three proposer-only.
+
+| | |
+|---|---|
+| `newTargetBps` | The new **standing** target in bps. Must be **strictly below** the current `targetLtvBps()` → `TargetLtvNotLower()` (`0x4f3f9c5d`); **equal also reverts**. Must be **non-zero** → `TargetLtvZero()` (`0xcc7b6172`), the same floor `setTargetLtv` and init enforce. A rejected value stores nothing and emits nothing. |
+| No `maxLtvBps` check | Not needed and not present: strictly below an already-validated stored target is below the cap by transitivity. |
+| Direction rule | The keeper can **only reduce**. Raising is `setTargetLtv`, admin-only. A compromised keeper key can de-lever the fund (bounded by the non-zero floor, loud via `TargetLtvUpdated`, reversible by the admin in one transaction) but can never lever it up and can never move tokens. |
+| Position effect | **None** — policy only, exactly like `setTargetLtv`. Takes effect on the next `adjustLeverage` / `deployIdle` / `compound`. |
+| State gate | **None** — matches `setTargetLtv` deliberately; legal in `Pending` as well as `Executed`. |
+| Events | `TargetLtvUpdated(uint16 previousBps, uint16 newBps)` — **the same event**, no second one to index. A monitor cannot tell admin from keeper (or a migration) by the event alone; use `tx.from` / the trace. |
+| What the ratchet rests on | The keeper's down-only rule is **not** the whole story: `migrateVenue` is proposer-gated and rewrites both `targetLtvBps` and `maxLtvBps` from its staged params. The keeper still cannot raise leverage only because (1) `stageVenue` is **owner-gated** and (2) `migrateVenue` re-derives `keccak256(abi.encode(p))` and requires it to equal the staged hash — so the keeper can execute only the exact parameter set the owner signed. Loosening either would silently un-gate the target LTV. |
+| Read-back | `targetLtvBps()` or `layout().targetLtvBps` (§E). |
+
+### `adjustLeverage` — move LTV toward the **stored** target
+
+```solidity
+function adjustLeverage(uint256 minLiq, uint256 minOut)
+    external onlyProposer nonReentrant;                           // selector 0x4be1cadd
+```
+
+> **⚠️ SIGNATURE CHANGED — the backend must remap.** Was
+> `adjustLeverage(uint16,uint256,uint256)` → `0x9792419f`. Now
+> `adjustLeverage(uint256,uint256)` → `0x4be1cadd`. The target LTV is **no longer a per-call argument**:
+> it is policy, set by the multisig with `setTargetLtv` (above). Read the target with `targetLtvBps()`
+> before deciding whether a retarget op is even worth sending.
+
+| | |
+|---|---|
+| Target | Read from storage (`layout().targetLtvBps`), **not** passed. No `maxLtvBps` check happens here — the stored value cleared that bound when the admin wrote it. |
 | `minLiq` | Minimum CL liquidity on a lever-**UP** add. |
 | `minOut` | Minimum USDC out of a lever-**DOWN** residual rebalancing swap. |
-| Position effect (both shapes) | Collateral untouched; LTV moves on the **debt** side. `targetDebt = targetLtvBps_ × collateralUsdc / 1e4`. Lever **down**: unwind the matching CL fraction and repay, per-leg residual rebalanced through USDC (`minOut`) — unchanged in asset-mode, where the leg-B residual **is** USDC and flows straight into the leg-A cover. Closes with `_assertHealthy()`. |
+| Position effect (both shapes) | Collateral untouched; LTV moves on the **debt** side. `targetDebt = targetLtvBps() × collateralUsdc / 1e4`. Lever **down**: unwind the matching CL fraction and repay, per-leg residual rebalanced through USDC (`minOut`) — unchanged in asset-mode, where the leg-B residual **is** USDC and flows straight into the leg-A cover. Closes with `_assertHealthy()`. |
 | Lever **down** — the cover sell is now **need-sized** | When one leg comes back short and the other long, `_rebalanceCover` sells the surplus leg to cover the shortfall. It now sells **only as much as covering the shortfall requires** and keeps the rest, instead of dumping the whole surplus balance. Two consequences for the operator: a lever-down (and the permissionless `deleverage`, same helper) realizes **less** unnecessary swap slippage and fees, and it **leaves the unsold surplus as an idle leg balance** — priced by `nav()`, still hedging its own debt, and redeployable on the next add. Do not model the residual sweep as "the surplus leg ends at zero" any more. |
 | Lever **up** — two borrowed legs | Borrow the delta 50/50 by USD across both legs and LP them against each other. **Self-funding**: the pair *is* the two borrows, so no idle USDC is consumed. |
 | Lever **up** — asset-mode | Borrows **only leg A** and pairs it with USDC **drawn from the strategy's idle balance**, sized closed-form (`assetModeLeverUpPair`) so the LP's leg-A amount equals the added leg-A debt — that is what preserves the delta-hedge (swapping part of the borrow to USDC would leave the book net short). **Operator consequence: an asset-mode lever-up CONSUMES idle USDC.** Value-conserving (a NAV component moving idle → LP, not a loss) but it shrinks the redeem cover budget until the next deposit. **Size lever-ups against available idle**; an under-funded one reverts `InsufficientIdleForLeverUp(needed, available)` and changes nothing — deliberately not a partial fill and not a silent cap. |
-| `targetLtvBps_` is **persisted** | The value is stored as the fund's standing target, so `execute` / `deployIdle` / `compound` size their **next** borrow at it. This holds even when neither branch runs (`targetDebt == debtUsdc`) — the retarget still takes effect, exactly like `rerange`-on-a-flat-book persisting `width` and `skewBps`. Read it back with `targetLtvBps()` or `layout().targetLtvBps` (§E). |
+| It writes **nothing** | The op no longer persists a target — the persist moved to `setTargetLtv`. When neither branch runs (`targetDebt == debtUsdc`, i.e. the book is already at policy) the call is a genuine no-op. The per-cycle range knobs are unaffected: `rerange` still persists `width` and `skewBps`. |
 | Fee interaction | **No crystallization** (like `rerange`): no supply change, no PnL realized; streaming fee defers, HWM unaffected. |
-| Errors | `TargetLtvExceedsMax`, `InsufficientLiquidity`, `MoonwellRepayFailed`/`MoonwellBorrowFailed`, `UnhealthyPosition`; **asset-mode lever-up also** `InsufficientIdleForLeverUp(uint256 needed, uint256 available)` and `DegenerateRange()` (the pairing is sized against the STORED range — a one-sided one fails closed; `rerange` unblocks it). `InsufficientIdleForLeverUp` is raised inside `LeveragedAeroValuation` but **re-declared on the strategy** (`LeveragedAerodromeCLStrategy.sol:93`, same selector) so it is on the clone's own ABI for the rebalancer / frontend — decode it off the strategy ABI, no library ABI needed. |
-| When to call | To hold the fund near `targetLtvBps`, and — critically — **before `fulfillRedeem`** to lever **down** so the oracle-free proportional unwind self-funds its IL/debt shortfall (see §C). In asset-mode note the two directions are asymmetric on idle: lever **down** frees USDC, lever **up** spends it. |
+| Errors | `InsufficientLiquidity`, `MoonwellRepayFailed`/`MoonwellBorrowFailed`, `UnhealthyPosition`; **asset-mode lever-up also** `InsufficientIdleForLeverUp(uint256 needed, uint256 available)` and `DegenerateRange()` (the pairing is sized against the STORED range — a one-sided one fails closed; `rerange` unblocks it). `InsufficientIdleForLeverUp` is raised inside `LeveragedAeroValuation` but **re-declared on the strategy** (same selector) so it is on the clone's own ABI for the rebalancer / frontend — decode it off the strategy ABI, no library ABI needed. `TargetLtvExceedsMax` is **no longer reachable here** — it moved to `setTargetLtv` with the parameter. |
+| When to call | To hold the fund near the standing `targetLtvBps()`. **To lever DOWN before `fulfillRedeem`** — so the oracle-free proportional unwind self-funds its IL/debt shortfall (see §C) — the keeper first calls **`lowerTargetLtv`** itself and then `adjustLeverage`: **no multisig step**, so the fulfil runbook is a single-actor sequence. Levering back **UP** afterwards is the multisig's `setTargetLtv`, and that one is not on the redemption critical path. (The permissionless `deleverage` remains available for the genuinely-unhealthy case.) In asset-mode note the two directions are asymmetric on idle: lever **down** frees USDC, lever **up** spends it. |
 
 ### `fulfillRedeem` — drain the withdraw queue
 
@@ -437,10 +525,13 @@ fully cover `f` of the debt, the unwind must cover the shortfall.
   needing more than the redeemer's slice reverts the whole redeem (fail-safe — never touches stayers'
   reserved `(1-f)` share of idle USDC/legs).
 
-Because a levered position tends to run a debt/IL shortfall against the collected legs, calling
-`adjustLeverage` to lever **down** first shrinks the debt the unwind must repay, so the proportional
-unwind self-funds cleanly instead of eating deep into collateral. This is the standard pre-fulfill
-step for anything but small requests.
+Because a levered position tends to run a debt/IL shortfall against the collected legs, levering
+**down** first shrinks the debt the unwind must repay, so the proportional unwind self-funds cleanly
+instead of eating deep into collateral. This is the standard pre-fulfill step for anything but small
+requests, and it is a **single-actor** step: the keeper lowers policy itself with
+`lowerTargetLtv(newTargetBps)` (down only) and then runs `adjustLeverage(minLiq, minOut)`. **No multisig
+signature is on the fulfil path**, which is what keeps the 2-day SLA achievable — raising the target back
+afterwards is the multisig's `setTargetLtv` and can happen at leisure.
 
 ### If `fulfillRedeem` reverts `InsufficientAssetsOut`
 
@@ -448,8 +539,8 @@ step for anything but small requests.
 position can't currently produce that floor (adverse IL / price move, or too much of the payout eaten
 by shortfall cover), the fulfill reverts `InsufficientAssetsOut()`. Reason from the code: the escrowed
 shares **carry no frozen price** — they keep bearing PnL until fulfilled — so the agent's options are
-(1) `adjustLeverage` down further to reduce the unwind's shortfall and raise the achievable net, then
-retry, or (2) **wait** for the position to recover and retry. Do **not** try to lower the floor — it is
+(1) lower policy further (the keeper's own `lowerTargetLtv`) and re-run `adjustLeverage` to reduce the unwind's
+shortfall and raise the achievable net, then retry, or (2) **wait** for the position to recover and retry. Do **not** try to lower the floor — it is
 the requester's, not the agent's. A stuck request self-resolves at the 2-day deadman (the account owner
 can also `cancelRedeem` to reclaim the shares).
 
@@ -457,13 +548,15 @@ can also `cancelRedeem` to reclaim the shares).
 sequenceDiagram
     participant A as Mamo account
     participant K as Agent keeper (proposer)
+    participant M as MAMO multisig (admin == vault owner)
     participant S as Strategy (LeveragedAerodromeCL)
 
     A->>S: requestRedeem(shares, minAssetsOut)
     S-->>K: RedeemRequested(id, account, shares)
     Note over K: read redeemRequest(id); assess if unwind self-funds
     opt shortfall likely (non-trivial size)
-        K->>S: adjustLeverage(lowerTarget, minLiq, minOut)   (lever DOWN)
+        K->>S: lowerTargetLtv(lowerTarget)                   (PROPOSER, down only — no multisig)
+        K->>S: adjustLeverage(minLiq, minOut)                (lever DOWN to it)
     end
     K->>S: fulfillRedeem(id)
     alt payout ≥ requester minAssetsOut
@@ -472,6 +565,8 @@ sequenceDiagram
         Note over K: deleverage/adjust more, or wait, then retry (never lower the floor)
     end
     Note over K: escalation — if unfulfilled at requestedAt + 2 days, the account can emergencyRedeem (missed SLA)
+    Note over M: the multisig is OFF this path; only raising the target back afterwards is its call
+    M-->>S: setTargetLtv(restoreTarget)                      (ADMIN-only, at leisure)
 ```
 
 ---
@@ -525,9 +620,11 @@ function targetLtvBps() external view returns (uint16);                         
 function hedgedDebt() external view returns (uint128 legA, uint128 legB);       // hedged borrow PRINCIPAL
 ```
 
-- **`targetLtvBps()`** is the fund's **standing** target — set at init and re-set by every `adjustLeverage`
-  — and it is what `execute` / `deployIdle` / `compound` size their borrow at. Read it **before** deciding
-  whether to retarget; do not infer it from the position's current LTV, which drifts with price.
+- **`targetLtvBps()`** is the fund's **standing** target — set at init, re-set in either direction by the
+  admin's `setTargetLtv`, and reducible by the keeper's `lowerTargetLtv` — and it is what `execute` /
+  `deployIdle` / `compound` size their borrow at and what `adjustLeverage` retargets the live position to.
+  Read it **before** rebalancing; do not infer it from the position's current LTV, which drifts with price.
+  If policy should be **higher** than it is, that is a multisig action, not a keeper one.
 - **`hedgedDebt()`** returns the borrowed **principal** each leg's LP side currently hedges. The unhedged
   accrued borrow interest is `borrowBalanceStored(market) − hedgedDebt*` per leg, and that difference is
   exactly what `compound` buys back and repays out of harvest proceeds (§B). Use it two ways: to decide
@@ -575,8 +672,10 @@ function hedgedDebt() external view returns (uint128 legA, uint128 legB);       
   plus the rest of the queue set (`RedeemFulfilled`/`RedeemCancelled`/`RedeemEmergency`) and
   `FeeCrystallizeDeferred`. Nothing needs to be added for the keeper's core watch-and-fulfill duty.
 - **Position-management ops emit nothing** — `deployIdle`, `compound`, `rerange`, `adjustLeverage`, and
-  `deleverage` are event-silent from both the strategy and the manager (verified: the manager emits no
-  events at all; the strategy declares only the five below). Until that changes, dashboards key off
+  `deleverage` are event-silent from both the strategy and the manager (the manager emits no events at
+  all). What *does* emit is every write to the standing target — the admin's `setTargetLtv`, the keeper's
+  `lowerTargetLtv`, and a `migrateVenue` whose staged params change it — all as
+  `TargetLtvUpdated(previousBps, newBps)`; watch it as a risk change. Until that changes, dashboards key off
   venue-level events (Moonwell mint/borrow/repay/redeem, Slipstream NPM increase/decrease, gauge
   stake/getReward) and transaction receipts.
 - **Adding events is an open option, not a blocker.** If the rebalancer or an indexer ends up needing
@@ -1067,11 +1166,11 @@ Production addresses are published separately at deploy.
 - [ ] **Read `layout().legBIsAsset` first and branch on it** — asset-mode changes `deployIdle` sizing, makes lever-**up** consume idle USDC, and adds `InsufficientIdleForLeverUp` / `DegenerateRange` to the error set (§G). `rerange` is **not** on that list any more: it re-adds only what its own unwind collected and never reaches idle.
 - [ ] `compound(minUsdcOut, minLiquidity)` on cadence with a **non-zero** `minUsdcOut`; expect it to defer (revert) on a stale AERO feed. **Do not predict the redeploy as `usdcOut − fee`** — `compound` first repays accrued borrow interest out of the harvest (§B), so the CL add is smaller by that amount; `MoonwellRepayFailed` is on that path.
 - [ ] Track drift with `hedgedDebt()` vs. each market's `borrowBalanceStored` (§E) to size the harvest cadence, and confirm it returns to ~0 after a compound; remember the on-chain measure accrues first, so the off-chain `…Stored` read is a lower bound.
-- [ ] Read the standing target with `targetLtvBps()`, not from the position's current LTV — `adjustLeverage` **persists** it and the next `deployIdle`/`compound` borrows at it.
+- [ ] Read the standing target with `targetLtvBps()`, not from the position's current LTV — the admin's `setTargetLtv` **persists** it, and `adjustLeverage` / the next `deployIdle`/`compound` all size at it.
 - [ ] `rerange(width, skewBps, minLiq0, minLiq1)` when spot drifts out of range or the model picks a new width **or skew** — `width` in raw ticks, tickSpacing-aligned, inside `[minWidth, maxWidth]`; `skewBps` in `(0, 10000)` (5000 = centered), inside the init-immutable `[minSkewBps, maxSkewBps]` band, with **both** spans ≥ one `tickSpacing` (else `OutOfBounds`, selector `0xb4120f14` — **re-point the backend error table off the retired `WidthOutOfBounds` `0x1f9f54af`**); expect calm-gate reverts on a shoved pool (retry when calm).
 - [ ] Size `(width, skewBps)` for the **realised** geometry, not the requested one: down-alignment preserves width exactly but always moves up to `tickSpacing − 1` ticks from the upper span into the lower one, so keep `upperSpan ≥ 2 × tickSpacing`; and remember skew is inert at `width == 2 × tickSpacing` (needs `≥ 3 × tickSpacing` to do anything) (§B).
 - [ ] In the two-borrowed-legs shape, budget for the **per-borrow ratchet** a skewed range creates against the range-blind 50/50 borrow: each `deployIdle`/`compound` strands a fresh, debt-funded slice of its own borrow (≈19 % at `skewBps` 3500, ≈33.5 % at 2000 *or* 8000) and the idle fraction grows with every compound until an op that resizes the book folds it back in (§B). Utilisation drag and borrow carry — not a hedge or health change.
-- [ ] `adjustLeverage(target, minLiq, minOut)` to hold near `targetLtvBps` — and to lever **down before `fulfillRedeem`** so the oracle-free unwind self-funds.
+- [ ] `adjustLeverage(minLiq, minOut)` — **selector `0x4be1cadd`, no target argument** — to hold near `targetLtvBps()`. To lever **down before `fulfillRedeem`** so the oracle-free unwind self-funds, call `lowerTargetLtv(newTargetBps)` first (**selector `0xbd41b78c`, proposer-only, strictly-lower**) — no multisig step. Raising the target back is the admin's `setTargetLtv`.
 - [ ] Watch `RedeemRequested` → assess self-funding via `redeemRequest(id)`/`previewRedeem` → (deleverage if needed) → `fulfillRedeem(id)`; on `InsufficientAssetsOut`, deleverage more or wait — never lower the requester's floor.
 - [ ] Treat `FULFILL_WINDOW = 2 days` as the hard SLA; alert before it; every `RedeemEmergency` is a missed SLA.
 - [ ] Alert on **supply reaching zero**: a full redeem burns the position NFT (`tokenId == 0` while still `Executed`) and the book cannot be rebuilt — `rerange` silently mints nothing, `deployIdle` fails closed, `compound` no-ops, and the only way forward is `settleStrategy()` plus a **new vault** (§F).

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -629,8 +629,9 @@ library LeveragedAeroManager {
         _assertHealthy();
     }
 
-    /// @notice Retarget the position's LTV to `targetLtvBps_` (body of the strategy's `adjustLeverage`;
-    ///         the entrypoint already enforced `targetLtvBps_ ≤ maxLtvBps`). Collateral is untouched,
+    /// @notice Retarget the position's LTV to `targetLtvBps_` (body of the strategy's `adjustLeverage`,
+    ///         which passes the fund's STORED standing target — already bounded by `maxLtvBps` when the
+    ///         admin wrote it via `setTargetLtv`, and non-zero). Collateral is untouched,
     ///         so LTV moves on the debt side: lever UP borrows the cbBTC/WETH delta and adds it
     ///         (`minLiq`); lever DOWN unwinds the matching CL fraction and repays (per-leg residual
     ///         rebalanced through USDC, bounded by `minOut`). Ends with `_assertHealthy`.
@@ -643,40 +644,29 @@ library LeveragedAeroManager {
     ///         into the LP, not a loss) but it shrinks the redeem cover budget until the next deposit, so
     ///         size lever-ups against available idle; an under-funded one reverts
     ///         `InsufficientIdleForLeverUp(needed, available)` and changes nothing.
-    /// @param targetLtvBps_ Target LTV in bps (≤ `maxLtvBps`). PERSISTED as the fund's standing target —
-    ///                      `execute` / `deployIdle` size their borrow off the STORED value, so a retarget
-    ///                      that did not persist would be silently undone by the next redeploy.
+    /// @param targetLtvBps_ Target LTV in bps. The caller passes the fund's STORED standing target
+    ///                      (`$.targetLtvBps`), which the admin's `setTargetLtv` already validated as
+    ///                      non-zero and `≤ maxLtvBps`; this function neither validates nor writes it.
     /// @param minLiq        Minimum CL liquidity on a lever-UP add (slippage guard).
     /// @param minOut        Minimum USDC out of a lever-DOWN residual swap (slippage guard).
     function adjustLeverageImpl(uint16 targetLtvBps_, uint256 minLiq, uint256 minOut) public {
-        // Persist the (already max-validated) target BEFORE the venue ops, exactly as `rerange`
-        // persists `width` / `skewBps`. Three reasons this ordering is the right one:
+        // NO PERSIST HERE — and none in the caller either. `targetLtvBps_` IS the stored standing
+        // target: the admin/proposer split moved the write out of this op entirely, into the
+        // admin-only `LeveragedAerodromeCLStrategy.setTargetLtv` (the proposer must be able to move the
+        // book toward policy, not to change policy). Two consequences worth stating:
         //
-        //   1. SAFETY IS UNAFFECTED. The strategy entrypoint already rejected `targetLtvBps_ >
-        //      maxLtvBps`, and this is the ONLY caller — so no out-of-band value can reach this write.
-        //      A later venue revert rolls the whole tx back atomically (there is no partial-failure
-        //      state in the EVM), so "stored target that doesn't match the position" is unreachable
-        //      either way: writing first cannot leave a stale target behind.
-        //   2. IT MUST APPLY EVEN WHEN NEITHER BRANCH RUNS. When `targetDebt == debtUsdc` (already at
-        //      target, or zero collateral pre-`execute`) both branches are skipped and the op is a
-        //      venue no-op — but the proposer's new target must still take effect, or it is silently
-        //      dropped. Identical to `rerange`-on-a-flat-book, and why the write is ahead of the
-        //      branches rather than tucked inside them.
-        //   3. NOTHING ON THE LEVERAGE PATH READS IT. `_leverUp` / `_leverDown` / `_assertHealthy` size
-        //      off the `targetDebt` computed below and off `maxLtvBps` / `minHealthBps`, never off
-        //      `$.targetLtvBps` (its only reader is `_supplyAndBorrow`, the deploy path). So this write
-        //      is behaviourally independent of the venue work in THIS call and only changes what the
-        //      NEXT `deployIdle` / `compound` sizes at.
-        //   4. WHERE THE WRITE LIVES. The `sstore` itself is performed by the STRATEGY entrypoint
-        //      (`LeveragedAerodromeCLStrategy.adjustLeverage`) rather than here, purely for EIP-170
-        //      headroom: that frame already loads `_layout()` for the `maxLtvBps` check, so the write
-        //      costs ~20 bytes there versus ~71 in this library, and this library is at the cap.
-        //      Semantics are identical — same transaction, same all-or-nothing revert, and still ahead
-        //      of the no-op branch below. (`rerangeImpl` used to persist `width` in-library, back when
-        //      the manager had room; the rerange-skew work made it the earmarked relocation candidate
-        //      and took it — `rerange` now writes BOTH `width` and `skewBps` in the strategy frame,
-        //      still ahead of the impl's own flat-book bail-out, and `rerangeImpl` takes no range
-        //      params at all.)
+        //   1. NOTHING ON THIS PATH READS `$.targetLtvBps` AGAIN. `_leverUp` / `_leverDown` /
+        //      `_assertHealthy` size off the `targetDebt` computed below and off `maxLtvBps` /
+        //      `minHealthBps`; `$.targetLtvBps`'s only other reader is `_supplyAndBorrow` (the deploy
+        //      path). So this op is purely "move the book to where policy already says".
+        //   2. THE NO-OP CASE IS NOW GENUINELY A NO-OP. When `targetDebt == debtUsdc` (already at
+        //      target, or zero collateral pre-`execute`) both branches are skipped and nothing happens
+        //      — previously this call still had to land the target write, which is what the ordering
+        //      argument that used to live here was about. The per-cycle range knobs are unaffected and
+        //      keep their own persistence: `rerange` writes BOTH `width` and `skewBps` in the STRATEGY
+        //      frame (for EIP-170 headroom, ahead of `rerangeImpl`'s own flat-book bail-out, so
+        //      `rerangeImpl` takes no range params at all) because those remain per-call proposer
+        //      knobs. The leverage target is not one.
         (uint256 collateralUsdc, uint256 debtUsdc) = _readCollateralDebt();
         uint256 targetDebt = (uint256(targetLtvBps_) * collateralUsdc) / 10000;
         if (targetDebt > debtUsdc) {
@@ -759,8 +749,8 @@ library LeveragedAeroManager {
     ///            SHORT the swapped amount — an op whose contract is "move leverage only" would silently
     ///            rewrite the fund's delta profile.
     ///
-    ///      (a) is implemented. `U′` is DERIVED, never passed, so `adjustLeverage`'s signature is
-    ///      unchanged: collateral is untouched by this op, so the debt delta is fixed by
+    ///      (a) is implemented. `U′` is DERIVED, never passed, so `adjustLeverage` needs no funding
+    ///      parameter for it: collateral is untouched by this op, so the debt delta is fixed by
     ///      `targetLtvBps_ × collateral` (computed in `adjustLeverageImpl`) and `U′` is that delta's
     ///      leg-A borrow paired at the STORED range's required (legA : USDC) ratio —
     ///      `LeveragedAeroValuation.assetModeLeverUpPair`, which shares its ratio probe and its

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -44,6 +44,12 @@ library LeveragedAeroVenue {
     // `MaxLtvExceedsCF`, `MinHealthMaxLtvConflict`) and `ComptrollerCallFailed` are NOT re-declared
     // here: `applyVenue` raises them through `LeveragedAeroValuation`'s copies, which already carry
     // the strategy's selectors. Re-declaring would be a second definition of the same ladder.
+    //
+    // `TargetLtvZero` IS declared here, and deliberately so: it is not part of that mirrored four-rung
+    // band (`checkLtvBand` / `checkRiskParams` carry the same four rungs on both the venue and init
+    // routes, and neither carries this one). It is a lower bound `applyVenue` alone enforces — see the
+    // rung itself, below the band call.
+    error TargetLtvZero(); // targetLtvBps == 0 — a standing target of zero can never lever
     error VenueNotStaged(); // migrate without a staged hash, or params that do not match it
     error BookNotFlat(); // migrate while a CL position, hedged basis, or leg debt is still live
     error PositionAlreadyOpen(); // redeploy on a book that already has a CL position (use deployIdle)
@@ -58,6 +64,24 @@ library LeveragedAeroVenue {
     event Flattened(uint256 idleUsdc);
     /// @notice The staged venue rewrite executed on a flat book.
     event VenueMigrated(address indexed oldPool, address indexed newPool);
+    /// @notice The fund's STANDING target LTV changed as a side effect of writing a venue — at init, and
+    ///         on every `migrateVenue` whose staged params carry a different `targetLtvBps`.
+    /// @dev RE-DECLARED, not imported: this is the SAME event `LeveragedAerodromeCLStrategy` declares for
+    ///      `setTargetLtv` / `lowerTargetLtv`, with the same signature and therefore the same `topic0`,
+    ///      and (like every event above) it is emitted from the STRATEGY's address because this library
+    ///      is linked and delegatecalled. A monitor filtering `TargetLtvUpdated` on the clone sees the
+    ///      migration-time change in the same stream as the setter-driven ones, with no ABI change on the
+    ///      strategy — it already declares this event. Importing the strategy here purely to qualify the
+    ///      name would make the strategy↔library import cycle two-way for zero behavioural difference;
+    ///      duplicate declaration is already this library's convention (`VenueStaged` et al. are declared
+    ///      here and consumed off the strategy ABI).
+    ///
+    ///      WHY IT MATTERS (review finding): `applyVenue` persists `p.targetLtvBps` unconditionally, and
+    ///      `migrateVenue` emits only `VenueMigrated`. Without this, an owner-staged migration could
+    ///      silently RESTORE a target the proposer had just ratcheted down with `lowerTargetLtv` —
+    ///      authorised (the params are hash-committed by the owner) but invisible to a monitor built on
+    ///      `lowerTargetLtv`'s "every step emits `TargetLtvUpdated`" contract.
+    event TargetLtvUpdated(uint16 previousBps, uint16 newBps);
 
     /// @notice The venue subset of the strategy's config — everything a pool/pair change touches.
     ///         Field semantics are LEG SLOTS exactly as in `InitParams` (names historical): `weth*`
@@ -537,6 +561,15 @@ library LeveragedAeroVenue {
         // Risk invariants against the LIVE collateral factor (re-read here — fresher than init's).
         // Both the read and the four rungs are the Valuation copies, shared with the init ladder.
         uint16 cfBps = LeveragedAeroValuation.readCollateralFactor($.comptroller, mUsdc);
+        // Lower bound as well as upper, and the ONLY rung of the band that is not mirrored in the init
+        // ladder. `applyVenue` is the SHARED route for both `_initialize` and `migrateVenue`, so this
+        // one check closes every path to a stored zero target that does not go through `setTargetLtv`.
+        // A zero standing target is not a brick (a zero target borrows nothing, so `debtUsdc == 0` and
+        // the full-unwind branch is unreachable — and `_leverDown` guards it anyway via
+        // `FullUnwindNotSupported`) but it IS a fund that can silently never lever. It stays HERE rather
+        // than inside `checkLtvBand` so the venue and init copies of that band remain the same four
+        // rungs in the same order.
+        if (p.targetLtvBps == 0) revert TargetLtvZero();
         LeveragedAeroValuation.checkLtvBand(p.targetLtvBps, p.maxLtvBps, p.minHealthBps, cfBps);
 
         // ── Persist the venue subset (every field a pool/pair change touches, nothing else) ──
@@ -556,6 +589,14 @@ library LeveragedAeroVenue {
         $.width = p.width;
         $.minWidth = p.minWidth;
         $.maxWidth = p.maxWidth;
+        // The target LTV is the one venue field that is also POLICY — the strategy exposes two setters
+        // for it and documents them as loud. Announce it here too, or a migration becomes the one route
+        // that moves the fund's leverage policy in silence (see `TargetLtvUpdated` above). Guarded on
+        // inequality: a migration that carries the SAME target stays quiet, so the event means "policy
+        // moved", never "a migration happened" (`VenueMigrated` already says that). At init the guard is
+        // trivially true (previous is 0), so a clone's opening policy is announced as well — a monitor
+        // can bootstrap the target from the log stream alone, with no init-time special case.
+        if ($.targetLtvBps != p.targetLtvBps) emit TargetLtvUpdated($.targetLtvBps, p.targetLtvBps);
         $.targetLtvBps = p.targetLtvBps;
         $.maxLtvBps = p.maxLtvBps;
         $.minHealthBps = p.minHealthBps;

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -75,7 +75,28 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     error InsufficientIdle();
     error HealthyNoDeleverage();
     error CannotRescuePositionToken();
-    error NotProposerOrOwner();
+    // Caller is not the ADMIN — i.e. not `Ownable(vault()).owner()`, the vault owner / MAMO multisig.
+    // The admin/proposer split (§8): the proposer is the rebalancer keeper and drives OPERATIONS; only
+    // the admin sets fund POLICY (`setTargetLtv`) or sweeps strays (`rescueToVault`). A compromised
+    // keeper key therefore cannot re-point the fund's leverage or move tokens out of the strategy.
+    error NotAdmin();
+    // A ZERO standing target is refused at EVERY route that can store one — `_initialize`, and both
+    // setters through the shared `_storeTargetLtv` floor check (so they cannot drift apart) — and the
+    // defence has always had a second, structural barrier behind those checks:
+    // a stored zero means `_supplyAndBorrow` borrows nothing, so `debtUsdc == 0`, so
+    // `adjustLeverageImpl`'s `targetDebt == debtUsdc` and both branches skip — `_unwindLiquidity`'s
+    // `num == den` full-removal branch (strips ALL liquidity, skips the re-stake, leaves `$.tokenId`
+    // pointing at an UNSTAKED NFT that every later venue op assumes is staked) is never reached.
+    // `deleverageImpl` computes its own non-zero `targetDebt` and gates on `debtBefore > targetDebt`,
+    // so nor can it. An unguarded init-zero is therefore milder than a brick: a clone that silently
+    // never levers, correctable only by a `setTargetLtv` the deployer must notice they need.
+    // `setTargetLtv(0)` on an ALREADY-LEVERED book is the sharp case — there `debtUsdc > 0`, so the
+    // full-removal branch IS reachable and the fund would be left with no trustless exit.
+    error TargetLtvZero();
+    // `lowerTargetLtv` is MONOTONIC DOWN: the proposer's copy of the leverage dial only ever reduces
+    // risk. Equal is refused too — a no-op write would emit a misleading `TargetLtvUpdated`, and the
+    // strict inequality is what makes the "keeper can never raise leverage" claim checkable in one line.
+    error TargetLtvNotLower();
     error OnlySelf();
     error PerformanceFeeTooHigh();
     error ManagementFeeTooHigh();
@@ -144,6 +165,12 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     event RedeemCancelled(uint256 indexed id, address indexed owner, uint256 shares);
     event RedeemEmergency(uint256 indexed id, address indexed owner, uint256 assetsOut);
 
+    /// @dev The fund's STANDING target LTV was re-set by the admin (`setTargetLtv`). This is a POLICY
+    ///      change, not an operation: it does not move the book by itself — the next `adjustLeverage`
+    ///      / `deployIdle` / `compound` sizes at the new value. Monitors should treat it as a
+    ///      multisig-signed risk change, and it is the only leverage-policy event on this contract.
+    event TargetLtvUpdated(uint16 previousBps, uint16 newBps);
+
     /// @dev A best-effort fee crystallise (deposit / fast redeem / proportional redeem) reverted and was
     ///      deferred; the op proceeded. Reverts on the fee-MINT (vault paused / feeRecipient
     ///      de-whitelisted) — or, near-unreachably, on the config read inside the crystallise (see the
@@ -162,6 +189,30 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///      failure — the tranche is left on the strategy and, now that the strategy is `Settled`, is
     ///      recoverable with `rescueToVault(rewardToken)` → the vault's `rescueERC20`.
     event SettleRewardSaleDeferred();
+
+    // ── Access control ──
+
+    /// @dev ADMIN == `Ownable(vault()).owner()` — the vault owner, i.e. the MAMO multisig. DERIVED,
+    ///      never stored: adding an admin field would mean a `Layout` change, and the vault owner is
+    ///      already the root of trust for this fund (it owns the vault that owns the shares, and it is
+    ///      the only party that can rotate the strategy). Following it also means an owner handover on
+    ///      the vault carries the strategy's admin rights with it, with no second migration to forget.
+    ///      Same read `rescueToVault` has always used for its owner leg.
+    ///
+    ///      This is the POLICY half of the operations/policy split — `onlyProposer` (BaseStrategy) is
+    ///      the operations half, held by the rebalancer keyed hot key. The keeper must not be capable
+    ///      of increasing what the fund risks: it can move the book toward the standing target and it
+    ///      can lower that target (`lowerTargetLtv`, strictly down, never to zero), but it can never
+    ///      raise it and it can never move tokens (`rescueToVault`).
+    ///
+    ///      DEPENDS ON TWO `LeveragedAeroVault` PROPERTIES (src/LeveragedAeroVault.sol): it overrides
+    ///      `renounceOwnership` to revert, and it is `Ownable2Step` so ownership cannot be handed to an
+    ///      address that never accepts. Drop either and one transaction on THAT contract permanently
+    ///      strands `setTargetLtv` and `rescueToVault` here, with no recovery path.
+    modifier onlyAdmin() {
+        if (msg.sender != Ownable(vault()).owner()) revert NotAdmin();
+        _;
+    }
 
     // ── Initialisation params (ABI-encoded → BaseStrategy.initialize → _initialize) ──
     //
@@ -463,9 +514,10 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         return _layout().redeemRequests[id];
     }
 
-    /// @notice The fund's STANDING target LTV in bps — set at init and re-set by every `adjustLeverage`.
-    ///         This is what `execute` / `deployIdle` / `compound` size their borrow at, so it is the value
-    ///         a rebalancer needs before deciding whether to retarget. Exposed as its own selector purely
+    /// @notice The fund's STANDING target LTV in bps — set at init and re-set ONLY by the admin's
+    ///         `setTargetLtv` (it is policy, not an operation). This is what `execute` / `deployIdle` /
+    ///         `compound` size their borrow at and what `adjustLeverage` retargets the live position to,
+    ///         so it is the value a rebalancer must read before rebalancing. Exposed as its own selector purely
     ///         for keeper ergonomics: `layout()` already carries it, but decoding a 40-plus-field
     ///         `LayoutView` to read one uint16 is needless work off-chain.
     /// @dev Same single storage read as `layout().targetLtvBps` (`_layout().targetLtvBps`, one diamond
@@ -741,8 +793,8 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         // where residual debt could not be covered at all, where no repay runs and the basis would
         // survive a book that no longer exists. Zeroed in THIS frame (not in the manager) because it
         // already holds `_layout()` for the fee discharge below, so the two `sstore`s cost ~20 bytes here
-        // versus ~70 in the manager, which is at the EIP-170 cap — the same relocation `adjustLeverage`'s
-        // target-LTV write already makes.
+        // versus ~70 in the manager, which is at the EIP-170 cap — the same relocation `setTargetLtv`'s
+        // target-LTV write makes.
         $.hedgedDebtA = 0;
         $.hedgedDebtB = 0;
         uint256 owed = $.protocolFeeOwed;
@@ -1101,11 +1153,116 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         LeveragedAeroManager.rerangeImpl(minLiq0, minLiq1);
     }
 
-    /// @notice Retarget the position's LTV to `targetLtvBps_` (borrow/repay; no new USDC). Collateral
-    ///         is untouched, so LTV moves on the debt side via `LeveragedAeroManager.adjustLeverageImpl`:
-    ///         lever UP borrows the cbBTC/WETH delta and adds it (`minLiq`); lever DOWN unwinds the
-    ///         matching CL fraction and repays (per-leg residual rebalanced through USDC, bounded by
-    ///         `minOut`). Ends with `_assertHealthy`. `targetLtvBps_ ≤ maxLtvBps` is checked here.
+    /// @notice ADMIN-ONLY POLICY: set the fund's STANDING target LTV, in EITHER direction. This is the
+    ///         multisig's leverage dial: the proposer moves the book toward the target
+    ///         (`adjustLeverage`) and may de-risk by lowering it (`lowerTargetLtv`), but only the admin
+    ///         can RAISE it. That is the whole point of `onlyAdmin` here: a compromised rebalancer key
+    ///         can rebalance and de-lever, but it cannot lever the fund up toward the cap.
+    ///
+    ///         Sets policy ONLY — it moves nothing on chain. `execute` / `deployIdle` / `compound` size
+    ///         their collateral/borrow split off the STORED target, and `adjustLeverage` retargets the
+    ///         live position to it, so the new value takes effect on the next such call.
+    ///
+    ///         NOT state-gated: legal in `Pending` as well as `Executed`. Setting policy before the
+    ///         genesis `execute` is exactly the case that most wants to be settable — it is how the
+    ///         multisig corrects an init-time target without redeploying the clone — and there is no
+    ///         invariant that a stored target only be meaningful post-execute (`_initialize` already
+    ///         writes one while Pending). Post-`Settled` it is a harmless no-op on a dead book.
+    /// @param targetLtvBps_ New standing target in bps. Must be non-zero (see `TargetLtvZero` — a zero
+    ///                      target is not a brick, but it borrows nothing, so it is a fund that can
+    ///                      silently never lever) and `≤ maxLtvBps`. A rejected value stores nothing and
+    ///                      emits nothing.
+    function setTargetLtv(uint16 targetLtvBps_) external onlyAdmin {
+        Layout storage $ = _layout();
+        if (targetLtvBps_ > $.maxLtvBps) revert TargetLtvExceedsMax();
+        _storeTargetLtv($, targetLtvBps_);
+    }
+
+    /// @notice PROPOSER-SAFE DE-RISK: the proposer (rebalancer) may lower the standing target, and only
+    ///         ever lower it. This is the one leverage knob the keeper holds, and it exists so the
+    ///         pre-`fulfillRedeem` lever-down does not need a multisig signature inside the 2-day
+    ///         `FULFILL_WINDOW` — the keeper can de-risk ahead of a large unwind and then run
+    ///         `adjustLeverage` itself.
+    ///
+    ///         THE SECURITY PROPERTY, PLAINLY: the proposer can lower leverage, but it can NEVER raise
+    ///         it (strictly-lower only), NEVER reach zero (`TargetLtvZero`, same floor as
+    ///         `setTargetLtv`), and NEVER move tokens (`rescueToVault` stays `onlyAdmin`). Raising the
+    ///         standing target remains admin-only via `setTargetLtv`. So the operations/policy split's
+    ///         premise survives intact: a compromised keeper key still cannot rug the fund, because
+    ///         levering DOWN is not a rug.
+    ///
+    ///         ACCEPTED RESIDUAL, stated honestly: a compromised or buggy keeper CAN ratchet the target
+    ///         down toward the floor and destroy yield. That harm is bounded (it cannot pass the
+    ///         non-zero floor, and de-levering conserves value modulo unwind costs), loud (every step
+    ///         emits `TargetLtvUpdated` — monitor it), and reversible by the admin in ONE `setTargetLtv`.
+    ///         "Every step emits `TargetLtvUpdated`" is a claim about the WHOLE contract, not just this
+    ///         function: `migrateVenue` rewrites the target too, and `LeveragedAeroVenue.applyVenue`
+    ///         emits the same event (same signature, same `topic0`, same emitting address) when it does.
+    ///         Do not add a fourth write path without an emit — the monitor built on this sentence would
+    ///         go blind to it.
+    ///
+    ///         THE GATE THIS RESTS ON, RECORDED SO IT IS NOT LOOSENED BY ACCIDENT. "The keeper cannot
+    ///         raise leverage" is NOT a property of this function alone. `migrateVenue` is `onlyProposer`
+    ///         and rewrites BOTH `targetLtvBps` and `maxLtvBps`, so a keeper that could choose the
+    ///         migration params could raise both in one call and walk straight past the strictly-lower
+    ///         rule here. It cannot, for exactly two reasons, and only those two:
+    ///           1. `stageVenue` is OWNER-gated — the keeper cannot author a destination; and
+    ///           2. the params are BYTE-COMMITTED — `migrateVenue` re-derives
+    ///              `keccak256(abi.encode(p))` and requires it to equal the staged hash, so the keeper
+    ///              can only execute the exact parameter set the owner signed off, never a variant.
+    ///         Both hold today. LOOSENING `stageVenue`'s GATE LATER — to the proposer, to a role, to a
+    ///         "trusted" relayer — WOULD SILENTLY UN-GATE THE TARGET LTV, with nothing in this file
+    ///         changing to say so. Same for weakening the hash commitment to a partial or field-wise
+    ///         check. If either must change, the target and `maxLtvBps` have to move out of the
+    ///         migratable venue subset first.
+    ///
+    ///         Sets policy ONLY — it moves nothing on chain; the next `adjustLeverage` / `deployIdle` /
+    ///         `compound` sizes at the new value. NOT state-gated, for the same reason `setTargetLtv`
+    ///         is not: the stored target is meaningful in `Pending` too, and a post-`Settled` write is a
+    ///         harmless no-op on a dead book.
+    /// @param newTargetBps New standing target in bps. Must be STRICTLY below the current
+    ///                     `targetLtvBps()` (equal reverts `TargetLtvNotLower`) and non-zero. A rejected
+    ///                     value stores nothing and emits nothing.
+    function lowerTargetLtv(uint16 newTargetBps) external onlyProposer {
+        Layout storage $ = _layout();
+        if (newTargetBps >= $.targetLtvBps) revert TargetLtvNotLower();
+        // NO `maxLtvBps` CHECK, deliberately — do not "fix" its absence. The stored target already
+        // cleared that bound (at init or via `setTargetLtv`), and this value is strictly below the
+        // stored one, so it clears the cap by transitivity.
+        _storeTargetLtv($, newTargetBps);
+    }
+
+    /// @dev Shared floor-check + persist behind BOTH target-LTV entrypoints, so the two cannot drift on
+    ///      the invariant that matters (never store a zero) or on the event contract. Each caller
+    ///      checks its OWN bound first — the admin's cap, the proposer's strict decrease — and passes
+    ///      `$` in rather than have this re-read it, both to save bytes on a contract at the EIP-170 cap.
+    ///
+    ///      Persists HERE, in the strategy frame, not in the manager library: the callers already hold
+    ///      `$` for their bound check, so the write is ~20 bytes here versus ~71 in the manager, which
+    ///      is itself at the cap. (That rationale moved with the write from `adjustLeverage`, which no
+    ///      longer takes or persists a target.)
+    ///
+    ///      Checking the floor AFTER the caller's bound is not an observable reorder for either caller:
+    ///      zero can never exceed `maxLtvBps`, and zero is never `>=` a stored target that is itself
+    ///      guaranteed non-zero — so a zero argument reaches `TargetLtvZero` on both paths, exactly as
+    ///      it did when `setTargetLtv` checked the floor first.
+    function _storeTargetLtv(Layout storage $, uint16 newTargetBps) private {
+        if (newTargetBps == 0) revert TargetLtvZero();
+        emit TargetLtvUpdated($.targetLtvBps, newTargetBps);
+        $.targetLtvBps = newTargetBps;
+    }
+
+    /// @notice Retarget the position's LTV to the fund's STORED standing target `targetLtvBps()`
+    ///         (borrow/repay; no new USDC). Collateral is untouched, so LTV moves on the debt side via
+    ///         `LeveragedAeroManager.adjustLeverageImpl`: lever UP borrows the cbBTC/WETH delta and adds
+    ///         it (`minLiq`); lever DOWN unwinds the matching CL fraction and repays (per-leg residual
+    ///         rebalanced through USDC, bounded by `minOut`). Ends with `_assertHealthy`.
+    ///
+    ///         The target is NOT a parameter — it is policy, written at init, by the admin via
+    ///         `setTargetLtv` (either direction), or by the proposer via `lowerTargetLtv` (DOWN only).
+    ///         That is what keeps the `onlyProposer` keeper unable to INCREASE the fund's risk. No
+    ///         `maxLtvBps` check is needed here: the stored target cleared that bound when it was
+    ///         written, so this entrypoint is purely "move the book to where policy already says".
     ///
     ///         ASSET-MODE (leg-B slot == usdc): a lever-UP borrows ONLY leg A and pairs it with USDC
     ///         drawn from the strategy's IDLE balance, sized closed-form so the LP's leg-A amount equals
@@ -1117,28 +1274,11 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///
     ///         NO fee crystallisation (like `rerange`): no supply change, no PnL realized; the
     ///         streaming fee is deferred and the HWM is unaffected.
-    ///         PERSISTED, like `rerange`'s `width`: `targetLtvBps_` becomes the fund's STANDING target
-    ///         (readable via `targetLtvBps()` / `layout().targetLtvBps`), not a one-shot per-call knob.
-    ///         `execute` / `deployIdle` / `compound` size their borrow off the STORED target, so a
-    ///         retarget that did not persist would be silently dragged back by the next redeploy —
-    ///         the rebalancer would be fighting its own book.
-    /// @param targetLtvBps_ Target LTV in bps (must be ≤ `maxLtvBps`). Persisted as the new standing
-    ///                      target once that check passes; a rejected value stores nothing.
-    /// @param minLiq        Minimum CL liquidity on a lever-UP add (slippage guard).
-    /// @param minOut        Minimum USDC out of a lever-DOWN residual swap (slippage guard).
-    function adjustLeverage(uint16 targetLtvBps_, uint256 minLiq, uint256 minOut) external onlyProposer nonReentrant {
+    /// @param minLiq Minimum CL liquidity on a lever-UP add (slippage guard).
+    /// @param minOut Minimum USDC out of a lever-DOWN residual swap (slippage guard).
+    function adjustLeverage(uint256 minLiq, uint256 minOut) external onlyProposer nonReentrant {
         if (_state != State.Executed) revert NotExecuted();
-        Layout storage $ = _layout();
-        if (targetLtvBps_ > $.maxLtvBps) revert TargetLtvExceedsMax();
-        // Persist the new standing target HERE, not in the manager: this frame already holds `$` for
-        // the bound check above, so the write is ~20 bytes here versus ~71 in the manager library,
-        // which sits at the EIP-170 cap. Semantics are unchanged — the write is in the same
-        // transaction as the venue work (a later revert rolls it back), it happens only after the
-        // `maxLtvBps` check, and it lands even when the retarget is a venue no-op
-        // (`targetDebt == debtUsdc`), which is the `rerange`-on-a-flat-book analogue. See the ordering
-        // note in `LeveragedAeroManager.adjustLeverageImpl`.
-        $.targetLtvBps = targetLtvBps_;
-        LeveragedAeroManager.adjustLeverageImpl(targetLtvBps_, minLiq, minOut);
+        LeveragedAeroManager.adjustLeverageImpl(_layout().targetLtvBps, minLiq, minOut);
     }
 
     /// @notice Permissionless safety valve: when health falls below `minHealthBps`, ANYONE may unwind
@@ -1294,7 +1434,11 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///         fast path can't serve (or when the oracle is down). Shares are pulled NOW
     ///         (`vault.approve(strategy, shares)` required) and held in the strategy; NO price is
     ///         stamped (shares keep bearing PnL until `fulfillRedeem`), so `cancelRedeem` is not a free
-    ///         look-back option. The backend deleverages (via `adjustLeverage`) then `fulfillRedeem`s.
+    ///         look-back option. Levering down before the fulfill stays a ONE-PARTY step under the
+    ///         admin/proposer split: the proposer (rebalancer) lowers the standing target itself with
+    ///         `lowerTargetLtv` (monotonic down), then runs `adjustLeverage` and `fulfillRedeem` — no
+    ///         multisig round trip inside `FULFILL_WINDOW`. Only RAISING the target back afterwards is
+    ///         the admin's `setTargetLtv`.
     /// @param shares       Vault shares to escrow (12dp).
     /// @param minAssetsOut Slippage floor enforced (on the net amount) at fulfill.
     /// @return id          The request id (also emitted).
@@ -1315,9 +1459,11 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
 
     /// @notice Fulfill an escrowed request via the oracle-free proportional unwind (the demoted
     ///         everyday path, now reachable ONLY here and via `emergencyRedeem`). `onlyProposer`: the
-    ///         backend deleverages first (`adjustLeverage`) so the unwind's IL self-funds, then fulfills
-    ///         paying `request.owner`. NOT owner-callable — an owner-callable fulfill would resurrect
-    ///         the demoted oracle-free path through the side door.
+    ///         proposer (rebalancer) lowers the standing target with `lowerTargetLtv` if the unwind
+    ///         needs it, runs `adjustLeverage` so the unwind's IL self-funds, then fulfills paying
+    ///         `request.owner` — all three are proposer-callable, so the 2-day `FULFILL_WINDOW` never
+    ///         depends on a multisig signature. NOT owner-callable — an owner-callable fulfill would
+    ///         resurrect the demoted oracle-free path through the side door.
     /// @param id Request id to fulfill.
     function fulfillRedeem(uint256 id) external onlyProposer nonReentrant {
         if (_state != State.Executed) revert NotExecuted();
@@ -1417,10 +1563,13 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         IERC20($.usdc).safeTransfer(recipient, fee);
     }
 
-    /// @notice Sweep a STRAY ERC-20 (airdrop / accidental send) back to the vault. Callable by the
-    ///         proposer OR the vault owner (§8) — the owner leg is what keeps the sweep reachable
-    ///         through a dead proposer key. Target is always `vault()`, never caller-supplied, so
-    ///         neither caller picks the destination (§13); onward recovery is the vault's own
+    /// @notice Sweep a STRAY ERC-20 (airdrop / accidental send) back to the vault. ADMIN-ONLY (§8) —
+    ///         the vault owner / multisig, NOT the proposer. Moving tokens out of the strategy is a
+    ///         custody action, not an operation, and the operations/policy split says the keeper key
+    ///         must not be able to move funds; the sweep is also rare and never time-critical, so
+    ///         routing it through the multisig costs nothing operationally. (It was previously
+    ///         `proposer() || owner()`; the proposer leg is gone.) Target is always `vault()`, never
+    ///         caller-supplied, so the caller cannot pick the destination (§13); onward recovery is the vault's own
     ///         owner-only `rescueERC20`, which refuses BOTH the vault asset (while shares are
     ///         outstanding) and the share token itself. Reverts `CannotRescuePositionToken` for any
     ///         position/accounting token — usdc / cbBTC / weth (all NAV-counted) / mUsdc / mCbBTC /
@@ -1440,8 +1589,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///           dust balance. That residue, plus any post-settle donation, is what this recovers.
     ///
     ///         The position NFT is never swept (no ERC-721 path).
-    function rescueToVault(address token) external nonReentrant {
-        if (msg.sender != proposer() && msg.sender != Ownable(vault()).owner()) revert NotProposerOrOwner();
+    function rescueToVault(address token) external onlyAdmin nonReentrant {
         Layout storage $ = _layout();
         address aero = ICLGauge($.gauge).rewardToken();
         if (

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -220,6 +220,17 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         strategy.execute();
     }
 
+    /// @dev The ADMIN/PROPOSER two-step that replaced the old one-shot `adjustLeverage(target, ...)`:
+    ///      the vault owner (multisig) sets POLICY with `setTargetLtv`, then the proposer (rebalancer)
+    ///      moves the book to it with `adjustLeverage`. Both roles are required — neither can do the
+    ///      other's half — which is exactly what these lifecycle tests exercise implicitly.
+    function _retarget(uint16 target) internal {
+        vm.prank(owner);
+        strategy.setTargetLtv(target);
+        vm.prank(proposer);
+        strategy.adjustLeverage(0, 0);
+    }
+
     /// @dev The collateral / LP-USDC / borrow triple the split would return for `amount` at the range
     ///      the production path will use — recomputed independently so the tests can assert against it.
     function _expectedSplit(uint256 amount, int24 tickLower, int24 tickUpper)
@@ -590,8 +601,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         (uint256 collateralBefore,) = _collateralAndDebt();
         usdc.mint(address(strategy), expLpUsdc); // fund the draw
 
-        vm.prank(proposer);
-        strategy.adjustLeverage(newTarget, 0, 0);
+        _retarget(newTarget);
 
         // 1. LTV reached the requested target. Tolerance 2 bps, and it is PHYSICAL, not slack: the debt
         //    delta is floor-divided into leg-A units at the 8dp feed price and the LTV is itself a floor
@@ -628,8 +638,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         uint256 npmUsdcBefore = usdc.balanceOf(address(npm));
         uint256 navBefore = strategy.nav();
 
-        vm.prank(proposer);
-        strategy.adjustLeverage(6000, 0, 0);
+        _retarget(6000);
 
         uint256 drawn = idleBefore - usdc.balanceOf(address(strategy));
         assertEq(drawn, usdc.balanceOf(address(npm)) - npmUsdcBefore, "every drawn USDC went into the LP");
@@ -655,11 +664,14 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         uint256 tokenIdBefore = strategy.layout().tokenId;
         uint128 liqBefore = npm.liquidityOf(tokenIdBefore);
 
+        vm.prank(owner);
+        strategy.setTargetLtv(6000);
+
         vm.prank(proposer);
         vm.expectRevert(
             abi.encodeWithSelector(LeveragedAerodromeCLStrategy.InsufficientIdleForLeverUp.selector, needed, needed - 1)
         );
-        strategy.adjustLeverage(6000, 0, 0);
+        strategy.adjustLeverage(0, 0);
 
         // State untouched — the check runs BEFORE the borrow, and the revert rolls back regardless.
         assertEq(mLegA.borrowBalance(address(strategy)), debtBefore, "no borrow happened");
@@ -671,7 +683,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         // One more wei of idle clears the bound — the boundary is exactly the derived U'.
         usdc.mint(address(strategy), 1);
         vm.prank(proposer);
-        strategy.adjustLeverage(6000, 0, 0);
+        strategy.adjustLeverage(0, 0);
         assertGt(mLegA.borrowBalance(address(strategy)), debtBefore, "lever UP went through at exactly U' idle");
     }
 
@@ -687,34 +699,40 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         pool.setTick(farTick);
         legAFeed.setAnswer(int256(_legAPriceFromSqrtP(pool.sqrtPriceX96())));
 
+        vm.prank(owner);
+        strategy.setTargetLtv(6000);
         vm.prank(proposer);
         vm.expectRevert(LeveragedAeroValuation.DegenerateRange.selector);
-        strategy.adjustLeverage(6000, 0, 0);
+        strategy.adjustLeverage(0, 0);
     }
 
     // ==================== TARGET-LTV PERSISTENCE (asset-mode) ====================
 
-    /// @dev `adjustLeverage` sets the fund's STANDING target, both directions — the same contract
-    ///      `rerange` has for `width`. The dedicated getter and `layout()` are the same storage read,
-    ///      so they are asserted together at every step: they can never legitimately disagree.
-    function testAdjustLeveragePersistsTheStandingTarget() public {
+    /// @dev The ADMIN's `setTargetLtv` is what sets the fund's STANDING target — the same contract
+    ///      `rerange`'s `width` has, except the write is policy and lives behind `onlyAdmin`.
+    ///      `adjustLeverage` CONSUMES it (both directions) and never writes it. The dedicated getter and
+    ///      `layout()` are the same storage read, so they are asserted together at every step: they can
+    ///      never legitimately disagree.
+    function testSetTargetLtvPersistsTheStandingTargetAndAdjustLeverageConsumesIt() public {
         _execute(SEED);
         assertEq(strategy.targetLtvBps(), TARGET_LTV_BPS, "genesis: the init target IS the standing target");
         assertEq(strategy.layout().targetLtvBps, TARGET_LTV_BPS, "genesis: getter == layout()");
 
-        // Lever UP persists.
+        // Lever UP: the admin writes policy, the keeper's op reads it.
         (, uint256 needed) = _expectedLeverUpPair(6000);
         usdc.mint(address(strategy), needed);
-        vm.prank(proposer);
-        strategy.adjustLeverage(6000, 0, 0);
-        assertEq(strategy.targetLtvBps(), 6000, "lever UP persisted the new standing target");
+        _retarget(6000);
+        assertEq(strategy.targetLtvBps(), 6000, "the admin's write IS the new standing target");
         assertEq(strategy.layout().targetLtvBps, 6000, "getter == layout() after lever UP");
+        (uint256 collateralUp, uint256 debtUp) = _collateralAndDebt();
+        assertApproxEqAbs((debtUp * 10_000) / collateralUp, 6000, 2, "the book landed on the STORED target");
 
-        // Lever DOWN persists too — the write is on the shared path, not the up-branch.
-        vm.prank(proposer);
-        strategy.adjustLeverage(3000, 0, 0);
-        assertEq(strategy.targetLtvBps(), 3000, "lever DOWN persisted the new standing target");
+        // Lever DOWN, same two-step. `adjustLeverage` still wrote nothing.
+        _retarget(3000);
+        assertEq(strategy.targetLtvBps(), 3000, "the admin re-set the standing target downward");
         assertEq(strategy.layout().targetLtvBps, 3000, "getter == layout() after lever DOWN");
+        (uint256 collateralDown, uint256 debtDown) = _collateralAndDebt();
+        assertApproxEqAbs((debtDown * 10_000) / collateralDown, 3000, 20, "the book followed the stored target down");
     }
 
     /**
@@ -734,8 +752,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         // 1. Retarget to 6000 and confirm the position really got there.
         (, uint256 needed) = _expectedLeverUpPair(6000);
         usdc.mint(address(strategy), needed);
-        vm.prank(proposer);
-        strategy.adjustLeverage(6000, 0, 0);
+        _retarget(6000);
 
         (uint256 collateralBefore, uint256 debtBefore) = _collateralAndDebt();
         assertApproxEqAbs((debtBefore * 10_000) / collateralBefore, 6000, 2, "the retarget landed at 6000");
@@ -766,16 +783,16 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         assertLt(staleLtv, 5900, "the stale-target sizing really would have dragged realized LTV down");
     }
 
-    /// @dev An out-of-band target is refused at the entrypoint and stores NOTHING — the persist sits
-    ///      behind the `targetLtvBps_ <= maxLtvBps` gate, so a rejected value can never become the
+    /// @dev An out-of-band target is refused at the ADMIN entrypoint and stores NOTHING — the persist
+    ///      sits behind the `targetLtvBps_ <= maxLtvBps` gate, so a rejected value can never become the
     ///      standing target that later redeploys size at.
-    function testAdjustLeverageAboveMaxRevertsAndLeavesTheStoredTargetUntouched() public {
+    function testSetTargetLtvAboveMaxRevertsAndLeavesTheStoredTargetUntouched() public {
         _execute(SEED);
         usdc.mint(address(strategy), 500_000e6); // idle is NOT what blocks it
 
-        vm.prank(proposer);
+        vm.prank(owner);
         vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvExceedsMax.selector);
-        strategy.adjustLeverage(6501, 0, 0); // maxLtvBps == 6500
+        strategy.setTargetLtv(6501); // maxLtvBps == 6500
 
         assertEq(strategy.targetLtvBps(), TARGET_LTV_BPS, "a rejected target stores nothing");
         assertEq(strategy.layout().targetLtvBps, TARGET_LTV_BPS, "layout() agrees: still the init target");
@@ -800,8 +817,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         _execute(SEED);
 
         uint256 debtBefore = mLegA.borrowBalance(address(strategy));
-        vm.prank(proposer);
-        strategy.adjustLeverage(3000, 0, 0);
+        _retarget(3000);
         assertLt(mLegA.borrowBalance(address(strategy)), debtBefore, "lever DOWN reduced the leg-A debt");
 
         (uint256 collateral, uint256 debtUsdc) = _collateralAndDebt();

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -35,6 +35,7 @@ import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 contract LeveragedAeroStrategyInitUnitTest is Test {
     /// @dev Mirrored from {LeveragedAerodromeCLStrategy} for `vm.expectEmit` / topic matching.
     event FeeCrystallizeDeferred(uint8 op, uint256 navPre);
+    event TargetLtvUpdated(uint16 previousBps, uint16 newBps);
 
     /// @dev The strategy's `OP_COMPOUND` deferral code (private there).
     uint8 internal constant OP_COMPOUND = 3;
@@ -803,6 +804,14 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
 
     // ==================== RISK PARAMS ====================
 
+    /// @dev `_initialize` is one of the routes to a stored ZERO standing target (the two setters are the
+    ///      others); all are guarded. An init-zero would deploy a clone that silently never levers.
+    function testInitRevertsOnZeroTargetLtv() public {
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.targetLtvBps = 0;
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.TargetLtvZero.selector);
+    }
+
     function testInitRevertsWhenTargetLtvExceedsMax() public {
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.targetLtvBps = 7000;
@@ -1489,11 +1498,11 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         vm.prank(owner);
         vault.setStrategy(address(s));
 
-        vm.prank(proposer);
+        vm.prank(owner);
         vm.expectRevert(LeveragedAerodromeCLStrategy.CannotRescuePositionToken.selector);
         s.rescueToVault(address(vault));
 
-        // Same answer through the owner leg, and after settlement.
+        // Same answer after settlement.
         _forceState(s, BaseStrategy.State.Settled);
         vm.prank(owner);
         vm.expectRevert(LeveragedAerodromeCLStrategy.CannotRescuePositionToken.selector);
@@ -1509,7 +1518,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         address[6] memory denied =
             [address(usdc), address(legB), address(legA), address(mUsdc), address(mLegB), address(mLegA)];
         for (uint256 i; i < denied.length; ++i) {
-            vm.prank(proposer);
+            vm.prank(owner);
             vm.expectRevert(LeveragedAerodromeCLStrategy.CannotRescuePositionToken.selector);
             s.rescueToVault(denied[i]);
         }
@@ -1523,7 +1532,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         vault.setStrategy(address(s));
         _forceState(s, BaseStrategy.State.Executed);
 
-        vm.prank(proposer);
+        vm.prank(owner);
         vm.expectRevert(LeveragedAerodromeCLStrategy.CannotRescuePositionToken.selector);
         s.rescueToVault(address(aero));
     }
@@ -1543,7 +1552,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         aero.mint(address(s), 7e18); // the settle-claimed tranche
         _forceState(s, BaseStrategy.State.Settled);
 
-        vm.prank(proposer);
+        vm.prank(owner);
         s.rescueToVault(address(aero));
 
         assertEq(aero.balanceOf(address(s)), 0, "strategy swept");
@@ -1561,7 +1570,207 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         vault.setStrategy(address(s));
 
         vm.prank(lp);
-        vm.expectRevert(LeveragedAerodromeCLStrategy.NotProposerOrOwner.selector);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
         s.rescueToVault(address(aero));
+    }
+
+    /**
+     * @dev BEHAVIOUR CHANGE (admin/proposer split): `rescueToVault` used to accept the proposer OR the
+     *      vault owner; it is now ADMIN-ONLY. Moving tokens out of the strategy is a custody action, and
+     *      the split's whole premise is that the keeper key cannot move funds. The admin leg still works,
+     *      so nothing is stranded — the sweep just costs a multisig signature.
+     */
+    function testRescueToVaultIsAdminOnlyAndRejectsTheProposer() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+        vm.prank(owner);
+        vault.setStrategy(address(s));
+        aero.mint(address(s), 3e18);
+        _forceState(s, BaseStrategy.State.Settled); // post-settle AERO is a genuine stray
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
+        s.rescueToVault(address(aero));
+        assertEq(aero.balanceOf(address(s)), 3e18, "the proposer's sweep changed nothing");
+
+        // The admin can.
+        vm.prank(owner);
+        s.rescueToVault(address(aero));
+        assertEq(aero.balanceOf(address(vault)), 3e18, "the admin's sweep landed on the vault");
+    }
+
+    // ==================== setTargetLtv (ADMIN-ONLY POLICY) ====================
+
+    /// @dev The happy path: the vault owner (== admin) writes the standing target, it is readable
+    ///      through both `targetLtvBps()` and `layout()`, and the policy event carries (previous, new).
+    function testSetTargetLtvPersistsAndEmits() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+        assertEq(s.targetLtvBps(), 5000, "the init target is the starting standing target");
+
+        vm.expectEmit(true, true, true, true, address(s));
+        emit TargetLtvUpdated(5000, 6200);
+        vm.prank(owner);
+        s.setTargetLtv(6200);
+
+        assertEq(s.targetLtvBps(), 6200, "the new standing target persisted");
+        assertEq(s.layout().targetLtvBps, 6200, "getter == layout()");
+    }
+
+    /// @dev THE POINT OF THE SPLIT: the proposer — the rebalancer keeper, the hot key — cannot set
+    ///      policy. Neither can anyone else. A compromised keeper can rebalance the book toward the
+    ///      standing target; it cannot move the target itself.
+    function testSetTargetLtvRevertsForProposerAndStrangers() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
+        s.setTargetLtv(6000);
+
+        vm.prank(lp);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
+        s.setTargetLtv(6000);
+
+        assertEq(s.targetLtvBps(), 5000, "a refused caller stores nothing");
+    }
+
+    /// @dev Zero is refused. On an already-levered book this is the sharp case: a zero target sends
+    ///      `_leverDown` through `_unwindLiquidity`'s full-removal branch — stripping all liquidity,
+    ///      skipping the re-stake, and leaving `$.tokenId` unstaked, which bricks every later venue op
+    ///      INCLUDING the `emergencyRedeem` deadman. Every route that can store a target shares this
+    ///      floor (`_initialize`, `setTargetLtv`, `lowerTargetLtv`). Refusal stores nothing.
+    function testSetTargetLtvRevertsOnZero() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvZero.selector);
+        s.setTargetLtv(0);
+
+        assertEq(s.targetLtvBps(), 5000, "the zero target stored nothing");
+    }
+
+    /// @dev The upper bound is `maxLtvBps` (6500 here) — the boundary itself is legal, one bps past it
+    ///      is not, and a refusal stores nothing.
+    function testSetTargetLtvRevertsAboveMaxLtv() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvExceedsMax.selector);
+        s.setTargetLtv(6501);
+        assertEq(s.targetLtvBps(), 5000, "a rejected target stores nothing");
+
+        vm.prank(owner);
+        s.setTargetLtv(6500); // the bound is inclusive
+        assertEq(s.targetLtvBps(), 6500, "maxLtvBps itself is a legal target");
+    }
+
+    /**
+     * @dev NOT state-gated: policy is settable while `Pending`, i.e. before the genesis `execute`.
+     *      Deliberate — correcting an init-time target before the fund is funded is exactly the case
+     *      that most wants to be settable, and it avoids redeploying the clone. Nothing about a stored
+     *      target requires a live position (`_initialize` itself writes one while Pending).
+     */
+    function testSetTargetLtvIsAllowedWhilePending() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+        assertEq(uint8(s.state()), uint8(BaseStrategy.State.Pending), "fixture is Pending");
+
+        vm.prank(owner);
+        s.setTargetLtv(4000);
+        assertEq(s.targetLtvBps(), 4000, "the target is settable before execute");
+    }
+
+    // ==================== lowerTargetLtv (PROPOSER-ONLY, MONOTONIC DOWN) ====================
+
+    /// @dev The happy path: the proposer — the keeper, the hot key — may REDUCE the standing target, so
+    ///      the pre-`fulfillRedeem` de-risk needs no multisig signature inside `FULFILL_WINDOW`. Same
+    ///      storage and the SAME `TargetLtvUpdated(previous, new)` event as the admin's setter (no second
+    ///      event to monitor), readable through both `targetLtvBps()` and `layout()`.
+    function testLowerTargetLtvPersistsAndEmits() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+        assertEq(s.targetLtvBps(), 5000, "the init target is the starting standing target");
+
+        vm.expectEmit(true, true, true, true, address(s));
+        emit TargetLtvUpdated(5000, 3000);
+        vm.prank(proposer);
+        s.lowerTargetLtv(3000);
+
+        assertEq(s.targetLtvBps(), 3000, "the reduced standing target persisted");
+        assertEq(s.layout().targetLtvBps, 3000, "getter == layout()");
+    }
+
+    /// @dev THE ASYMMETRY IS THE DESIGN, so it gets its own test: this entrypoint is the exact INVERSE
+    ///      gating of `setTargetLtv`. The admin — who may set policy in either direction there — is
+    ///      refused here, as is any stranger; only the proposer passes.
+    function testLowerTargetLtvRevertsForAdminAndStrangers() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(owner);
+        vm.expectRevert(BaseStrategy.NotProposer.selector);
+        s.lowerTargetLtv(3000);
+
+        vm.prank(lp);
+        vm.expectRevert(BaseStrategy.NotProposer.selector);
+        s.lowerTargetLtv(3000);
+
+        assertEq(s.targetLtvBps(), 5000, "a refused caller stores nothing");
+    }
+
+    /// @dev MONOTONIC DOWN, strictly: the keeper can never raise leverage, and equal is refused too — a
+    ///      no-op write would emit a misleading policy event. Both refusals store nothing.
+    function testLowerTargetLtvRevertsOnEqualOrHigher() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvNotLower.selector);
+        s.lowerTargetLtv(5000); // equal
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvNotLower.selector);
+        s.lowerTargetLtv(5001); // higher
+
+        assertEq(s.targetLtvBps(), 5000, "a rejected target stores nothing");
+
+        // One bps below IS legal — the bound is strict, not a band.
+        vm.prank(proposer);
+        s.lowerTargetLtv(4999);
+        assertEq(s.targetLtvBps(), 4999, "strictly lower is accepted");
+    }
+
+    /// @dev The floor is the SAME one `setTargetLtv` and `_initialize` enforce (`_storeTargetLtv`), so
+    ///      the keeper cannot ratchet the target all the way to the zero-target hazard.
+    function testLowerTargetLtvRevertsOnZero() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvZero.selector);
+        s.lowerTargetLtv(0);
+
+        assertEq(s.targetLtvBps(), 5000, "the zero target stored nothing");
+    }
+
+    /// @dev Matches `setTargetLtv`'s state gating deliberately — neither is gated to `Executed`, and the
+    ///      same reasoning applies: the stored target is meaningful while `Pending` too.
+    function testLowerTargetLtvIsAllowedWhilePending() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+        assertEq(uint8(s.state()), uint8(BaseStrategy.State.Pending), "fixture is Pending");
+
+        vm.prank(proposer);
+        s.lowerTargetLtv(4000);
+        assertEq(s.targetLtvBps(), 4000, "the target is reducible before execute");
+    }
+
+    /// @dev The admin's setter is unaffected by sharing `_storeTargetLtv` with the proposer's: it still
+    ///      raises (the direction the keeper can never take) and still enforces the cap.
+    function testAdminCanStillRaiseAfterAProposerLower() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(proposer);
+        s.lowerTargetLtv(2000);
+
+        vm.prank(owner);
+        s.setTargetLtv(6000);
+        assertEq(s.targetLtvBps(), 6000, "the admin reverses a keeper ratchet in one transaction");
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvExceedsMax.selector);
+        s.setTargetLtv(6501);
     }
 }

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -215,6 +215,17 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         strategy.execute();
     }
 
+    /// @dev The ADMIN/PROPOSER two-step that replaced the old one-shot `adjustLeverage(target, ...)`:
+    ///      the vault owner (multisig) sets POLICY with `setTargetLtv`, then the proposer (rebalancer)
+    ///      moves the book to it with `adjustLeverage`. Both roles are required — neither can do the
+    ///      other's half — which is exactly what these lifecycle tests exercise implicitly.
+    function _retarget(uint16 target) internal {
+        vm.prank(owner);
+        strategy.setTargetLtv(target);
+        vm.prank(proposer);
+        strategy.adjustLeverage(0, 0);
+    }
+
     function _valueUsdc(uint256 amt, uint256 price8, uint256 dec) internal pure returns (uint256) {
         return (amt * price8 * 1e6) / ((10 ** dec) * P_USDC);
     }
@@ -319,8 +330,7 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         usdc.mint(address(strategy), 100_000e6); // idle that a two-leg lever-up must NOT touch
         uint256 idleBefore = usdc.balanceOf(address(strategy));
 
-        vm.prank(proposer);
-        strategy.adjustLeverage(6000, 0, 0); // lever UP — allowed here
+        _retarget(6000); // lever UP — allowed here
         assertGt(mLegB.borrowBalance(address(strategy)), debtBBefore, "lever UP borrowed more leg B");
         assertGt(mLegA.borrowBalance(address(strategy)), debtABefore, "lever UP borrowed more leg A");
         assertEq(usdc.balanceOf(address(strategy)), idleBefore, "two-leg lever UP is self-funding: idle untouched");
@@ -335,8 +345,7 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         assertApproxEqAbs((debtUsdc * 10_000) / collateral, 6000, 2, "LTV == the new target");
 
         uint256 debtBUp = mLegB.borrowBalance(address(strategy));
-        vm.prank(proposer);
-        strategy.adjustLeverage(3000, 0, 0); // lever DOWN
+        _retarget(3000); // lever DOWN
         assertLt(mLegB.borrowBalance(address(strategy)), debtBUp, "lever DOWN repaid leg B");
     }
 
@@ -360,9 +369,12 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         _execute(SEED);
         uint256 tokenIdBefore = strategy.layout().tokenId;
 
-        vm.prank(proposer);
-        vm.expectRevert(LeveragedAeroManager.FullUnwindNotSupported.selector);
-        strategy.adjustLeverage(0, 0, 0);
+        // Post role-split there is no target argument, so a zero target can only be reached through
+        // `setTargetLtv` — where it is rejected one barrier EARLIER than the manager's full-unwind
+        // guard. That guard remains the backstop and is exercised by the dust-target test below.
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvZero.selector);
+        strategy.setTargetLtv(0);
 
         // Nothing moved, and the position is still staked — the whole point of the guard.
         assertEq(strategy.layout().tokenId, tokenIdBefore, "position untouched");
@@ -380,9 +392,11 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         // targetLtvBps of 1 floors to 0. Shrink the collateral basis to reach that band.
         mUsdc.setExchangeRateStored(1);
 
+        vm.prank(owner);
+        strategy.setTargetLtv(1); // non-zero, so it clears `TargetLtvZero` and reaches the manager
         vm.prank(proposer);
         vm.expectRevert(LeveragedAeroManager.FullUnwindNotSupported.selector);
-        strategy.adjustLeverage(1, 0, 0);
+        strategy.adjustLeverage(0, 0);
     }
 
     /// @dev The guard must NOT catch an ordinary lever-down: a partial repay leaves liquidity, so the
@@ -391,8 +405,7 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         _execute(SEED);
         uint256 tokenId = strategy.layout().tokenId;
 
-        vm.prank(proposer);
-        strategy.adjustLeverage(3000, 0, 0);
+        _retarget(3000);
 
         assertEq(strategy.layout().tokenId, tokenId, "same position");
         assertTrue(gauge.stakedContains(address(strategy), tokenId), "re-staked after a partial unwind");
@@ -401,23 +414,68 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
 
     // ==================== TARGET-LTV PERSISTENCE (two-borrowed-legs) ====================
 
-    /// @dev The persist is SHAPE-INDEPENDENT — it is one write on the shared `adjustLeverageImpl` path,
-    ///      so it holds in the two-borrowed-legs shape exactly as in asset-mode, both directions. The
-    ///      dedicated getter and `layout()` are the same storage read and are asserted together.
-    function testAdjustLeveragePersistsTheStandingTarget() public {
+    /// @dev The persist lives in the ADMIN's `setTargetLtv` and is SHAPE-INDEPENDENT, so it holds in the
+    ///      two-borrowed-legs shape exactly as in asset-mode, both directions. `adjustLeverage` no longer
+    ///      writes it at all — it CONSUMES it — which is asserted here by taking the position to the
+    ///      stored value in both directions with no target argument anywhere. The dedicated getter and
+    ///      `layout()` are the same storage read and are asserted together.
+    function testSetTargetLtvPersistsTheStandingTargetAndAdjustLeverageConsumesIt() public {
         _execute(SEED);
         assertEq(strategy.targetLtvBps(), TARGET_LTV_BPS, "genesis: the init target IS the standing target");
         assertEq(strategy.layout().targetLtvBps, TARGET_LTV_BPS, "genesis: getter == layout()");
 
+        // Policy alone moves nothing — the write lands before any venue call.
+        uint256 debtBAtInit = mLegB.borrowBalance(address(strategy));
+        vm.prank(owner);
+        strategy.setTargetLtv(6000);
+        assertEq(strategy.targetLtvBps(), 6000, "the admin's write IS the new standing target");
+        assertEq(strategy.layout().targetLtvBps, 6000, "getter == layout() after setTargetLtv");
+        assertEq(mLegB.borrowBalance(address(strategy)), debtBAtInit, "setTargetLtv is policy only: book untouched");
+
+        // The keeper's op then takes the book there, reading the STORED value (self-funding in this shape).
         vm.prank(proposer);
-        strategy.adjustLeverage(6000, 0, 0); // lever UP (self-funding in this shape)
-        assertEq(strategy.targetLtvBps(), 6000, "lever UP persisted the new standing target");
-        assertEq(strategy.layout().targetLtvBps, 6000, "getter == layout() after lever UP");
+        strategy.adjustLeverage(0, 0);
+        assertGt(mLegB.borrowBalance(address(strategy)), debtBAtInit, "lever UP ran off the stored target");
+        assertEq(strategy.targetLtvBps(), 6000, "adjustLeverage left the standing target alone");
+
+        uint256 collateral = mUsdc.balanceOf(address(strategy));
+        uint256 debtUsdc = _valueUsdc(mLegB.borrowBalance(address(strategy)), P_LEG_B, 8)
+            + _valueUsdc(mLegA.borrowBalance(address(strategy)), P_LEG_A, 18);
+        assertApproxEqAbs((debtUsdc * 10_000) / collateral, 6000, 2, "the book landed on the STORED target");
+
+        // Same for lever DOWN.
+        _retarget(3000);
+        assertEq(strategy.targetLtvBps(), 3000, "the admin re-set the standing target downward");
+        assertEq(strategy.layout().targetLtvBps, 3000, "getter == layout() after lever DOWN");
+        collateral = mUsdc.balanceOf(address(strategy));
+        debtUsdc = _valueUsdc(mLegB.borrowBalance(address(strategy)), P_LEG_B, 8)
+            + _valueUsdc(mLegA.borrowBalance(address(strategy)), P_LEG_A, 18);
+        assertApproxEqAbs((debtUsdc * 10_000) / collateral, 3000, 20, "the book followed the stored target down");
+    }
+
+    /// @dev The KEEPER-ONLY de-risk, end to end and asserted on the BOOK, not just the getter: the
+    ///      proposer lowers policy itself with `lowerTargetLtv` (no multisig, which is the whole point —
+    ///      the 2-day `FULFILL_WINDOW` must not depend on a signature) and its own `adjustLeverage` then
+    ///      sizes against the NEW stored value. The admin is never involved in this sequence.
+    function testProposerLowerTargetLtvThenAdjustLeverageDeleversTheBook() public {
+        _execute(SEED);
+        uint256 debtBAtInit = mLegB.borrowBalance(address(strategy));
+
+        // Policy alone moves nothing here either — same contract as the admin's setter.
+        vm.prank(proposer);
+        strategy.lowerTargetLtv(4000);
+        assertEq(strategy.targetLtvBps(), 4000, "the keeper's write IS the new standing target");
+        assertEq(mLegB.borrowBalance(address(strategy)), debtBAtInit, "lowerTargetLtv is policy only: book untouched");
 
         vm.prank(proposer);
-        strategy.adjustLeverage(3000, 0, 0); // lever DOWN
-        assertEq(strategy.targetLtvBps(), 3000, "lever DOWN persisted the new standing target");
-        assertEq(strategy.layout().targetLtvBps, 3000, "getter == layout() after lever DOWN");
+        strategy.adjustLeverage(0, 0);
+        assertLt(mLegB.borrowBalance(address(strategy)), debtBAtInit, "lever DOWN ran off the keeper's target");
+
+        uint256 collateral = mUsdc.balanceOf(address(strategy));
+        uint256 debtUsdc = _valueUsdc(mLegB.borrowBalance(address(strategy)), P_LEG_B, 8)
+            + _valueUsdc(mLegA.borrowBalance(address(strategy)), P_LEG_A, 18);
+        assertApproxEqAbs((debtUsdc * 10_000) / collateral, 4000, 20, "the book landed on the KEEPER's target");
+        assertEq(strategy.targetLtvBps(), 4000, "adjustLeverage left the standing target alone");
     }
 
     /**
@@ -431,10 +489,10 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
     function testDeployIdleAfterAdjustLeverageSizesAtTheNewTarget() public {
         _execute(SEED);
 
-        vm.prank(proposer);
-        strategy.adjustLeverage(6000, 0, 0);
-        // Deliberately NOT asserting the getter here — `testAdjustLeveragePersistsTheStandingTarget`
-        // owns that. This test must fail on the OBSERVABLE BORROW instead, so the regression it guards
+        _retarget(6000);
+        // Deliberately NOT asserting the getter here — that belongs to
+        // `testSetTargetLtvPersistsTheStandingTargetAndAdjustLeverageConsumesIt`.
+        // This test must fail on the OBSERVABLE BORROW instead, so the regression it guards
         // is the economic one (the redeploy sizing) and not merely a storage read.
 
         uint256 debtBBefore = mLegB.borrowBalance(address(strategy));
@@ -462,13 +520,15 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         assertApproxEqAbs((debtUsdc * 10_000) / collateral, 6000, 2, "realized LTV HELD at 6000");
     }
 
-    /// @dev Out-of-band target: refused at the entrypoint, stores nothing, standing target untouched.
-    function testAdjustLeverageAboveMaxRevertsAndLeavesTheStoredTargetUntouched() public {
+    /// @dev Out-of-band target: refused at the ADMIN entrypoint, stores nothing, standing target
+    ///      untouched. The bound moved to `setTargetLtv` with the parameter — `adjustLeverage` has no
+    ///      target argument to bound any more.
+    function testSetTargetLtvAboveMaxRevertsAndLeavesTheStoredTargetUntouched() public {
         _execute(SEED);
 
-        vm.prank(proposer);
+        vm.prank(owner);
         vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvExceedsMax.selector);
-        strategy.adjustLeverage(6501, 0, 0); // maxLtvBps == 6500
+        strategy.setTargetLtv(6501); // maxLtvBps == 6500
 
         assertEq(strategy.targetLtvBps(), TARGET_LTV_BPS, "a rejected target stores nothing");
         assertEq(strategy.layout().targetLtvBps, TARGET_LTV_BPS, "layout() agrees: still the init target");
@@ -689,8 +749,7 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
 
         uint256 debtBBefore = mLegB.borrowBalance(address(strategy));
 
-        vm.prank(proposer);
-        strategy.adjustLeverage(3000, 0, 0); // lever DOWN — repays f of both debts
+        _retarget(3000); // lever DOWN — repays f of both debts
 
         // 1. The remainder survived: only a need-sized slice of the leg-A balance was sold.
         assertGt(

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -713,8 +713,9 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         assertEq(aero.balanceOf(address(strategy)), tranche, "tranche untouched, never sold blind");
         assertApproxEqRel(usdc.balanceOf(address(vault)), SEED, 0.0001e18, "the book itself still settled");
         // ...and the residue is recoverable exactly as the pre-fix tranche was: the reward-token
-        // block on `rescueToVault` is scoped to `Executed`.
-        vm.prank(proposer);
+        // block on `rescueToVault` is scoped to `Executed`. Caller is the ADMIN (the vault owner):
+        // the admin/proposer split made `rescueToVault` admin-only.
+        vm.prank(owner);
         strategy.rescueToVault(address(aero));
         assertEq(aero.balanceOf(address(vault)), tranche, "residual tranche recovered post-settle");
     }
@@ -1168,6 +1169,96 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         LeveragedAeroVenue.VenueParams memory v = _venueBParams();
         v.targetLtvBps = 6100; // > maxLtvBps 6000
         _expectMigrateRevert(v, LeveragedAeroValuation.TargetLtvExceedsMax.selector);
+    }
+
+    /// @dev The LOWER twin of the bound above, and the reason the zero guard lives in `applyVenue`
+    ///      rather than beside `setTargetLtv`: `migrateVenue` is a THIRD write path to `targetLtvBps`,
+    ///      alongside the two setters, and it is the only one whose value is not typed by a human at
+    ///      call time — it comes out of a staged struct. `TargetLtvZero` is raised from the library
+    ///      (`LeveragedAeroVenue`) here, not from the strategy, but the selector is the same one
+    ///      `setTargetLtv` / `lowerTargetLtv` raise, so a caller decodes it off the strategy ABI either
+    ///      way. A zero target is not a brick — it borrows nothing — but it is a fund that can silently
+    ///      never lever, and a migration is precisely where that would go unnoticed.
+    function testMigrateRejectsZeroTargetLtv() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.targetLtvBps = 0;
+        _expectMigrateRevert(v, LeveragedAeroVenue.TargetLtvZero.selector);
+    }
+
+    // ==================== migrate: the target-LTV write is LOUD ====================
+
+    /// @dev `applyVenue` persists `p.targetLtvBps`, so a migration MOVES THE FUND'S LEVERAGE POLICY.
+    ///      `migrateVenue` only emits `VenueMigrated`, which says nothing about the target — so without
+    ///      the emit in `applyVenue` this would be the one silent policy change on the contract, and
+    ///      `lowerTargetLtv`'s "every step emits `TargetLtvUpdated` — monitor it" would be false. Same
+    ///      event, same signature, same emitting address (the library is delegatecalled), so a monitor
+    ///      filtering `TargetLtvUpdated` on the clone needs no new subscription.
+    function testMigrateEmitsTargetLtvUpdatedWhenTheStagedTargetDiffers() public {
+        _execute(SEED);
+        _flatten();
+        assertEq(strategy.layout().targetLtvBps, TARGET_LTV_BPS, "live target before the migration");
+
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams(); // targetLtvBps 4000 != 5000
+        _stage(v);
+        vm.expectEmit(false, false, false, true, address(strategy));
+        emit LeveragedAerodromeCLStrategy.TargetLtvUpdated(TARGET_LTV_BPS, 4000);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+
+        assertEq(strategy.layout().targetLtvBps, 4000, "the staged target is what got stored");
+    }
+
+    /// @dev The other half of the inequality guard: a migration that carries the SAME target is quiet.
+    ///      The event has to mean "policy moved", not "a migration happened" — `VenueMigrated` already
+    ///      says the latter, and a `TargetLtvUpdated(5000, 5000)` on every venue rewrite would train a
+    ///      monitor to ignore the event that matters.
+    function testMigrateDoesNotEmitTargetLtvUpdatedWhenTheStagedTargetIsUnchanged() public {
+        _execute(SEED);
+        _flatten();
+
+        LeveragedAeroVenue.VenueParams memory v = _venueAParams(); // targetLtvBps == the live one
+        _stage(v);
+        vm.recordLogs();
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bool sawMigrated;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != address(strategy)) continue;
+            assertTrue(
+                logs[i].topics[0] != LeveragedAerodromeCLStrategy.TargetLtvUpdated.selector,
+                "an unchanged target must not announce a policy change"
+            );
+            if (logs[i].topics[0] == LeveragedAeroVenue.VenueMigrated.selector) sawMigrated = true;
+        }
+        assertTrue(sawMigrated, "the migration itself did run -- the assertion above is not vacuous");
+        assertEq(strategy.layout().targetLtvBps, TARGET_LTV_BPS, "target unchanged");
+    }
+
+    /// @dev THE SCENARIO THE EVENT EXISTS FOR. The proposer ratchets the target down ahead of a large
+    ///      unwind (`lowerTargetLtv`, its one leverage knob), and a subsequently-executed migration —
+    ///      whose staged params carry their own `targetLtvBps` — RESTORES it. That is authorised: the
+    ///      params were byte-committed by the vault owner at `stageVenue`, so the raise is the owner's
+    ///      decision, not the keeper's. But authorised is not the same as visible, and the restore is
+    ///      not the migration's headline effect. It emits.
+    function testMigrateAnnouncesRestoringATargetTheProposerLowered() public {
+        _execute(SEED);
+        vm.prank(proposer);
+        strategy.lowerTargetLtv(3000);
+        assertEq(strategy.layout().targetLtvBps, 3000, "keeper de-risked");
+
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueAParams(); // same venue, target back to 5000
+        _stage(v);
+        vm.expectEmit(false, false, false, true, address(strategy));
+        emit LeveragedAerodromeCLStrategy.TargetLtvUpdated(3000, TARGET_LTV_BPS);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+
+        assertEq(strategy.layout().targetLtvBps, TARGET_LTV_BPS, "the staged target won, loudly");
     }
 
     // ==================== migrate: happy paths ====================


### PR DESCRIPTION
Stacked on #66. Splits the single `proposer` role so the backend keeper cannot change fund policy.

| Tier | Who | Ops |
|---|---|---|
| **admin** = `Ownable(vault()).owner()` | MAMO_MULTISIG | `setTargetLtv`, `rescueToVault` |
| **proposer** — the rebalancer, deliberately *not* renamed | backend keeper | `deployIdle`, `compound`, `rerange`, `adjustLeverage`, `fulfillRedeem` |
| permissionless | anyone | `deleverage` |

## Why admin is derived, not stored

A stored admin address would add a `Layout` field — and `Layout`/`RedeemRequest`/`STORAGE_SLOT` are duplicated byte-identically across the strategy and manager under a 3-way parity gate. Deriving it from the vault owner means **zero layout change** and near-zero bytecode, which matters at 348 B of EIP-170 headroom. `rescueToVault` already used this pattern.

Trade-off: admin is coupled to vault ownership. Decoupling later costs a slot.

## Breaking changes

**`adjustLeverage` selector changes — the backend must remap.**

| | |
|---|---|
| old `adjustLeverage(uint16,uint256,uint256)` | `0x9792419f` |
| new `adjustLeverage(uint256,uint256)` | `0x4be1cadd` |
| new `setTargetLtv(uint16)` | `0x45325ee3` |
| `NotAdmin()` | `0x7bfa4b9f` |

**`rescueToVault` is admin-only** (was proposer-or-owner). Keeper tooling that calls it will start reverting `NotAdmin`.

## The zero-target guard moved with the parameter

A zero target drives `_leverDown` into `_unwindLiquidity`'s `num == den` branch, which strips all liquidity, **skips the re-stake**, and leaves `$.tokenId` pointing at an unstaked NFT — bricking every later venue op **including the `emergencyRedeem` deadman**. With the parameter gone from `adjustLeverage`, `setTargetLtv` is the only route to zero, so the guard lives there — independent of #70's `FullUnwindNotSupported`, which is not on this branch.

## Deliberately untouched

`maxLtvBps`, `minHealthBps`, `maxSlippageBps` and the width band stay **immutable post-deploy**. That immutability is a property we cite to integrators; it shouldn't erode by default. Consequence: a bad `maxLtvBps` at init still requires redeploying the clone.

`setTargetLtv` is **not** state-gated — correcting an init-time target while `Pending` is the case that most needs to work.

## Verification

- sizes: strategy 24,228 → **24,426** (150 B margin); manager, valuation, vault unchanged; no audited money path relocated
- layout parity **IDENTICAL ×3**, `LayoutParityTest` 4/4
- **147** leveraged-aero + **70** vault tests pass, including new coverage for admin gating, zero/above-max rejection, `adjustLeverage` consuming the stored target, and `rescueToVault` rejecting the proposer
- `forge fmt --check` clean under the **CI-pinned** nightly (local 1.7.1 disagrees on pre-existing code — do not run repo-wide fmt with it)

## Follow-on

#70's `flatten`, `migrateVenue` and `redeploy` are the other policy-shaped ops and should pick up `onlyAdmin` when it rebases onto this — which also settles whether the rebalancer may unwind the whole book. The answer becomes no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)