### PR TITLE
fix: pin the permissionless deleverage trigger below the Moonwell CF

### DIFF
--- a/script/tenderly/LeveragedAeroStackHarness.s.sol
+++ b/script/tenderly/LeveragedAeroStackHarness.s.sol
@@ -209,8 +209,7 @@ contract LeveragedAeroStackHarness is Script {
         // ── skew governance band, fixed for the clone's life: `0 < min <= max < 10000`.
         p.minSkewBps = uint16(vm.envOr("MIN_SKEW_BPS", uint256(1000)));
         p.maxSkewBps = uint16(vm.envOr("MAX_SKEW_BPS", uint256(9000)));
-        // ── risk params: targetLtv ≤ maxLtv < USDC CF, minHealth ≥ 10500, minHealth×maxLtv < 1e8, and
-        //    minHealth×CF > 1e8 so the public-deleverage trigger sits BELOW the CF (12000 × 8800 = 1.056e8) ──
+        // ── risk params: targetLtv ≤ maxLtv < USDC CF, minHealth ≥ 10500, minHealth×maxLtv < 1e8, minHealth×CF > 1e8 ──
         p.targetLtvBps = uint16(vm.envOr("TARGET_LTV_BPS", uint256(5000)));
         p.maxLtvBps = uint16(vm.envOr("MAX_LTV_BPS", uint256(6500)));
         p.minHealthBps = uint16(vm.envOr("MIN_HEALTH_BPS", uint256(12_000)));

--- a/script/tenderly/LeveragedAeroStackHarness.s.sol
+++ b/script/tenderly/LeveragedAeroStackHarness.s.sol
@@ -209,7 +209,8 @@ contract LeveragedAeroStackHarness is Script {
         // ── skew governance band, fixed for the clone's life: `0 < min <= max < 10000`.
         p.minSkewBps = uint16(vm.envOr("MIN_SKEW_BPS", uint256(1000)));
         p.maxSkewBps = uint16(vm.envOr("MAX_SKEW_BPS", uint256(9000)));
-        // ── risk params: targetLtv ≤ maxLtv < USDC CF, minHealth ≥ 10500, minHealth×maxLtv < 1e8 ──
+        // ── risk params: targetLtv ≤ maxLtv < USDC CF, minHealth ≥ 10500, minHealth×maxLtv < 1e8, and
+        //    minHealth×CF > 1e8 so the public-deleverage trigger sits BELOW the CF (12000 × 8800 = 1.056e8) ──
         p.targetLtvBps = uint16(vm.envOr("TARGET_LTV_BPS", uint256(5000)));
         p.maxLtvBps = uint16(vm.envOr("MAX_LTV_BPS", uint256(6500)));
         p.minHealthBps = uint16(vm.envOr("MIN_HEALTH_BPS", uint256(12_000)));

--- a/src/leveraged-aero/LeveragedAeroValuation.sol
+++ b/src/leveraged-aero/LeveragedAeroValuation.sol
@@ -128,8 +128,7 @@ library LeveragedAeroValuation {
     error MaxLtvExceedsCF();
     /// @notice `minHealthBps × maxLtvBps >= 1e8` — the deleverage trigger LTV would sit inside the band (L4).
     error MinHealthMaxLtvConflict();
-    /// @notice `minHealthBps × cfBps <= 1e8` — the deleverage trigger LTV would sit at or above the
-    ///         Moonwell collateral factor, i.e. liquidation could precede the public rescue (L4).
+    /// @notice `minHealthBps × cfBps <= 1e8` — the deleverage trigger LTV would sit at or above the CF (L4).
     error DeleverageTriggerAboveCF();
     /// @notice A non-zero fee rate with a zero recipient.
     error FeeRecipientRequired();
@@ -328,15 +327,9 @@ library LeveragedAeroValuation {
     /// @notice The five VENUE-SCOPED risk invariants: the LTV band's own shape and its relationship to the
     ///         destination market's collateral factor (bps). Shared by `checkRiskParams` and
     ///         `LeveragedAeroVenue.applyVenue`, which re-runs them at every `migrateVenue`.
-    /// @dev L4: permissionless deleverage triggers at `LTV = 1e8 / minHealthBps`, and that trigger LTV is
-    ///      BRACKETED from both sides — the two rungs below are what make the rescue window structural
-    ///      rather than a lucky parameter choice:
-    ///      - strictly ABOVE `maxLtvBps` (`minHealthBps × maxLtvBps < 1e8`), or there is an in-band range
-    ///        anyone can grief-deleverage;
-    ///      - strictly BELOW `cfBps`, the market's liquidation line (`minHealthBps × cfBps > 1e8`), or there
-    ///        is a band where the book is already liquidatable while `deleverage()` still reverts
-    ///        `HealthyNoDeleverage` — liquidation would precede the public rescue.
-    ///      Together with `maxLtvBps < cfBps` the ordering is `target ≤ maxLtv < 1e8/minHealth < cf`.
+    /// @dev L4: permissionless deleverage triggers at `LTV = 1e8 / minHealthBps`; the last two rungs bracket
+    ///      it above `maxLtvBps` (grief-deleverage) and below `cfBps` (liquidation precedes the rescue), so
+    ///      the ordering is `target ≤ maxLtv < 1e8/minHealth < cf`.
     function checkLtvBand(uint16 targetLtvBps, uint16 maxLtvBps, uint16 minHealthBps, uint16 cfBps) public pure {
         if (targetLtvBps > maxLtvBps) revert TargetLtvExceedsMax();
         if (minHealthBps < 10500) revert MinHealthTooLow();

--- a/src/leveraged-aero/LeveragedAeroValuation.sol
+++ b/src/leveraged-aero/LeveragedAeroValuation.sol
@@ -329,7 +329,8 @@ library LeveragedAeroValuation {
     ///         `LeveragedAeroVenue.applyVenue`, which re-runs them at every `migrateVenue`.
     /// @dev L4: permissionless deleverage triggers at `LTV = 1e8 / minHealthBps`; the last two rungs bracket
     ///      it above `maxLtvBps` (grief-deleverage) and below `cfBps` (liquidation precedes the rescue), so
-    ///      the ordering is `target ≤ maxLtv < 1e8/minHealth < cf`.
+    ///      the ordering is `target ≤ maxLtv < 1e8/minHealth < cf`. CONFIG-TIME ONLY: a CF that Moonwell
+    ///      cuts post-init reopens that window until the next `migrateVenue` re-reads it.
     function checkLtvBand(uint16 targetLtvBps, uint16 maxLtvBps, uint16 minHealthBps, uint16 cfBps) public pure {
         if (targetLtvBps > maxLtvBps) revert TargetLtvExceedsMax();
         if (minHealthBps < 10500) revert MinHealthTooLow();

--- a/src/leveraged-aero/LeveragedAeroValuation.sol
+++ b/src/leveraged-aero/LeveragedAeroValuation.sol
@@ -128,6 +128,9 @@ library LeveragedAeroValuation {
     error MaxLtvExceedsCF();
     /// @notice `minHealthBps × maxLtvBps >= 1e8` — the deleverage trigger LTV would sit inside the band (L4).
     error MinHealthMaxLtvConflict();
+    /// @notice `minHealthBps × cfBps <= 1e8` — the deleverage trigger LTV would sit at or above the
+    ///         Moonwell collateral factor, i.e. liquidation could precede the public rescue (L4).
+    error DeleverageTriggerAboveCF();
     /// @notice A non-zero fee rate with a zero recipient.
     error FeeRecipientRequired();
     /// @notice Performance fee above the protocol-wide cap.
@@ -322,16 +325,24 @@ library LeveragedAeroValuation {
         if (minSkewBps_ == 0 || minSkewBps_ > maxSkewBps_ || maxSkewBps_ >= 10000) revert OutOfBounds();
     }
 
-    /// @notice The four VENUE-SCOPED risk invariants: the LTV band's own shape and its relationship to the
+    /// @notice The five VENUE-SCOPED risk invariants: the LTV band's own shape and its relationship to the
     ///         destination market's collateral factor (bps). Shared by `checkRiskParams` and
     ///         `LeveragedAeroVenue.applyVenue`, which re-runs them at every `migrateVenue`.
-    /// @dev L4: permissionless deleverage triggers at `LTV = 1e8 / minHealthBps`, which MUST sit strictly
-    ///      above `maxLtvBps` or there is an in-band range anyone can grief-deleverage.
+    /// @dev L4: permissionless deleverage triggers at `LTV = 1e8 / minHealthBps`, and that trigger LTV is
+    ///      BRACKETED from both sides — the two rungs below are what make the rescue window structural
+    ///      rather than a lucky parameter choice:
+    ///      - strictly ABOVE `maxLtvBps` (`minHealthBps × maxLtvBps < 1e8`), or there is an in-band range
+    ///        anyone can grief-deleverage;
+    ///      - strictly BELOW `cfBps`, the market's liquidation line (`minHealthBps × cfBps > 1e8`), or there
+    ///        is a band where the book is already liquidatable while `deleverage()` still reverts
+    ///        `HealthyNoDeleverage` — liquidation would precede the public rescue.
+    ///      Together with `maxLtvBps < cfBps` the ordering is `target ≤ maxLtv < 1e8/minHealth < cf`.
     function checkLtvBand(uint16 targetLtvBps, uint16 maxLtvBps, uint16 minHealthBps, uint16 cfBps) public pure {
         if (targetLtvBps > maxLtvBps) revert TargetLtvExceedsMax();
         if (minHealthBps < 10500) revert MinHealthTooLow();
         if (maxLtvBps >= cfBps) revert MaxLtvExceedsCF();
         if (uint256(minHealthBps) * uint256(maxLtvBps) >= 1e8) revert MinHealthMaxLtvConflict();
+        if (uint256(minHealthBps) * uint256(cfBps) <= 1e8) revert DeleverageTriggerAboveCF();
     }
 
     /// @notice The INIT-ONLY numeric ladder over the risk and oracle params, in the strategy's original

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -647,7 +647,7 @@ library LeveragedAeroVenue {
         );
 
         // Risk invariants against the LIVE collateral factor (fresher than init's); both the read and the
-        // four rungs are the Valuation copies shared with the init ladder.
+        // five rungs are the Valuation copies shared with the init ladder.
         uint16 cfBps = LeveragedAeroValuation.readCollateralFactor($.comptroller, mUsdc);
         // The lower bound is the only rung not mirrored in that ladder, and `applyVenue` is the shared route
         // for init and migrate, so it closes every path to a stored zero target — a fund that can never lever.

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -91,9 +91,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     error PerformanceFeeTooHigh();
     error ManagementFeeTooHigh();
     error MinHealthMaxLtvConflict();
-    // minHealthBps * cfBps <= 1e8 — the permissionless-deleverage trigger LTV (1e8 / minHealthBps) would sit
-    // at or above the market's collateral factor, so liquidation could precede the public rescue.
-    error DeleverageTriggerAboveCF();
+    error DeleverageTriggerAboveCF(); // minHealthBps * cfBps <= 1e8 — trigger LTV at or above the CF
     error AssetMismatch();
     error UnexpectedAssetDecimals();
     error UnexpectedFeedDecimals(); // AERO/USD aggregator not 8dp (L9 oracle-floor scaling assumption)

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -91,6 +91,9 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     error PerformanceFeeTooHigh();
     error ManagementFeeTooHigh();
     error MinHealthMaxLtvConflict();
+    // minHealthBps * cfBps <= 1e8 — the permissionless-deleverage trigger LTV (1e8 / minHealthBps) would sit
+    // at or above the market's collateral factor, so liquidation could precede the public rescue.
+    error DeleverageTriggerAboveCF();
     error AssetMismatch();
     error UnexpectedAssetDecimals();
     error UnexpectedFeedDecimals(); // AERO/USD aggregator not 8dp (L9 oracle-floor scaling assumption)

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -1007,6 +1007,28 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         assertGe(healthAfter, 12_000, "health restored above the minimum");
     }
 
+    /// @dev L4's other half: the valve is a BACKSTOP, not a lever anyone may pull. On a healthy book
+    ///      (`_execute` lands at target 5000, i.e. health 20000 vs the 12000 minimum) `deleverage()`
+    ///      refuses, so a stranger cannot force-delever a fund that is inside policy.
+    ///      MUTATION: drop the `healthBefore >= minHealth` clause and this succeeds.
+    function testDeleverageRefusesAHealthyBookForAnyCaller() public {
+        _execute(SEED);
+
+        (uint256 collateral, uint256 debt) = _collateralAndDebt();
+        assertGe((collateral * 10_000) / debt, 12_000, "the fixture must be healthy for this to mean anything");
+
+        uint256 debtBefore = mLegA.borrowBalance(address(strategy));
+        vm.prank(makeAddr("stranger"));
+        vm.expectRevert(LeveragedAerodromeCLStrategy.HealthyNoDeleverage.selector);
+        strategy.deleverage(0);
+
+        vm.prank(proposer); // not even the proposer gets the valve on a healthy book
+        vm.expectRevert(LeveragedAerodromeCLStrategy.HealthyNoDeleverage.selector);
+        strategy.deleverage(0);
+
+        assertEq(mLegA.borrowBalance(address(strategy)), debtBefore, "debt untouched by the refused calls");
+    }
+
     /// @dev In the collateral-dust tail `targetDebt` floors to 0, so `repayUsd == debtBefore` would trip
     ///      `_leverDown`'s orphaned-NFT guard and switch the PERMISSIONLESS valve off exactly where it is
     ///      needed; the `repayUsd = debtBefore - 1` clamp keeps ≥1 liquidity and the re-stake alive.
@@ -1063,6 +1085,71 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         vm.prank(makeAddr("keeper"));
         vm.expectPartialRevert(LeveragedAerodromeCLStrategy.UnhealthyPosition.selector);
         strategy.deleverage(0);
+    }
+
+    // ============ LAYER 2: THE POST-OP HEALTH GATE (`_assertHealthy`) ============
+    // Every debt-adding op ends in `LeveragedAeroManager._assertHealthy()` — `executeImpl`,
+    // `deployIdleImpl` (and `compoundImpl` through it), `rerangeImpl`, `adjustLeverageImpl`. It reverts
+    // `UnhealthyPosition(ltvBps, maxLtvBps)` on a Chainlink-priced LTV above `maxLtvBps`, or on any
+    // Moonwell shortfall. It is the gate that makes "the proposer key over-levers the book" unreachable
+    // regardless of what the proposer asks for: an op that would land above the ceiling does not land.
+    // The collateral basis is the lever here (prices untouched), so the LP stays two-sided and the only
+    // thing under test is the gate.
+
+    /// @dev `rerangeImpl`'s gate. Rerange itself is debt-neutral (it unwinds and remints liquidity, it
+    ///      does not borrow), so it is the cleanest read of the gate alone: the book is ALREADY above
+    ///      `maxLtvBps` and the op is refused rather than allowed to consolidate the breach.
+    function testRerangeRevertsUnhealthyPositionWhenTheBookSitsAboveMaxLtv() public {
+        _execute(SEED);
+        mUsdc.setExchangeRateStored(0.7e18); // LTV 5000 -> ~7142, above maxLtv 6500
+        (uint256 c, uint256 d) = _collateralAndDebt();
+        assertGt((d * 10_000) / c, 6500, "the arm must actually breach maxLtv");
+
+        vm.prank(proposer);
+        vm.expectPartialRevert(LeveragedAerodromeCLStrategy.UnhealthyPosition.selector);
+        strategy.rerange(WIDTH, SKEW_CENTERED, 0, 0);
+    }
+
+    /// @dev The non-vacuity twin: the SAME op at an LTV inside the ceiling succeeds, so the revert above
+    ///      is the gate firing and not rerange being broken by a moved collateral basis.
+    function testRerangeSucceedsWhenTheSameCollateralMoveKeepsTheBookInsideMaxLtv() public {
+        _execute(SEED);
+        mUsdc.setExchangeRateStored(0.9e18); // LTV 5000 -> ~5555, still under maxLtv 6500
+        (uint256 c, uint256 d) = _collateralAndDebt();
+        assertLt((d * 10_000) / c, 6500, "still inside the ceiling");
+
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, SKEW_CENTERED, 0, 0);
+        assertGt(strategy.layout().tokenId, 0, "rerange landed: the position is live, the op was not refused");
+    }
+
+    /// @dev `deployIdleImpl`'s gate. Deploying idle USDC BORROWS at the standing target, so this is the
+    ///      "add debt to an already-breached book" case — the shape of an over-leverage attempt. The op
+    ///      is sized at target 5000, well under the ceiling, and is still refused because the gate reads
+    ///      the WHOLE book's post-op LTV, not the marginal op's.
+    function testDeployIdleRevertsUnhealthyPositionOnABookAlreadyAboveMaxLtv() public {
+        _execute(SEED);
+        mUsdc.setExchangeRateStored(0.5e18); // LTV 5000 -> ~10000, far above maxLtv 6500
+
+        usdc.mint(address(strategy), 10_000e6); // fresh idle to deploy
+        vm.prank(proposer);
+        vm.expectPartialRevert(LeveragedAerodromeCLStrategy.UnhealthyPosition.selector);
+        strategy.deployIdle(10_000e6, 0);
+    }
+
+    /// @dev The Moonwell belt, on an op rather than on `deleverage`: even with the strategy's own
+    ///      Chainlink LTV inside `maxLtvBps`, a shortfall reported by the comptroller fails the op.
+    ///      That is the authoritative liquidation check, and it binds the proposer's ops too.
+    ///      MUTATION: delete the `shortfall != 0` clause in `_assertHealthy` and this succeeds.
+    function testRerangeRevertsOnAMoonwellShortfallEvenWhileTheChainlinkLtvIsInsideTheCeiling() public {
+        _execute(SEED);
+        (uint256 c, uint256 d) = _collateralAndDebt();
+        assertLt((d * 10_000) / c, 6500, "Chainlink-priced LTV is inside the ceiling");
+
+        comptroller.setShortfall(1e18);
+        vm.prank(proposer);
+        vm.expectPartialRevert(LeveragedAerodromeCLStrategy.UnhealthyPosition.selector);
+        strategy.rerange(WIDTH, SKEW_CENTERED, 0, 0);
     }
 
     // ==================== THE CRUX INVARIANT ====================

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -1007,10 +1007,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         assertGe(healthAfter, 12_000, "health restored above the minimum");
     }
 
-    /// @dev L4's other half: the valve is a BACKSTOP, not a lever anyone may pull. On a healthy book
-    ///      (`_execute` lands at target 5000, i.e. health 20000 vs the 12000 minimum) `deleverage()`
-    ///      refuses, so a stranger cannot force-delever a fund that is inside policy.
-    ///      MUTATION: drop the `healthBefore >= minHealth` clause and this succeeds.
+    /// @dev L4's other half: the valve is a BACKSTOP — neither a stranger nor the proposer may force-delever.
     function testDeleverageRefusesAHealthyBookForAnyCaller() public {
         _execute(SEED);
 
@@ -1088,17 +1085,9 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
     }
 
     // ============ LAYER 2: THE POST-OP HEALTH GATE (`_assertHealthy`) ============
-    // Every debt-adding op ends in `LeveragedAeroManager._assertHealthy()` — `executeImpl`,
-    // `deployIdleImpl` (and `compoundImpl` through it), `rerangeImpl`, `adjustLeverageImpl`. It reverts
-    // `UnhealthyPosition(ltvBps, maxLtvBps)` on a Chainlink-priced LTV above `maxLtvBps`, or on any
-    // Moonwell shortfall. It is the gate that makes "the proposer key over-levers the book" unreachable
-    // regardless of what the proposer asks for: an op that would land above the ceiling does not land.
-    // The collateral basis is the lever here (prices untouched), so the LP stays two-sided and the only
-    // thing under test is the gate.
+    // The collateral basis is the lever below (prices untouched), so the LP stays two-sided.
 
-    /// @dev `rerangeImpl`'s gate. Rerange itself is debt-neutral (it unwinds and remints liquidity, it
-    ///      does not borrow), so it is the cleanest read of the gate alone: the book is ALREADY above
-    ///      `maxLtvBps` and the op is refused rather than allowed to consolidate the breach.
+    /// @dev Rerange is debt-neutral, so it reads the gate alone: the book is ALREADY above `maxLtvBps`.
     function testRerangeRevertsUnhealthyPositionWhenTheBookSitsAboveMaxLtv() public {
         _execute(SEED);
         mUsdc.setExchangeRateStored(0.7e18); // LTV 5000 -> ~7142, above maxLtv 6500
@@ -1110,8 +1099,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         strategy.rerange(WIDTH, SKEW_CENTERED, 0, 0);
     }
 
-    /// @dev The non-vacuity twin: the SAME op at an LTV inside the ceiling succeeds, so the revert above
-    ///      is the gate firing and not rerange being broken by a moved collateral basis.
+    /// @dev Non-vacuity: the same op inside the ceiling succeeds, so the revert above is the gate firing.
     function testRerangeSucceedsWhenTheSameCollateralMoveKeepsTheBookInsideMaxLtv() public {
         _execute(SEED);
         mUsdc.setExchangeRateStored(0.9e18); // LTV 5000 -> ~5555, still under maxLtv 6500
@@ -1123,10 +1111,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         assertGt(strategy.layout().tokenId, 0, "rerange landed: the position is live, the op was not refused");
     }
 
-    /// @dev `deployIdleImpl`'s gate. Deploying idle USDC BORROWS at the standing target, so this is the
-    ///      "add debt to an already-breached book" case — the shape of an over-leverage attempt. The op
-    ///      is sized at target 5000, well under the ceiling, and is still refused because the gate reads
-    ///      the WHOLE book's post-op LTV, not the marginal op's.
+    /// @dev The op is sized at target 5000 yet still refused: the gate reads the WHOLE book's post-op LTV.
     function testDeployIdleRevertsUnhealthyPositionOnABookAlreadyAboveMaxLtv() public {
         _execute(SEED);
         mUsdc.setExchangeRateStored(0.5e18); // LTV 5000 -> ~10000, far above maxLtv 6500
@@ -1137,10 +1122,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         strategy.deployIdle(10_000e6, 0);
     }
 
-    /// @dev The Moonwell belt, on an op rather than on `deleverage`: even with the strategy's own
-    ///      Chainlink LTV inside `maxLtvBps`, a shortfall reported by the comptroller fails the op.
-    ///      That is the authoritative liquidation check, and it binds the proposer's ops too.
-    ///      MUTATION: delete the `shortfall != 0` clause in `_assertHealthy` and this succeeds.
+    /// @dev The Moonwell belt binds ops too, not just `deleverage` — the Chainlink LTV here is in-ceiling.
     function testRerangeRevertsOnAMoonwellShortfallEvenWhileTheChainlinkLtvIsInsideTheCeiling() public {
         _execute(SEED);
         (uint256 c, uint256 d) = _collateralAndDebt();

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -1014,7 +1014,7 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         (uint256 collateral, uint256 debt) = _collateralAndDebt();
         assertGe((collateral * 10_000) / debt, 12_000, "the fixture must be healthy for this to mean anything");
 
-        uint256 debtBefore = mLegA.borrowBalance(address(strategy));
+        // The reverts ARE the pin: a post-revert state assertion would be inert, since the call unwinds it.
         vm.prank(makeAddr("stranger"));
         vm.expectRevert(LeveragedAerodromeCLStrategy.HealthyNoDeleverage.selector);
         strategy.deleverage(0);
@@ -1022,8 +1022,6 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         vm.prank(proposer); // not even the proposer gets the valve on a healthy book
         vm.expectRevert(LeveragedAerodromeCLStrategy.HealthyNoDeleverage.selector);
         strategy.deleverage(0);
-
-        assertEq(mLegA.borrowBalance(address(strategy)), debtBefore, "debt untouched by the refused calls");
     }
 
     /// @dev In the collateral-dust tail `targetDebt` floors to 0, so `repayUsd == debtBefore` would trip
@@ -1106,9 +1104,12 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         (uint256 c, uint256 d) = _collateralAndDebt();
         assertLt((d * 10_000) / c, 6500, "still inside the ceiling");
 
+        uint256 tokenIdBefore = strategy.layout().tokenId;
         vm.prank(proposer);
         strategy.rerange(WIDTH, SKEW_CENTERED, 0, 0);
-        assertGt(strategy.layout().tokenId, 0, "rerange landed: the position is live, the op was not refused");
+        // `rerangeImpl` always mints a FRESH NFT, so a changed id pins that the op ran, not just that it
+        // failed to revert.
+        assertTrue(strategy.layout().tokenId != tokenIdBefore, "rerange actually reminted the position");
     }
 
     /// @dev The op is sized at target 5000 yet still refused: the gate reads the WHOLE book's post-op LTV.

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -897,7 +897,12 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.MinHealthTooLow.selector);
     }
 
+    /// @dev The 10500 floor is only REACHABLE in a market whose collateral factor clears the second L4
+    ///      rung: the trigger LTV at the floor is `1e8 / 10500 = 9523`, so the CF must exceed it. The
+    ///      fixture's default 8800 does NOT (that combination is `DeleverageTriggerAboveCF`, pinned
+    ///      below), so this test raises the CF to 9600 to isolate the floor itself.
     function testInitAcceptsMinHealthAtTheFloor() public {
+        comptroller.setCollateralFactorMantissa(0.96e18); // cf 9600; 10500 * 9600 = 1.008e8 > 1e8
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.minHealthBps = 10_500;
         p.maxLtvBps = 6500; // 10500 * 6500 = 6.825e7 < 1e8, so the L4 conflict guard still clears
@@ -932,6 +937,57 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         p.minHealthBps = 12_500;
         p.maxLtvBps = 7900; // 9.875e7 < 1e8 -> accepted
         assertEq(_init(p).layout().maxLtvBps, 7900, "just under the bound accepted");
+    }
+
+    /// @dev L4, the OTHER side of the trigger LTV. `deleverage()` only unlocks at `LTV = 1e8 /
+    ///      minHealthBps`, so that trigger must also sit strictly BELOW the market's collateral factor —
+    ///      the liquidation line. Otherwise the book is already liquidatable while the public rescue still
+    ///      reverts `HealthyNoDeleverage`. Here the floor `minHealthBps` triggers at 1e8/10500 = 9523,
+    ///      ABOVE the fixture's 8800 CF, which is exactly the band this rung closes.
+    function testInitRevertsWhenTheDeleverageTriggerSitsAtOrAboveTheCollateralFactor() public {
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.minHealthBps = 10_500; // 10500 * 8800 = 9.24e7 <= 1e8 -> trigger 9523 > CF 8800
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.DeleverageTriggerAboveCF.selector);
+    }
+
+    /// @dev The rung is a strict `>`: the product landing exactly ON 1e8 means trigger == CF, i.e. the
+    ///      rescue unlocks at the very LTV Moonwell liquidates at, and is rejected. One bps of CF more
+    ///      (the smallest step `readCollateralFactor` can resolve) is accepted.
+    function testInitDeleverageTriggerCollateralFactorBoundaryIsStrict() public {
+        // 12500 * 8000 == 1e8 exactly -> rejected. maxLtv 6500 keeps the two earlier rungs clear
+        // (6500 < 8000 and 12500 * 6500 = 8.125e7 < 1e8), so THIS rung is the one that fires.
+        comptroller.setCollateralFactorMantissa(0.8e18); // cf 8000
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.minHealthBps = 12_500;
+        _expectInitRevert(p, LeveragedAerodromeCLStrategy.DeleverageTriggerAboveCF.selector);
+
+        // One bps of CF more: 12500 * 8001 = 1.000125e8 > 1e8 -> accepted.
+        comptroller.setCollateralFactorMantissa(0.8001e18); // cf 8001
+        p = _baseParams();
+        p.minHealthBps = 12_500;
+        assertEq(_init(p).layout().minHealthBps, 12_500, "one bps of CF above the bound accepted");
+    }
+
+    /// @dev The same boundary walked from the `minHealthBps` side, since either knob can be the misconfig:
+    ///      a HIGHER minHealth lowers the trigger LTV, so it moves the product the safe way.
+    function testInitDeleverageTriggerAcceptsTheSmallestMinHealthStepAboveTheBound() public {
+        comptroller.setCollateralFactorMantissa(0.8e18); // cf 8000
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        p.minHealthBps = 12_501; // 12501 * 8000 = 1.00008e8 > 1e8 -> accepted
+        assertEq(_init(p).layout().minHealthBps, 12_501, "one bps of minHealth above the bound accepted");
+    }
+
+    /// @dev The shipping params clear the rung with room: trigger 1e8/12000 = 8333 vs the mainnet USDC
+    ///      CF of 8800. Guards the production configuration against a silent regression in either knob.
+    function testInitAcceptsTheProductionRiskParamsUnderTheDeleverageTriggerRung() public {
+        // `_baseParams()` IS the shipping set: target 5000, maxLtv 6500, minHealth 12000; CF 8800.
+        LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
+        LeveragedAerodromeCLStrategy s = _init(p);
+        assertEq(s.layout().minHealthBps, 12_000, "minHealth stored");
+        assertEq(s.layout().usdcCollateralFactorBps, 8800, "CF read from the comptroller");
+        // 12000 * 8800 = 1.056e8 > 1e8, and the full ordering holds: 5000 <= 6500 < 8333 < 8800.
+        assertLt(1e8 / uint256(s.layout().minHealthBps), uint256(s.layout().usdcCollateralFactorBps), "trigger < CF");
+        assertLt(uint256(s.layout().maxLtvBps), 1e8 / uint256(s.layout().minHealthBps), "maxLtv < trigger");
     }
 
     /// @dev A comptroller reporting a zero collateral factor is unusable — the read must fail loudly

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -897,10 +897,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.MinHealthTooLow.selector);
     }
 
-    /// @dev The 10500 floor is only REACHABLE in a market whose collateral factor clears the second L4
-    ///      rung: the trigger LTV at the floor is `1e8 / 10500 = 9523`, so the CF must exceed it. The
-    ///      fixture's default 8800 does NOT (that combination is `DeleverageTriggerAboveCF`, pinned
-    ///      below), so this test raises the CF to 9600 to isolate the floor itself.
+    /// @dev The floor triggers at `1e8 / 10500 = 9523`, so it needs a CF above that — hence the raise here.
     function testInitAcceptsMinHealthAtTheFloor() public {
         comptroller.setCollateralFactorMantissa(0.96e18); // cf 9600; 10500 * 9600 = 1.008e8 > 1e8
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
@@ -939,37 +936,27 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(_init(p).layout().maxLtvBps, 7900, "just under the bound accepted");
     }
 
-    /// @dev L4, the OTHER side of the trigger LTV. `deleverage()` only unlocks at `LTV = 1e8 /
-    ///      minHealthBps`, so that trigger must also sit strictly BELOW the market's collateral factor —
-    ///      the liquidation line. Otherwise the book is already liquidatable while the public rescue still
-    ///      reverts `HealthyNoDeleverage`. Here the floor `minHealthBps` triggers at 1e8/10500 = 9523,
-    ///      ABOVE the fixture's 8800 CF, which is exactly the band this rung closes.
+    /// @dev L4's other side: trigger below CF, else the book is liquidatable while `deleverage()` reverts.
     function testInitRevertsWhenTheDeleverageTriggerSitsAtOrAboveTheCollateralFactor() public {
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.minHealthBps = 10_500; // 10500 * 8800 = 9.24e7 <= 1e8 -> trigger 9523 > CF 8800
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.DeleverageTriggerAboveCF.selector);
     }
 
-    /// @dev The rung is a strict `>`: the product landing exactly ON 1e8 means trigger == CF, i.e. the
-    ///      rescue unlocks at the very LTV Moonwell liquidates at, and is rejected. One bps of CF more
-    ///      (the smallest step `readCollateralFactor` can resolve) is accepted.
+    /// @dev Strict `>`: product == 1e8 means trigger == CF and is rejected; one bps of CF more is accepted.
     function testInitDeleverageTriggerCollateralFactorBoundaryIsStrict() public {
-        // 12500 * 8000 == 1e8 exactly -> rejected. maxLtv 6500 keeps the two earlier rungs clear
-        // (6500 < 8000 and 12500 * 6500 = 8.125e7 < 1e8), so THIS rung is the one that fires.
         comptroller.setCollateralFactorMantissa(0.8e18); // cf 8000
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         p.minHealthBps = 12_500;
         _expectInitRevert(p, LeveragedAerodromeCLStrategy.DeleverageTriggerAboveCF.selector);
 
-        // One bps of CF more: 12500 * 8001 = 1.000125e8 > 1e8 -> accepted.
-        comptroller.setCollateralFactorMantissa(0.8001e18); // cf 8001
+        comptroller.setCollateralFactorMantissa(0.8001e18); // cf 8001; 12500 * 8001 = 1.000125e8 > 1e8
         p = _baseParams();
         p.minHealthBps = 12_500;
         assertEq(_init(p).layout().minHealthBps, 12_500, "one bps of CF above the bound accepted");
     }
 
-    /// @dev The same boundary walked from the `minHealthBps` side, since either knob can be the misconfig:
-    ///      a HIGHER minHealth lowers the trigger LTV, so it moves the product the safe way.
+    /// @dev The same boundary from the other knob: a HIGHER minHealth lowers the trigger LTV.
     function testInitDeleverageTriggerAcceptsTheSmallestMinHealthStepAboveTheBound() public {
         comptroller.setCollateralFactorMantissa(0.8e18); // cf 8000
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
@@ -977,15 +964,12 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(_init(p).layout().minHealthBps, 12_501, "one bps of minHealth above the bound accepted");
     }
 
-    /// @dev The shipping params clear the rung with room: trigger 1e8/12000 = 8333 vs the mainnet USDC
-    ///      CF of 8800. Guards the production configuration against a silent regression in either knob.
+    /// @dev `_baseParams()` IS the shipping set, so this pins the ordering `5000 <= 6500 < 8333 < 8800`.
     function testInitAcceptsTheProductionRiskParamsUnderTheDeleverageTriggerRung() public {
-        // `_baseParams()` IS the shipping set: target 5000, maxLtv 6500, minHealth 12000; CF 8800.
         LeveragedAerodromeCLStrategy.InitParams memory p = _baseParams();
         LeveragedAerodromeCLStrategy s = _init(p);
         assertEq(s.layout().minHealthBps, 12_000, "minHealth stored");
         assertEq(s.layout().usdcCollateralFactorBps, 8800, "CF read from the comptroller");
-        // 12000 * 8800 = 1.056e8 > 1e8, and the full ordering holds: 5000 <= 6500 < 8333 < 8800.
         assertLt(1e8 / uint256(s.layout().minHealthBps), uint256(s.layout().usdcCollateralFactorBps), "trigger < CF");
         assertLt(uint256(s.layout().maxLtvBps), 1e8 / uint256(s.layout().minHealthBps), "maxLtv < trigger");
     }

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -1348,27 +1348,16 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         );
     }
 
-    /// @dev THE LTV-PRESERVATION PROPERTY OF THE ASYNC UNWIND. `_proportionalRedeem` ->
-    ///      `LeveragedAeroManager.redeemUnwindImpl(shares, supply)` repays `f = shares/supply` of EACH
-    ///      leg's debt and redeems `f` of the collateral, so both sides of the ratio shrink by the same
-    ///      factor and post-LTV cannot exceed pre-LTV. That is why `fulfillRedeem` can never push a
-    ///      healthy book above `maxLtvBps` and so cannot be the route to a liquidation.
-    ///
-    ///      To be precise about the guarantee: `fulfillRedeem` has NO max-LTV revert of its own (unlike
-    ///      the fast path's `FastRedeemExceedsLtv`) and this PR adds none — the property is preserved BY
-    ///      MECHANISM and pinned here by test. The tolerance is one-sided on purpose: LTV may only drift
-    ///      DOWN (mulDiv floors the repay and the collateral burn independently), never up.
-    ///      MUTATION: make the repay less than pro-rata — e.g. scale step B's repay by `f/2` — and the
-    ///      post-LTV rises above the pre-LTV and this fails.
+    /// @dev `redeemUnwindImpl` repays `f = shares/supply` of each leg's debt and redeems `f` of the collateral,
+    ///      so post-LTV cannot exceed pre-LTV. `fulfillRedeem` has NO max-LTV revert (unlike the fast path's
+    ///      `FastRedeemExceedsLtv`): the property holds by mechanism, pinned here. Tolerance is one-sided.
     function testPartialFulfillRedeemNeverRaisesTheBookLtv() public {
         _execute(SEED);
-        // A non-unit collateral basis, so `f` of the cTokens is not `f` of the underlying face value —
-        // the case where a naive "burn f of a stored underlying estimate" unwind WOULD drift the ratio.
-        // Stored == pending on purpose: no accrual fires DURING the fulfil, so `_ltvBps()` reads the
-        // same basis before and after and the delta below is the unwind's own rounding, nothing else.
+        // Non-unit basis, and stored == pending so no accrual fires mid-fulfil: the delta below is the
+        // unwind's own rounding, nothing else.
         mUsdc.setExchangeRateStored(1.37e18);
         mUsdc.setPendingExchangeRate(1.37e18);
-        // THEN lever up NEAR the ceiling (maxLtv 6500) on that basis, so a rise of a few bps is material.
+        // THEN lever up near the 6500 ceiling on that basis, so a rise of a few bps would be material.
         _retarget(6000);
         vm.prank(address(strategy));
         vault.strategyMint(lp, SUPPLY);
@@ -1383,26 +1372,18 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         strategy.fulfillRedeem(id, 0);
 
         uint256 ltvAfter = _ltvBps();
-        // Non-vacuity: the unwind actually moved the book, and both legs still carry debt, so the
-        // post-read is a real levered LTV rather than a flattened 0.
         assertLt(_collateralUsdc(), collateralBefore, "the fulfil actually withdrew collateral");
         assertGt(mLegA.borrowBalance(address(strategy)), 0, "leg A still levered after the partial");
         assertGt(mLegB.borrowBalance(address(strategy)), 0, "leg B still levered after the partial");
         assertGt(ltvAfter, 0, "post-LTV is a real levered reading");
 
-        // THE PROPERTY. One-sided: no epsilon is granted upward. Measured drift on this fixture and
-        // on-chain is <= 0.02 bps and always DOWNWARD (floored repay/burn favour the stayers).
+        // THE PROPERTY. No epsilon upward; measured drift here and on-chain is <= 0.02 bps, always down.
         assertLe(ltvAfter, ltvBefore, "a partial fulfillRedeem never RAISES the book LTV");
         assertApproxEqAbs(ltvAfter, ltvBefore, 2, "and it stays within rounding of it: a true pro-rata unwind");
-        // ... and therefore it can never walk the book up to the post-op ceiling every other op is gated on.
         assertLe(ltvAfter, 6500, "post-fulfil LTV is still inside maxLtvBps");
     }
 
-    /// @dev The sibling with COLLATERAL ACCRUAL landing during the fulfil (pending rate above stored, as
-    ///      F15 arms it). Accrual is a real drift source, and it moves the ratio the SAFE way: the burn
-    ///      settles at the fresh rate, so the stayers keep more collateral against unchanged debt. Only
-    ///      the one-sided property is asserted here — there is no tight bound to claim, because the basis
-    ///      itself moved. Cross-checked against the stable-basis sibling above, which owns the tight bound.
+    /// @dev The accrual sibling: the basis itself moves, so only the one-sided property is claimable here.
     function testPartialFulfillRedeemUnderCollateralAccrualStillOnlyMovesTheLtvDown() public {
         _execute(SEED);
         _retarget(6000);

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -1348,6 +1348,81 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         );
     }
 
+    /// @dev THE LTV-PRESERVATION PROPERTY OF THE ASYNC UNWIND. `_proportionalRedeem` ->
+    ///      `LeveragedAeroManager.redeemUnwindImpl(shares, supply)` repays `f = shares/supply` of EACH
+    ///      leg's debt and redeems `f` of the collateral, so both sides of the ratio shrink by the same
+    ///      factor and post-LTV cannot exceed pre-LTV. That is why `fulfillRedeem` can never push a
+    ///      healthy book above `maxLtvBps` and so cannot be the route to a liquidation.
+    ///
+    ///      To be precise about the guarantee: `fulfillRedeem` has NO max-LTV revert of its own (unlike
+    ///      the fast path's `FastRedeemExceedsLtv`) and this PR adds none — the property is preserved BY
+    ///      MECHANISM and pinned here by test. The tolerance is one-sided on purpose: LTV may only drift
+    ///      DOWN (mulDiv floors the repay and the collateral burn independently), never up.
+    ///      MUTATION: make the repay less than pro-rata — e.g. scale step B's repay by `f/2` — and the
+    ///      post-LTV rises above the pre-LTV and this fails.
+    function testPartialFulfillRedeemNeverRaisesTheBookLtv() public {
+        _execute(SEED);
+        // A non-unit collateral basis, so `f` of the cTokens is not `f` of the underlying face value —
+        // the case where a naive "burn f of a stored underlying estimate" unwind WOULD drift the ratio.
+        // Stored == pending on purpose: no accrual fires DURING the fulfil, so `_ltvBps()` reads the
+        // same basis before and after and the delta below is the unwind's own rounding, nothing else.
+        mUsdc.setExchangeRateStored(1.37e18);
+        mUsdc.setPendingExchangeRate(1.37e18);
+        // THEN lever up NEAR the ceiling (maxLtv 6500) on that basis, so a rise of a few bps is material.
+        _retarget(6000);
+        vm.prank(address(strategy));
+        vault.strategyMint(lp, SUPPLY);
+
+        uint256 ltvBefore = _ltvBps();
+        assertApproxEqAbs(ltvBefore, 6000, 50, "premise: the book starts just under the 6500 ceiling");
+        uint256 collateralBefore = _collateralUsdc();
+
+        uint256 shares = SUPPLY / 4; // a PARTIAL fulfil — the only branch that can move the ratio
+        uint256 id = _requestRedeem(shares);
+        vm.prank(proposer);
+        strategy.fulfillRedeem(id, 0);
+
+        uint256 ltvAfter = _ltvBps();
+        // Non-vacuity: the unwind actually moved the book, and both legs still carry debt, so the
+        // post-read is a real levered LTV rather than a flattened 0.
+        assertLt(_collateralUsdc(), collateralBefore, "the fulfil actually withdrew collateral");
+        assertGt(mLegA.borrowBalance(address(strategy)), 0, "leg A still levered after the partial");
+        assertGt(mLegB.borrowBalance(address(strategy)), 0, "leg B still levered after the partial");
+        assertGt(ltvAfter, 0, "post-LTV is a real levered reading");
+
+        // THE PROPERTY. One-sided: no epsilon is granted upward. Measured drift on this fixture and
+        // on-chain is <= 0.02 bps and always DOWNWARD (floored repay/burn favour the stayers).
+        assertLe(ltvAfter, ltvBefore, "a partial fulfillRedeem never RAISES the book LTV");
+        assertApproxEqAbs(ltvAfter, ltvBefore, 2, "and it stays within rounding of it: a true pro-rata unwind");
+        // ... and therefore it can never walk the book up to the post-op ceiling every other op is gated on.
+        assertLe(ltvAfter, 6500, "post-fulfil LTV is still inside maxLtvBps");
+    }
+
+    /// @dev The sibling with COLLATERAL ACCRUAL landing during the fulfil (pending rate above stored, as
+    ///      F15 arms it). Accrual is a real drift source, and it moves the ratio the SAFE way: the burn
+    ///      settles at the fresh rate, so the stayers keep more collateral against unchanged debt. Only
+    ///      the one-sided property is asserted here — there is no tight bound to claim, because the basis
+    ///      itself moved. Cross-checked against the stable-basis sibling above, which owns the tight bound.
+    function testPartialFulfillRedeemUnderCollateralAccrualStillOnlyMovesTheLtvDown() public {
+        _execute(SEED);
+        _retarget(6000);
+        vm.prank(address(strategy));
+        vault.strategyMint(lp, SUPPLY);
+
+        mUsdc.setExchangeRateStored(1.37e18);
+        mUsdc.setPendingExchangeRate(1.4e18); // accrual fires inside the fulfil
+
+        uint256 ltvBefore = _ltvBps();
+        uint256 id = _requestRedeem(SUPPLY / 4);
+        vm.prank(proposer);
+        strategy.fulfillRedeem(id, 0);
+
+        uint256 ltvAfter = _ltvBps();
+        assertGt(ltvAfter, 0, "post-LTV is a real levered reading");
+        assertLe(ltvAfter, ltvBefore, "accrual can only move the LTV DOWN, never up");
+        assertLe(ltvAfter, 6500, "post-fulfil LTV is still inside maxLtvBps");
+    }
+
     /// @dev THE FAST PATH WITH NOTHING RAW: idle is drawn first, so a fully parked book always draws collateral and
     ///      the LTV gate is always live -- no tightening, since the supply lowers LTV before the exit.
     function testFastRedeemDrawsFromCollateralWhenNothingIsRawIdle() public {

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -1225,6 +1225,42 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         _expectMigrateRevert(v, LeveragedAeroVenue.TargetLtvZero.selector);
     }
 
+    /// @dev L4 on the MIGRATE path, driven from the CF side — the case only this path can produce.
+    ///      `applyVenue` re-reads the LIVE collateral factor, so a market whose CF Moonwell has since
+    ///      LOWERED can push the permissionless-deleverage trigger (`1e8 / minHealthBps`, 8333 here) up to
+    ///      or past the liquidation line even though the same params passed at init. Rejected here rather
+    ///      than left as a book that is liquidatable before anyone can publicly rescue it.
+    function testMigrateRejectsADestinationWhoseCollateralFactorSitsUnderTheDeleverageTrigger() public {
+        _execute(SEED);
+        _flatten();
+        comptroller.setCollateralFactorMantissa(0.83e18); // cf 8300; 12000 * 8300 = 9.96e7 <= 1e8
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams(); // maxLtv 6000 < 8300, so the earlier
+        _expectMigrateRevert(v, LeveragedAeroValuation.DeleverageTriggerAboveCF.selector); // rungs clear
+    }
+
+    /// @dev The same rung driven from the `minHealthBps` side: a migration may lower minHealth, which
+    ///      RAISES the trigger LTV. 11000 triggers at 9090, above the 8800 CF -> rejected.
+    function testMigrateRejectsAMinHealthThatLiftsTheDeleverageTriggerToTheCollateralFactor() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        v.minHealthBps = 11_000; // 11000 * 8800 = 9.68e7 <= 1e8
+        _expectMigrateRevert(v, LeveragedAeroValuation.DeleverageTriggerAboveCF.selector);
+    }
+
+    /// @dev The positive twin, one bps of CF above the bound: 12000 * 8334 = 1.00008e8 > 1e8, so the
+    ///      migration lands and the venue is actually rewritten. Pins the rung as a boundary, not a ban.
+    function testMigrateAcceptsACollateralFactorOneBpsAboveTheDeleverageTrigger() public {
+        _execute(SEED);
+        _flatten();
+        comptroller.setCollateralFactorMantissa(0.8334e18); // cf 8334
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams();
+        _stage(v);
+        _migrate(v);
+        assertEq(strategy.layout().pool, address(poolB), "venue migrated at the boundary");
+        assertEq(strategy.layout().usdcCollateralFactorBps, 8334, "the live CF was re-read and stored");
+    }
+
     // ==================== migrate: the target-LTV write is LOUD ====================
 
     /// @dev `applyVenue` persists `p.targetLtvBps`, so a migration MOVES THE FUND'S LEVERAGE POLICY.

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -1225,21 +1225,17 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         _expectMigrateRevert(v, LeveragedAeroVenue.TargetLtvZero.selector);
     }
 
-    /// @dev L4 on the MIGRATE path, driven from the CF side — the case only this path can produce.
-    ///      `applyVenue` re-reads the LIVE collateral factor, so a market whose CF Moonwell has since
-    ///      LOWERED can push the permissionless-deleverage trigger (`1e8 / minHealthBps`, 8333 here) up to
-    ///      or past the liquidation line even though the same params passed at init. Rejected here rather
-    ///      than left as a book that is liquidatable before anyone can publicly rescue it.
+    /// @dev Only this path can produce it: `applyVenue` re-reads the LIVE CF, so a CF Moonwell has since
+    ///      LOWERED lifts the trigger past the liquidation line post-init.
     function testMigrateRejectsADestinationWhoseCollateralFactorSitsUnderTheDeleverageTrigger() public {
         _execute(SEED);
         _flatten();
         comptroller.setCollateralFactorMantissa(0.83e18); // cf 8300; 12000 * 8300 = 9.96e7 <= 1e8
-        LeveragedAeroVenue.VenueParams memory v = _venueBParams(); // maxLtv 6000 < 8300, so the earlier
-        _expectMigrateRevert(v, LeveragedAeroValuation.DeleverageTriggerAboveCF.selector); // rungs clear
+        LeveragedAeroVenue.VenueParams memory v = _venueBParams(); // maxLtv 6000 < 8300: earlier rungs clear
+        _expectMigrateRevert(v, LeveragedAeroValuation.DeleverageTriggerAboveCF.selector);
     }
 
-    /// @dev The same rung driven from the `minHealthBps` side: a migration may lower minHealth, which
-    ///      RAISES the trigger LTV. 11000 triggers at 9090, above the 8800 CF -> rejected.
+    /// @dev The other knob: a migration may lower minHealth, which RAISES the trigger (11000 -> 9090 > 8800).
     function testMigrateRejectsAMinHealthThatLiftsTheDeleverageTriggerToTheCollateralFactor() public {
         _execute(SEED);
         _flatten();
@@ -1248,8 +1244,7 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         _expectMigrateRevert(v, LeveragedAeroValuation.DeleverageTriggerAboveCF.selector);
     }
 
-    /// @dev The positive twin, one bps of CF above the bound: 12000 * 8334 = 1.00008e8 > 1e8, so the
-    ///      migration lands and the venue is actually rewritten. Pins the rung as a boundary, not a ban.
+    /// @dev The positive twin, one bps of CF above the bound: the migration lands. A boundary, not a ban.
     function testMigrateAcceptsACollateralFactorOneBpsAboveTheDeleverageTrigger() public {
         _execute(SEED);
         _flatten();


### PR DESCRIPTION
Adds one missing invariant check, plus the tests proving the strategy's over-leverage protections actually hold.

## The two questions this answers

**1. Can the backend over-leverage the book and get it liquidated?**

No — three independent protections stand in the way, and all three are now tested:

- The backend key cannot raise leverage above the admin's target: `adjustLeverage` reverts on any target above the stored policy (5000 bps). Only the multisig can raise policy, and never above `maxLtvBps`.
- Every operation that adds debt ends with a health check: if the book would land above `maxLtvBps` (6500), or Moonwell itself reports a shortfall, the whole operation reverts.
- If price drift pushes the book unhealthy with no operation at fault, **anyone** — not just the backend — can call `deleverage()` and repay debt once LTV crosses 8333, well before Moonwell liquidation at the 8800 collateral factor.

**2. Does `fulfillRedeem` need a revert if it would put the book above max LTV?**

No, because it can't. The async fulfil unwinds proportionally — it repays debt and withdraws collateral by the same fraction, so LTV never rises. A gate there would only block exits on an already-drifted book (which the fulfil doesn't worsen) and would add an oracle dependency to the deliberately oracle-free path. Instead of a gate, this PR pins the property with tests: post-fulfil LTV ≤ pre-fulfil LTV, with no upward tolerance.

## What the new guard adds

The ordering that makes liquidation unreachable is: **ops stop at 6500 → public rescue unlocks at 8333 → Moonwell liquidates at 8800.** The first two steps were already enforced in code; the last one — rescue strictly before liquidation — held only because we picked good parameters. The old checks would have accepted a `minHealthBps` that puts the rescue trigger *above* the liquidation line (e.g. the allowed floor 10500 → trigger 9524 > CF 8800), creating a zone where the book can be liquidated before anyone is permitted to rescue it.

New rung in `checkLtvBand`: `minHealthBps × cfBps > 1e8` (typed `DeleverageTriggerAboveCF`), enforced at init and re-checked against the **live** collateral factor at every `migrateVenue` — so a CF that Moonwell later lowers is caught at the next migration. Production params pass with room: 12000 × 8800 = 1.056e8. Signature unchanged; strategy/manager bytecode unchanged (+38 B in the Valuation library only).

## What the tests support (14 new)

| Protection | Coverage |
|---|---|
| Backend can't lever above policy | existing (5 tests) |
| Post-op health gate (`_assertHealthy`) | **new — previously had zero coverage**: LTV ceiling, the Moonwell shortfall belt, and a passing-case control |
| New rung, both entry paths (init + migrate) | **new** (7 tests incl. the exact 1e8 boundary; the previously-accepted 10500/8800 pair is now pinned as a revert) |
| Public `deleverage()` rescues an unhealthy book, refuses a healthy one | existing rescue tests + **new refusal test** (the refusal half was untested) |
| `fulfillRedeem` never raises LTV | **new** (2 tests, one-sided ≤2 bps bound — matches the ≤0.02 bps measured on the vnet fulfilments) |

Mutation-verification, stated precisely (the earlier blanket claim was too broad). The **revert** tests are mutation-killing: deleting the exact clause each one pins makes it fail — the 4 `DeleverageTriggerAboveCF` reverts across both entry paths, the strict-boundary test, both `_assertHealthy` tests (LTV clause and shortfall clause), the `HealthyNoDeleverage` refusal, and both `fulfillRedeem` preservation tests (under-repaying at `f/2` sends post-LTV 4379 → 5109). The **acceptance** tests (`testInitAcceptsTheProductionRiskParamsUnderTheDeleverageTriggerRung`, `testInitAcceptsMinHealthAtTheFloor`, `testInitDeleverageTriggerAcceptsTheSmallestMinHealthStepAboveTheBound`, `testMigrateAcceptsACollateralFactorOneBpsAboveTheDeleverageTrigger`, the rerange control) survive that mutation by construction — they exist to kill *over-tightening* mutants, not clause-deletion ones, and to document the ordering. One test fixture used the newly-rejected parameter pair and was updated deliberately. Suites: 387 + 84 passed, 0 failed.

Part of [MOO-798](https://linear.app/moonwell/issue/MOO-798/validate-latest-rebalancer-findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


