### PR TITLE
MOO-768: give the QA vnet a heartbeat so wallets behave like they do on Base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ script/tenderly/.phase-*.log
 # directly with the frontend (or commit intentionally), don't bake a soon-stale URL into history.
 docs/tenderly-staging.md
 script/tenderly/staging-setup.log
+
+script/tenderly/mine-ticker.log
+script/tenderly/.mine-ticker.pid

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ tenderly-price-checker:
 # Vnet heartbeat (MOO-768). A Tenderly vnet mines a block ONLY when a tx arrives, so an idle chain
 # mints nothing and wallets misbehave: any waitForTransactionReceipt with confirmations > 1 deadlocks
 # between interactive legs, and MetaMask's activity tracker keeps mined txs as "submitted/pending"
-# (the stale-queue banner). This calls evm_mine every 2s so the chain ticks like Base while a human is
+# (the stale-queue banner). This calls evm_mine every 15s so the chain keeps ticking while a human is
 # clicking through a manual QA session. Foreground; Ctrl-C to stop. Holds no state — safe to start and
 # stop at will, and it does NOT fast-forward chain time (Tenderly stamps each block with the real
 # elapsed time). Uses TENDERLY_VNET_RPC_URL; `--once` catches a drifted vnet up before a run.

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,29 @@ tenderly-matrix:
 tenderly-price-checker:
 	./script/tenderly/run-harness.sh price-checker
 
+# Vnet heartbeat (MOO-768). A Tenderly vnet mines a block ONLY when a tx arrives, so an idle chain
+# mints nothing and wallets misbehave: any waitForTransactionReceipt with confirmations > 1 deadlocks
+# between interactive legs, and MetaMask's activity tracker keeps mined txs as "submitted/pending"
+# (the stale-queue banner). This calls evm_mine every 2s so the chain ticks like Base while a human is
+# clicking through a manual QA session. Foreground; Ctrl-C to stop. Holds no state — safe to start and
+# stop at will, and it does NOT fast-forward chain time (Tenderly stamps each block with the real
+# elapsed time). Uses TENDERLY_VNET_RPC_URL; `--once` catches a drifted vnet up before a run.
+tenderly-mine:
+	./script/tenderly/mine-ticker.sh
+
+# Same heartbeat, detached — for an all-day ticker the team can share. Logs to
+# script/tenderly/mine-ticker.log (gitignored). Run it on an always-on host: a laptop that
+# sleeps stops the chain, which is the failure the ticker exists to prevent. See the launchd
+# recipe under "Vnet heartbeat" in script/tenderly/README.md.
+tenderly-mine-start:
+	./script/tenderly/mine-ticker.sh --daemon
+
+tenderly-mine-stop:
+	./script/tenderly/mine-ticker.sh --stop
+
+tenderly-mine-status:
+	./script/tenderly/mine-ticker.sh --status
+
 # POOLED-layer deploy against the LIVE persistent Base-fork vnet (runbook Phase B). B.0 FreshFeed-
 # overrides the 5 venue Chainlink feeds via tenderly_setCode (never stale, warping safe) → B.1 deploys
 # the LeveragedAerodromeCLStrategy TEMPLATE + LeveragedAeroVault(USDC, owner=MAMO_MULTISIG) as
@@ -124,4 +147,4 @@ tenderly-leveraged-aero-stack:
 tenderly-leveraged-aero-account:
 	./script/tenderly/run-harness.sh leveraged-aero-account
 
-.PHONY: test test-unit coverage deploy-broadcast usdc-strategy cbbtc-strategy strategy-factory strategy-multicall usdc-price-checker cbbtc-price-checker fee-splitter integration-test mamo-staking lp-auto-balancer-v2 lp-v2-setup leveraged-aero-account leveraged-aero-vault test-all tenderly-harness tenderly-matrix tenderly-price-checker tenderly-leveraged-aero-stack tenderly-leveraged-aero-account
+.PHONY: test test-unit coverage deploy-broadcast usdc-strategy cbbtc-strategy strategy-factory strategy-multicall usdc-price-checker cbbtc-price-checker fee-splitter integration-test mamo-staking lp-auto-balancer-v2 lp-v2-setup leveraged-aero-account leveraged-aero-vault test-all tenderly-harness tenderly-matrix tenderly-price-checker tenderly-mine tenderly-mine-start tenderly-mine-stop tenderly-mine-status tenderly-leveraged-aero-stack tenderly-leveraged-aero-account

--- a/script/tenderly/README.md
+++ b/script/tenderly/README.md
@@ -265,16 +265,17 @@ always safe, and it needs the **admin** (write-capable) RPC: on the public one `
 `Access forbidden by access rules`.
 
 ```bash
-make tenderly-mine                                  # foreground 2s heartbeat, Ctrl-C to stop
+make tenderly-mine                                  # foreground 15s heartbeat, Ctrl-C to stop
 make tenderly-mine-start                            # detached — logs to mine-ticker.log
 make tenderly-mine-status                           # running? and how far behind wall clock
 make tenderly-mine-stop
 ./script/tenderly/mine-ticker.sh --once             # single block — catch a drifted vnet up
-./script/tenderly/mine-ticker.sh --interval 5 --quiet --rpc-url <admin-rpc>
+./script/tenderly/mine-ticker.sh --interval 2 --quiet   # exactly Base's cadence
 ```
 
 **It does not fast-forward the chain.** Tenderly stamps each mined block with the real time elapsed
-since the previous one, so a 2s cadence advances chain time ~2s per block. What it fixes is *drift*:
+since the previous one, so the cadence sets the block rate, not the rate of chain time — a 15s ticker
+and a 2s ticker both keep the offset flat. What it fixes is *drift*:
 an idle vnet falls behind wall clock by exactly as long as it sat idle (measured 2026-08-19: the
 shared instance was ~2h behind after a quiet stretch), and the first transaction afterwards closes the
 whole gap in a single block's timestamp. A running ticker keeps that offset flat — which is the more
@@ -292,7 +293,7 @@ failure this exists to prevent. On macOS, a LaunchAgent restarts it across crash
   <key>Label</key>            <string>fi.moonwell.vnet-mine</string>
   <key>ProgramArguments</key> <array>
     <string>/path/to/mamo-contracts/script/tenderly/mine-ticker.sh</string>
-    <string>--interval</string><string>2</string>
+    <string>--interval</string><string>15</string>
     <string>--quiet</string>
   </array>
   <key>EnvironmentVariables</key> <dict>

--- a/script/tenderly/README.md
+++ b/script/tenderly/README.md
@@ -245,6 +245,84 @@ cast call <account> 'sharesBalance()(uint256)' --rpc-url <public-rpc>
 TENDERLY_VNET_RPC_URL=<admin-rpc> make tenderly-leveraged-aero-account
 ```
 
+## Vnet heartbeat — an idle vnet mines nothing (MOO-768)
+
+A Tenderly vnet produces a block **only when a transaction arrives**. Real Base produces one every
+~2s, and wallets assume the latter. Two QA artifacts fall out of that, both seen during FE-05 manual
+testing:
+
+1. **Confirmation deadlock** — any `waitForTransactionReceipt` with `confirmations > 1` between
+   interactive legs never resolves: the first leg mines into its own block and no further blocks come.
+2. **MetaMask "previous transactions are still being signed or submitted"** — MetaMask's activity
+   tracker needs block progression to mark a tx confirmed, so mined txs linger locally as
+   submitted/pending and the next signature request shows the stale-queue banner. Benign (nonces come
+   from the RPC and are correct) but it reads as a failure to testers. Clears via MetaMask → Settings
+   → Advanced → *Clear activity tab data*.
+
+`mine-ticker.sh` closes the gap from outside the app — it calls `evm_mine` on a fixed interval so the
+chain keeps ticking while nobody is transacting. It holds no state, so starting and stopping it is
+always safe, and it needs the **admin** (write-capable) RPC: on the public one `evm_mine` returns
+`Access forbidden by access rules`.
+
+```bash
+make tenderly-mine                                  # foreground 2s heartbeat, Ctrl-C to stop
+make tenderly-mine-start                            # detached — logs to mine-ticker.log
+make tenderly-mine-status                           # running? and how far behind wall clock
+make tenderly-mine-stop
+./script/tenderly/mine-ticker.sh --once             # single block — catch a drifted vnet up
+./script/tenderly/mine-ticker.sh --interval 5 --quiet --rpc-url <admin-rpc>
+```
+
+**It does not fast-forward the chain.** Tenderly stamps each mined block with the real time elapsed
+since the previous one, so a 2s cadence advances chain time ~2s per block. What it fixes is *drift*:
+an idle vnet falls behind wall clock by exactly as long as it sat idle (measured 2026-08-19: the
+shared instance was ~2h behind after a quiet stretch), and the first transaction afterwards closes the
+whole gap in a single block's timestamp. A running ticker keeps that offset flat — which is the more
+production-faithful thing for anything reading a TWAP or an oracle age.
+
+### Keeping it up all day
+
+QA wants blocks whenever someone is clicking, not only when someone remembers to start a ticker. The
+daemon has to live on a host that does not sleep — a closed laptop stops the chain, which is the exact
+failure this exists to prevent. On macOS, a LaunchAgent restarts it across crashes and reboots:
+
+```xml
+<!-- ~/Library/LaunchAgents/fi.moonwell.vnet-mine.plist -->
+<plist version="1.0"><dict>
+  <key>Label</key>            <string>fi.moonwell.vnet-mine</string>
+  <key>ProgramArguments</key> <array>
+    <string>/path/to/mamo-contracts/script/tenderly/mine-ticker.sh</string>
+    <string>--interval</string><string>2</string>
+    <string>--quiet</string>
+  </array>
+  <key>EnvironmentVariables</key> <dict>
+    <!-- admin RPC from 1Password; the plist is NOT in the repo -->
+    <key>TENDERLY_VNET_RPC_URL</key> <string>https://virtual.base.…</string>
+  </dict>
+  <key>RunAtLoad</key>  <true/>
+  <key>KeepAlive</key>  <true/>
+  <key>StandardOutPath</key>   <string>/tmp/vnet-mine.log</string>
+  <key>StandardErrorPath</key> <string>/tmp/vnet-mine.err</string>
+</dict></plist>
+```
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/fi.moonwell.vnet-mine.plist
+launchctl print gui/$(id -u)/fi.moonwell.vnet-mine | grep 'pid ='
+launchctl bootout   gui/$(id -u) ~/Library/LaunchAgents/fi.moonwell.vnet-mine.plist   # remove
+```
+
+Run it under `--quiet` there: the status line is for humans watching a terminal, and unattended it
+just grows the log. Note the plist embeds the write-capable RPC, so it stays out of the repo — keep it
+in `~/Library/LaunchAgents` and source the URL from 1Password.
+
+The alternative that depends on nobody's machine is a scheduled CI job holding the admin RPC as a
+secret and mining for the length of its run — worth it only if the vnet outlives the QA train.
+
+Fixing this at the source instead — interval mining configured on the vnet itself — is a Tenderly
+dashboard/admin action rather than anything in this repo, and it is still the right permanent answer.
+The ticker is the version that needs no account privileges and no maintainer in the loop.
+
 ## vnet resolution
 
 Mirrors the goal's "(a) spin up a vnet **or** (b) use the url in `.env`":
@@ -298,6 +376,9 @@ interleave Tenderly cheat-RPCs (funding, time advance, snapshots) between phases
   the persistent vnet carrying the pooled layer (unlocked impersonation; always `--reuse`). See section
   above.
 - `setup-staging.sh` — stands up a **persistent** frontend staging vnet (not torn down after the run).
+- `mine-ticker.sh` — vnet heartbeat: `evm_mine` on an interval so an idle chain keeps producing
+  blocks for wallet-driven manual QA. `--daemon/--stop/--status` for an all-day ticker (see
+  "Vnet heartbeat" above for the launchd recipe). Standalone; not part of any harness run.
 - `lib/common.sh` — shared plumbing (vnet resolution/teardown, cheat-RPC fund/time helpers, the
   forge-phase runner, address-book lookup, vnet gotcha fixes). Sourced, never executed.
 - `lib/market.sh` — reusable price/market simulation cheat primitives (`snapshot`/`revert_to`,

--- a/script/tenderly/compound-cycle.sh
+++ b/script/tenderly/compound-cycle.sh
@@ -48,9 +48,11 @@ ROOT="$(cd "$HERE/../.." && pwd)"
 CFG="$HERE/leveraged-aero-vnet.json"
 
 [[ -f "$ROOT/.env" ]] && set -a && . "$ROOT/.env" && set +a
-# LEVERAGED_AERO_ADMIN_RPC_URL wins over TENDERLY_VNET_RPC_URL: the latter is shared with the LPV2
-# harness and routinely points at a DIFFERENT vnet. Pointing this script at the wrong instance is
-# caught by `check-feeds` (a non-FreshFeed instance fails the gate) — but set it explicitly.
+# LEVERAGED_AERO_ADMIN_RPC_URL wins over TENDERLY_VNET_RPC_URL. Historically the latter named a
+# DIFFERENT vnet (the LPV2 one), so the two had to be kept apart; since 2026-08-19 both names
+# resolve to the shared leveraged-aero instance (chainId 73578453) and .env says to keep them in
+# sync. The preference order is retained so an explicit override still wins. Pointing this script
+# at the wrong instance is caught by `check-feeds` (a non-FreshFeed instance fails the gate).
 RPC="${LEVERAGED_AERO_ADMIN_RPC_URL:-${TENDERLY_VNET_RPC_URL:?set LEVERAGED_AERO_ADMIN_RPC_URL (admin RPC) or TENDERLY_VNET_RPC_URL}}"
 
 # ── resolved from leveraged-aero-vnet.json (never hardcode; the instance rotates) ──

--- a/script/tenderly/mine-ticker.sh
+++ b/script/tenderly/mine-ticker.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# mine-ticker.sh — give a Tenderly Virtual TestNet a heartbeat (MOO-768)
+# ==============================================================================
+# A Tenderly vnet mines a block ONLY when a transaction arrives; an idle chain
+# mints nothing. Real Base mints one every ~2s. Wallets assume the latter, which
+# is where the two QA artifacts on MOO-768 come from:
+#
+#   1. any waitForTransactionReceipt with confirmations > 1 between interactive
+#      legs never resolves — the first leg mines its own block and no more come;
+#   2. MetaMask's activity tracker needs block progression to mark a tx
+#      confirmed, so mined txs linger as "submitted/pending" locally and the
+#      next signature request shows the stale-queue warning banner.
+#
+# This script closes that gap from the outside: it calls evm_mine on a fixed
+# interval so the chain keeps ticking while nobody is transacting. Run it
+# alongside a manual QA session; stop it with Ctrl-C when you are done. It holds
+# no state — starting and stopping it is always safe.
+#
+# It does NOT fast-forward the chain. Tenderly stamps each mined block with the
+# real time elapsed since the previous one, so a 2s cadence advances chain time
+# ~2s per block. What it does fix is drift: an idle vnet falls behind wall clock
+# by exactly as long as it sat idle (measured 2026-08-19: ~2h of lag after an
+# idle weekend), and the first transaction after that idles jumps the timestamp
+# by the whole gap in one block. A running ticker keeps the offset flat.
+#
+# Usage:
+#   ./script/tenderly/mine-ticker.sh [--interval <seconds>] [--rpc-url <url>]
+#                                    [--once | --daemon | --stop | --status] [--quiet]
+#
+#   --interval N   seconds between blocks (default 2, matching Base)
+#   --rpc-url URL  admin (write-capable) RPC; else $TENDERLY_VNET_RPC_URL, else .env
+#   --once         mine a single block and exit — use to catch a vnet up before a run
+#   --daemon       detach and keep mining across terminals; logs to mine-ticker.log
+#   --stop         stop the detached ticker
+#   --status       is it running, and how far behind wall clock is the chain
+#   --quiet        suppress the periodic status line (errors still print)
+#
+# Examples:
+#   ./script/tenderly/mine-ticker.sh                     # 2s heartbeat, Ctrl-C to stop
+#   ./script/tenderly/mine-ticker.sh --interval 5
+#   ./script/tenderly/mine-ticker.sh --once
+#   make tenderly-mine / tenderly-mine-start / tenderly-mine-stop / tenderly-mine-status
+#
+# For an all-day heartbeat the team can rely on, run the daemon on an always-on box
+# (see "Vnet heartbeat" in script/tenderly/README.md for the launchd recipe). A laptop
+# that sleeps stops the chain; that is the same failure the ticker exists to prevent.
+# ==============================================================================
+set -euo pipefail
+export FOUNDRY_DISABLE_NIGHTLY_WARNING=1
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+STATUS_EVERY=${STATUS_EVERY:-30} # seconds between status lines
+
+die()  { printf '\033[0;31m✗ %s\033[0m\n' "$1" >&2; exit 1; }
+ok()   { printf '\033[0;32m✓ %s\033[0m\n' "$1"; }
+warn() { printf '\033[0;33m! %s\033[0m\n' "$1" >&2; }
+
+# ── args ─────────────────────────────────────────────────────────────────────
+INTERVAL=2; ONCE=0; QUIET=0; MODE=run; RPC="${TENDERLY_VNET_RPC_URL:-}"
+PIDFILE="$ROOT/script/tenderly/.mine-ticker.pid"
+LOGFILE="$ROOT/script/tenderly/mine-ticker.log"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --interval) INTERVAL="$2"; shift 2 ;;
+    --rpc-url)  RPC="$2";      shift 2 ;;
+    --once)     ONCE=1;        shift ;;
+    --daemon)   MODE=daemon;   shift ;;
+    --stop)     MODE=stop;     shift ;;
+    --status)   MODE=status;   shift ;;
+    --quiet)    QUIET=1;       shift ;;
+    # the header block IS the help text; stop at its closing banner rather than a
+    # hardcoded line number, which drifts every time the header is edited
+    -h|--help)  awk 'NR>=2{print; if (/^# ={20,}$/ && ++c==3) exit}' "$0"; exit 0 ;;
+    *) die "unknown arg: $1 (see --help)" ;;
+  esac
+done
+[[ "$INTERVAL" =~ ^[0-9]+$ ]] && [ "$INTERVAL" -ge 1 ] || die "--interval must be a whole number of seconds >= 1"
+
+# ── rpc resolution (never printed in full — the admin URL is write-capable) ──
+if [ -z "$RPC" ] && [ -f "$ROOT/.env" ]; then
+  RPC="$(grep -E '^TENDERLY_VNET_RPC_URL=' "$ROOT/.env" | tail -1 | cut -d= -f2- | tr -d '"')"
+fi
+[ -n "$RPC" ] && [ "$RPC" != "..." ] || die "no admin RPC: pass --rpc-url or set TENDERLY_VNET_RPC_URL (in env or .env)"
+
+rpc() { # $1 = method, $2 = params json (default []) — always emits valid JSON
+  local out
+  out="$(curl -sS --max-time 15 -X POST -H 'Content-Type: application/json' \
+    --data "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$1\",\"params\":${2:-[]}}" \
+    "$RPC" 2>/dev/null || true)"
+  # A blip can return nothing, or an HTML error page. Normalising to {} here keeps
+  # every caller's `jq` from failing the script under `set -e` mid-retry.
+  if printf '%s' "$out" | jq -e . >/dev/null 2>&1; then printf '%s' "$out"; else printf '{}'; fi
+}
+hex2dec() { [ -n "${1:-}" ] && [ "$1" != "null" ] && printf '%d' "$1" 2>/dev/null || echo ""; }
+
+block_number() { hex2dec "$(rpc eth_blockNumber | jq -r '.result // empty')"; }
+block_ts()     { hex2dec "$(rpc eth_getBlockByNumber '["latest",false]' | jq -r '.result.timestamp // empty')"; }
+# How far the chain's clock trails real time. Prints "?" rather than doing
+# arithmetic on an empty read — Ctrl-C can interrupt the RPC mid-substitution.
+lag() { local t; t="$(block_ts)"; [ -n "$t" ] && echo "$(( $(date +%s) - t ))" || echo '?'; }
+bn()  { local b; b="$(block_number)"; echo "${b:-?}"; }
+
+# ── detached-mode plumbing ───────────────────────────────────────────────────
+# A pidfile can outlive its process (crash, reboot, kill -9), so every read of it
+# is confirmed against the process table before it is believed.
+running_pid() {
+  local pid
+  [ -f "$PIDFILE" ] || return 1
+  pid="$(cat "$PIDFILE" 2>/dev/null || true)"
+  [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null || { rm -f "$PIDFILE"; return 1; }
+  echo "$pid"
+}
+
+# Refuse a second ticker before the preflight probe mines anything.
+if [ "$MODE" = daemon ] && pid="$(running_pid)"; then
+  die "ticker already running (pid $pid) — --stop it first"
+fi
+
+case "$MODE" in
+  stop)
+    pid="$(running_pid)" || die "no ticker running (no live pid in ${PIDFILE##*/})"
+    kill -TERM "$pid" 2>/dev/null || true
+    for _ in 1 2 3 4 5; do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+    kill -0 "$pid" 2>/dev/null && die "pid $pid did not exit — kill -9 $pid"
+    rm -f "$PIDFILE"
+    ok "stopped ticker (pid $pid); chain now at block $(bn)"
+    exit 0 ;;
+  status)
+    if pid="$(running_pid)"; then
+      ok "ticker running (pid $pid) — block $(bn), $(lag)s behind wall clock"
+      echo "  log: ${LOGFILE#$ROOT/}"
+    else
+      warn "no ticker running — block $(bn), $(lag)s behind wall clock"
+    fi
+    exit 0 ;;
+esac
+
+# ── preflight: reachable, write-capable, and report the starting drift ───────
+CHAIN="$(hex2dec "$(rpc eth_chainId | jq -r '.result // empty')")"
+[ -n "$CHAIN" ] || die "RPC unreachable: ${RPC:0:42}…"
+START_BLOCK="$(block_number)"
+echo "vnet: ${RPC:0:42}…  chain $CHAIN  block $START_BLOCK  $(lag)s behind wall clock"
+
+MINE_ERR="$(rpc evm_mine | jq -r '.error.message // empty')"
+[ -z "$MINE_ERR" ] || die "evm_mine rejected ($MINE_ERR) — is this the ADMIN RPC (not the public one)?"
+
+if [ "$ONCE" -eq 1 ]; then
+  ok "mined 1 block → $(bn) ($(lag)s behind wall clock)"
+  exit 0
+fi
+
+if [ "$MODE" = daemon ]; then
+  # Preflight already proved the RPC reachable and write-capable, so a failure to
+  # start is visible here rather than buried in the log.
+  # via the environment, not argv: `ps` would otherwise publish the admin URL.
+  TENDERLY_VNET_RPC_URL="$RPC" nohup "$0" --interval "$INTERVAL" >>"$LOGFILE" 2>&1 &
+  echo $! >"$PIDFILE"
+  sleep 1
+  running_pid >/dev/null || { rm -f "$PIDFILE"; die "daemon exited immediately — see ${LOGFILE#$ROOT/}"; }
+  ok "ticker detached (pid $(cat "$PIDFILE"), every ${INTERVAL}s) → ${LOGFILE#$ROOT/}"
+  echo "  stop with: ./script/tenderly/mine-ticker.sh --stop"
+  exit 0
+fi
+
+# ── heartbeat ────────────────────────────────────────────────────────────────
+MINED=0; FAILS=0; LAST_STATUS=$(date +%s)
+finish() {
+  trap - INT TERM # a second Ctrl-C should kill it, not re-enter this
+  echo
+  ok "stopped after $MINED block(s) at $(bn)"
+  exit 0
+}
+trap finish INT TERM
+
+# Whoever the parent registered under this pidfile is responsible for clearing it,
+# however it exits — otherwise --status reports a ghost after a crash.
+release_pidfile() { [ "$(cat "$PIDFILE" 2>/dev/null || true)" = "$$" ] && rm -f "$PIDFILE"; return 0; }
+trap release_pidfile EXIT
+
+ok "mining every ${INTERVAL}s — Ctrl-C to stop"
+while :; do
+  sleep "$INTERVAL"
+  err="$(rpc evm_mine | jq -r '.error.message // empty')"
+  if [ -n "$err" ]; then
+    FAILS=$((FAILS + 1))
+    # A vnet can blip (redeploy, rate limit). Ride out a few, but do not spin
+    # silently forever against a vnet that has gone away.
+    [ "$FAILS" -ge 10 ] && die "evm_mine failed 10 times in a row — last error: $err"
+    warn "evm_mine failed ($err) — retry $FAILS/10"
+    continue
+  fi
+  FAILS=0; MINED=$((MINED + 1))
+
+  now=$(date +%s)
+  if [ "$QUIET" -eq 0 ] && [ $((now - LAST_STATUS)) -ge "$STATUS_EVERY" ]; then
+    printf '  block %s  ·  %s mined  ·  %ss behind wall clock\n' \
+      "$(bn)" "$MINED" "$(lag)"
+    LAST_STATUS=$now
+  fi
+done

--- a/script/tenderly/mine-ticker.sh
+++ b/script/tenderly/mine-ticker.sh
@@ -125,8 +125,11 @@ case "$MODE" in
   stop)
     pid="$(running_pid)" || die "no ticker running (no live pid in ${PIDFILE##*/})"
     kill -TERM "$pid" 2>/dev/null || true
-    for _ in 1 2 3 4 5; do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
-    kill -0 "$pid" 2>/dev/null && die "pid $pid did not exit — kill -9 $pid"
+    # The child only notices TERM when its `sleep <interval>` ends, so the grace
+    # period has to exceed the interval it was started with — which --stop does not
+    # know. 60s covers any sane setting; past that it is a genuine hang.
+    for _ in $(seq 60); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+    kill -0 "$pid" 2>/dev/null && die "pid $pid still alive after 60s — kill -9 $pid"
     rm -f "$PIDFILE"
     ok "stopped ticker (pid $pid); chain now at block $(bn)"
     exit 0 ;;
@@ -172,7 +175,8 @@ MINED=0; FAILS=0; LAST_STATUS=$(date +%s)
 finish() {
   trap - INT TERM # a second Ctrl-C should kill it, not re-enter this
   echo
-  ok "stopped after $MINED block(s) at $(bn)"
+  # No RPC here: the whole point is to be gone before --stop's grace period expires.
+  ok "stopped after $MINED block(s) since $START_BLOCK"
   exit 0
 }
 trap finish INT TERM

--- a/script/tenderly/mine-ticker.sh
+++ b/script/tenderly/mine-ticker.sh
@@ -18,8 +18,8 @@
 # no state — starting and stopping it is always safe.
 #
 # It does NOT fast-forward the chain. Tenderly stamps each mined block with the
-# real time elapsed since the previous one, so a 2s cadence advances chain time
-# ~2s per block. What it does fix is drift: an idle vnet falls behind wall clock
+# real time elapsed since the previous one, so the cadence sets the block rate but
+# not the rate of chain time. What it does fix is drift: an idle vnet falls behind
 # by exactly as long as it sat idle (measured 2026-08-19: ~2h of lag after an
 # idle weekend), and the first transaction after that idles jumps the timestamp
 # by the whole gap in one block. A running ticker keeps the offset flat.
@@ -28,7 +28,11 @@
 #   ./script/tenderly/mine-ticker.sh [--interval <seconds>] [--rpc-url <url>]
 #                                    [--once | --daemon | --stop | --status] [--quiet]
 #
-#   --interval N   seconds between blocks (default 2, matching Base)
+#   --interval N   seconds between blocks (default 15). Base is 2s, but the heartbeat
+#                  only has to cover the IDLE gaps: a tester's own transaction still
+#                  mines its own block instantly. 15s keeps the wallet tracker moving
+#                  at ~1/7th the RPC traffic. Drop to 2 to mirror Base exactly; raise
+#                  to 30 if the vnet is rate-limiting.
 #   --rpc-url URL  admin (write-capable) RPC; else $TENDERLY_VNET_RPC_URL, else .env
 #   --once         mine a single block and exit — use to catch a vnet up before a run
 #   --daemon       detach and keep mining across terminals; logs to mine-ticker.log
@@ -37,8 +41,8 @@
 #   --quiet        suppress the periodic status line (errors still print)
 #
 # Examples:
-#   ./script/tenderly/mine-ticker.sh                     # 2s heartbeat, Ctrl-C to stop
-#   ./script/tenderly/mine-ticker.sh --interval 5
+#   ./script/tenderly/mine-ticker.sh                     # 15s heartbeat, Ctrl-C to stop
+#   ./script/tenderly/mine-ticker.sh --interval 2        # exactly Base's cadence
 #   ./script/tenderly/mine-ticker.sh --once
 #   make tenderly-mine / tenderly-mine-start / tenderly-mine-stop / tenderly-mine-status
 #
@@ -57,7 +61,7 @@ ok()   { printf '\033[0;32m✓ %s\033[0m\n' "$1"; }
 warn() { printf '\033[0;33m! %s\033[0m\n' "$1" >&2; }
 
 # ── args ─────────────────────────────────────────────────────────────────────
-INTERVAL=2; ONCE=0; QUIET=0; MODE=run; RPC="${TENDERLY_VNET_RPC_URL:-}"
+INTERVAL=15; ONCE=0; QUIET=0; MODE=run; RPC="${TENDERLY_VNET_RPC_URL:-}"
 PIDFILE="$ROOT/script/tenderly/.mine-ticker.pid"
 LOGFILE="$ROOT/script/tenderly/mine-ticker.log"
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
A Tenderly vnet mines a block only when a transaction arrives. Real Base mines one every ~2s, and wallets assume the latter. Two QA artifacts came out of that during FE-05 manual testing:

1. any `waitForTransactionReceipt` with `confirmations > 1` between interactive legs never resolves — the first leg mines into its own block and no further blocks come;
2. MetaMask's activity tracker needs block progression to mark a tx confirmed, so mined txs linger locally as submitted/pending and the next signature request shows the stale-queue banner.

Only the first was addressed, app-side, by routing everything through `TRANSACTION_CONFIRMATIONS = 1`. The second is still live for the withdraw and migration QA still ahead.

## `script/tenderly/mine-ticker.sh`

Calls `evm_mine` on an interval so the chain keeps ticking while nobody is transacting. It needs the admin RPC we already hold, not a Tenderly account privilege — which is what makes it available to whoever is running the QA session rather than to a maintainer.

```bash
make tenderly-mine            # foreground 2s heartbeat, Ctrl-C to stop
make tenderly-mine-start      # detached, logs to script/tenderly/mine-ticker.log
make tenderly-mine-status
make tenderly-mine-stop
./script/tenderly/mine-ticker.sh --once    # single block, catch a drifted vnet up
```

**It does not fast-forward the chain.** Tenderly stamps each mined block with the real time elapsed since the previous one, so a 2s cadence advances chain time ~2s per block — verified live, the lag readout sat pinned at 7167s for a whole run. What it fixes is drift: an idle vnet falls behind wall clock by exactly as long as it sat idle (the shared instance was ~2h behind when this was written), and the next transaction closes that whole gap in one block's timestamp. A running ticker keeps the offset flat, which is the more production-faithful thing for anything reading a TWAP or an oracle age.

For an all-day ticker the daemon has to live on a host that does not sleep — a closed laptop stops the chain, which is the failure this exists to prevent. The README carries a launchd recipe. The admin URL reaches the detached child through the environment rather than argv, so `ps` does not publish it.

Interval mining configured on the vnet itself is still the right permanent fix; this is the version that needs nobody's Tenderly account.

## The RPC-preference comment in `compound-cycle.sh`

Separate, found while wiring the above. The comment claimed `TENDERLY_VNET_RPC_URL` "is shared with the LPV2 harness and routinely points at a DIFFERENT vnet", which is why `LEVERAGED_AERO_ADMIN_RPC_URL` was preferred. Both names now resolve to the shared leveraged-aero instance (chainId 73578453).

Worse than stale: `LEVERAGED_AERO_ADMIN_RPC_URL` still named the pre-#66 instance, where the same deployer and nonces put **different bytecode at the same addresses** — `pooled.strategyClone` has codesize 0 there, and `pooled.vault` resolves to a 3750-byte factory. Anything following that comment bound to contracts that merely looked present. Local `.env` repointed; **check yours**. The preference order stays so an explicit override still wins.

## Verification

Run against the live QA vnet (chainId 73578453, `mamo-leveraged-aero-pr66-1786640530`):

- `evm_mine` accepted on the admin RPC, rejected on the public one (`Access forbidden by access rules`) and on real Base (`rpc method is unsupported`)
- ~40s at 2s cadence: 19 blocks, clean SIGTERM shutdown, no stray processes
- daemon mode: double-start refuses before the preflight mines anything, the pidfile is confirmed against the process table so a crash leaves no ghost, the child clears its own pidfile on any exit
- unreachable host and an HTML error page both fail legibly rather than crashing the retry loop
- pooled layer confirmed healthy while testing: `nav()` 111,886 USDC, `depositsOpen()` true, clone is an EIP-1167 proxy pointing at the manifest template, pool `observe([1800,0])` does not revert `OLD`

No contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)