### PR TITLE
feat: admin setters for maxLtvBps and the rerange width band

### DIFF
--- a/docs/integrations/LEVERAGED_AERO_REBALANCER.md
+++ b/docs/integrations/LEVERAGED_AERO_REBALANCER.md
@@ -1253,6 +1253,10 @@ same vault, same share token, same user accounts, no user action. Three new stra
 4. Rebalancer: `redeploy(minLiquidity)`; afterwards sweep old-leg unwind dust with
    `rescueToVault(oldLeg)` (former legs leave the deny-list at the rewrite; the NEW legs enter it).
 
+**Do not change LTV policy while a stage is armed.** `setMaxLtv` / `setWidthBounds` between steps 1
+and 3 clear the staged hash (re-stage to proceed), but `setTargetLtv` does not — a later
+`migrateVenue` would restore the pre-ratchet target, so clear or fire the stage before moving policy.
+
 **Trust split:** the owner alone picks the venue (hash-committed, byte-exact); the proposer alone
 sequences execution and can neither deviate from the committed config nor move funds out of the
 contract at any step.

--- a/docs/integrations/LEVERAGED_AERO_REBALANCER.md
+++ b/docs/integrations/LEVERAGED_AERO_REBALANCER.md
@@ -1253,9 +1253,8 @@ same vault, same share token, same user accounts, no user action. Three new stra
 4. Rebalancer: `redeploy(minLiquidity)`; afterwards sweep old-leg unwind dust with
    `rescueToVault(oldLeg)` (former legs leave the deny-list at the rewrite; the NEW legs enter it).
 
-**Do not change LTV policy while a stage is armed.** `setMaxLtv` / `setWidthBounds` between steps 1
-and 3 clear the staged hash (re-stage to proceed), but `setTargetLtv` does not — a later
-`migrateVenue` would restore the pre-ratchet target, so clear or fire the stage before moving policy.
+**Any admin policy setter clears an armed stage.** `setTargetLtv` / `setMaxLtv` / `setWidthBounds`
+between steps 1 and 3 consume the staged hash — re-stage to proceed.
 
 **Trust split:** the owner alone picks the venue (hash-committed, byte-exact); the proposer alone
 sequences execution and can neither deviate from the committed config nor move funds out of the

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -36,6 +36,7 @@ library LeveragedAeroVenue {
     // strategy's selectors), so they are not re-declared; `TargetLtvZero` is a lower bound `applyVenue`
     // alone enforces and so lives here.
     error TargetLtvZero(); // targetLtvBps == 0 — a standing target of zero can never lever
+    error TargetLtvExceedsMax(); // selector mirrors the strategy's / the valuation's
     error VenueNotStaged(); // migrate without a staged hash, or params that do not match it
     error BookNotFlat(); // migrate while a CL position, hedged basis, or leg debt is still live
     error PositionAlreadyOpen(); // redeploy on a book that already has a CL position (use deployIdle)
@@ -734,6 +735,17 @@ library LeveragedAeroVenue {
             $.stagedVenueHash = bytes32(0);
             emit VenueStaged(bytes32(0));
         }
+    }
+
+    /// @notice The BODY of `LeveragedAerodromeCLStrategy.setTargetLtv` — validation, persist and emit
+    ///         verbatim from the strategy, relocated for its EIP-170 budget and to share the stage clear.
+    function setTargetLtvImpl(uint16 targetLtvBps_) public {
+        Layout storage $ = _layout();
+        if (targetLtvBps_ > $.maxLtvBps) revert TargetLtvExceedsMax();
+        if (targetLtvBps_ == 0) revert TargetLtvZero();
+        emit TargetLtvUpdated($.targetLtvBps, targetLtvBps_);
+        $.targetLtvBps = targetLtvBps_;
+        _clearStagedVenue($);
     }
 
     /// @notice The BODY of `LeveragedAerodromeCLStrategy.setMaxLtv`, on the shared `checkLtvBand` ladder.

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -60,8 +60,9 @@ library LeveragedAeroVenue {
     /// @dev Re-declared with the strategy's signature (so the same `topic0`): without it an owner-staged
     ///      migration could silently restore a target the proposer had just ratcheted down.
     event TargetLtvUpdated(uint16 previousBps, uint16 newBps);
-    /// @notice The admin's standalone `setMaxLtv` / `setWidthBounds` landed. Re-declared with the strategy's
-    ///         signatures (same `topic0`); `applyVenue` rewrites both fields inside a `VenueMigrated` instead.
+    /// @notice The ceiling / width band moved — through the admin's standalone setters, or through
+    ///         `applyVenue`, which emits the same pair inequality-guarded. Re-declared with the strategy's
+    ///         signatures (same `topic0`), since both routes log from the strategy's address.
     event MaxLtvUpdated(uint16 previousBps, uint16 newBps);
     event WidthBoundsUpdated(uint24 previousMinWidth, uint24 previousMaxWidth, uint24 newMinWidth, uint24 newMaxWidth);
 
@@ -698,12 +699,19 @@ library LeveragedAeroVenue {
         $.wethSwapTickSpacing = p.wethSwapTickSpacing;
         $.wethDeliversNative = p.wethDeliversNative;
         $.width = p.width;
+        // MUST precede the two persists below — the guard reads the OUTGOING band.
+        if ($.minWidth != p.minWidth || $.maxWidth != p.maxWidth) {
+            emit WidthBoundsUpdated($.minWidth, $.maxWidth, p.minWidth, p.maxWidth);
+        }
         $.minWidth = p.minWidth;
         $.maxWidth = p.maxWidth;
         // The target LTV is the one venue field that is also POLICY, so announce it or a migration becomes
         // the one route that moves leverage policy in silence. Guarded on inequality, so the event means
         // "policy moved", not "a migration happened"; at init it is trivially true, announcing the opener.
+        // Same argument for the ceiling and the band above: `VenueMigrated` carries only the two pools, so
+        // without these a migration moves them in silence past a monitor keyed on the setters' events.
         if ($.targetLtvBps != p.targetLtvBps) emit TargetLtvUpdated($.targetLtvBps, p.targetLtvBps);
+        if ($.maxLtvBps != p.maxLtvBps) emit MaxLtvUpdated($.maxLtvBps, p.maxLtvBps);
         $.targetLtvBps = p.targetLtvBps;
         $.maxLtvBps = p.maxLtvBps;
         $.minHealthBps = p.minHealthBps;
@@ -716,6 +724,18 @@ library LeveragedAeroVenue {
 
     // ── Bodies of the strategy's `setMaxLtv` / `setWidthBounds`, hosted here for its EIP-170 budget ──
 
+    /// @dev A staged hash authorises a venue whose params carry a `maxLtvBps` / width band / target the
+    ///      owner picked under the policy standing AT STAGE TIME. An admin write moves that policy, so the
+    ///      authorization is consumed here for the same reason `redeployImpl` consumes it: a stale
+    ///      `migrateVenue` must not be firable into a context the owner did not stage it for. The owner
+    ///      re-stages against the new policy.
+    function _clearStagedVenue(Layout storage $) private {
+        if ($.stagedVenueHash != bytes32(0)) {
+            $.stagedVenueHash = bytes32(0);
+            emit VenueStaged(bytes32(0));
+        }
+    }
+
     /// @notice The BODY of `LeveragedAerodromeCLStrategy.setMaxLtv`, on the shared `checkLtvBand` ladder.
     /// @dev The CF is read live (see the entrypoint); `$.usdcCollateralFactorBps` stays the adoption record.
     function setMaxLtvImpl(uint16 maxLtvBps_) public {
@@ -724,6 +744,7 @@ library LeveragedAeroVenue {
         LeveragedAeroValuation.checkLtvBand($.targetLtvBps, maxLtvBps_, $.minHealthBps, cfBps);
         emit MaxLtvUpdated($.maxLtvBps, maxLtvBps_);
         $.maxLtvBps = maxLtvBps_;
+        _clearStagedVenue($);
     }
 
     /// @notice The BODY of `LeveragedAerodromeCLStrategy.setWidthBounds`, on both ladders `applyVenue` runs.
@@ -738,6 +759,7 @@ library LeveragedAeroVenue {
         emit WidthBoundsUpdated($.minWidth, $.maxWidth, minWidth_, maxWidth_);
         $.minWidth = minWidth_;
         $.maxWidth = maxWidth_;
+        _clearStagedVenue($);
     }
 
     /// @notice The strategy's full `LayoutView` read out of diamond storage — the BODY of

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -723,7 +723,7 @@ library LeveragedAeroVenue {
         $.legBIsAsset = legBIsAsset_;
     }
 
-    // ── Bodies of the strategy's `setMaxLtv` / `setWidthBounds`, hosted here for its EIP-170 budget ──
+    // ── Bodies of the strategy's three admin policy setters, hosted here for its EIP-170 budget ──
 
     /// @dev A staged hash authorises a venue whose params carry a `maxLtvBps` / width band / target the
     ///      owner picked under the policy standing AT STAGE TIME. An admin write moves that policy, so the

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -60,15 +60,9 @@ library LeveragedAeroVenue {
     /// @dev Re-declared with the strategy's signature (so the same `topic0`): without it an owner-staged
     ///      migration could silently restore a target the proposer had just ratcheted down.
     event TargetLtvUpdated(uint16 previousBps, uint16 newBps);
-    /// @notice The fund's OPERATIONAL LTV ceiling changed through the admin's standalone `setMaxLtv`.
-    /// @dev Re-declared with the strategy's signature (so the same `topic0`): `setMaxLtvImpl` is
-    ///      delegatecalled, so the log carries the STRATEGY's address. `applyVenue` writes `maxLtvBps`
-    ///      too but announces nothing there — that path is already announced as `VenueMigrated`, whose
-    ///      byte-committed params a monitor reads in full; this setter has no such envelope.
+    /// @notice The admin's standalone `setMaxLtv` / `setWidthBounds` landed. Re-declared with the strategy's
+    ///         signatures (same `topic0`); `applyVenue` rewrites both fields inside a `VenueMigrated` instead.
     event MaxLtvUpdated(uint16 previousBps, uint16 newBps);
-    /// @notice The rerange width band changed through the admin's standalone `setWidthBounds`.
-    /// @dev Same delegatecall/topic0 mirroring as above; `applyVenue` rewrites the band inside a
-    ///      `VenueMigrated` and emits nothing band-specific.
     event WidthBoundsUpdated(uint24 previousMinWidth, uint24 previousMaxWidth, uint24 newMinWidth, uint24 newMaxWidth);
 
     /// @notice An async-redeem request was escrowed. Re-declared with the strategy's signature (same `topic0`).
@@ -720,19 +714,10 @@ library LeveragedAeroVenue {
         $.legBIsAsset = legBIsAsset_;
     }
 
-    // ── Standalone ADMIN band setters (bodies of the strategy's `setMaxLtv` / `setWidthBounds`,
-    //    hosted here for the strategy's EIP-170 budget; delegatecalled, so they write the strategy's
-    //    storage and log from its address) ──
+    // ── Bodies of the strategy's `setMaxLtv` / `setWidthBounds`, hosted here for its EIP-170 budget ──
 
-    /// @notice The BODY of `LeveragedAerodromeCLStrategy.setMaxLtv`: rewrite the operational LTV ceiling
-    ///         after re-running the WHOLE band ladder against the LIVE collateral factor.
-    /// @dev Validation is `LeveragedAeroValuation.checkLtvBand` — the SAME four rungs `applyVenue` and the
-    ///      init ladder run, not an ad-hoc pair of comparisons, so a rung added there is inherited here.
-    ///      The collateral factor is read FRESH from the comptroller: Moonwell governance can lower USDC's
-    ///      CF after init, and validating against the init-time snapshot could approve a ceiling that now
-    ///      sits above the live liquidation line. `$.usdcCollateralFactorBps` is deliberately NOT rewritten
-    ///      — it is the init/migration RECORD of the venue adoption, not a cache anything reads.
-    /// @param maxLtvBps_ The new ceiling in bps.
+    /// @notice The BODY of `LeveragedAerodromeCLStrategy.setMaxLtv`, on the shared `checkLtvBand` ladder.
+    /// @dev The CF is read live (see the entrypoint); `$.usdcCollateralFactorBps` stays the adoption record.
     function setMaxLtvImpl(uint16 maxLtvBps_) public {
         Layout storage $ = _layout();
         uint16 cfBps = LeveragedAeroValuation.readCollateralFactor($.comptroller, $.mUsdc);
@@ -741,16 +726,8 @@ library LeveragedAeroVenue {
         $.maxLtvBps = maxLtvBps_;
     }
 
-    /// @notice The BODY of `LeveragedAerodromeCLStrategy.setWidthBounds`: rewrite the rerange width band
-    ///         after re-running BOTH range ladders `applyVenue` runs, in the same order.
-    /// @dev `checkBands` is the band's own shape; `checkRange` then re-validates the CURRENTLY STORED
-    ///      `(width, skewBps)` inside the candidate band. The second call is load-bearing:
-    ///      `redeployImpl` / `rerangeImpl` size from the STORED width, so a band that excluded it would
-    ///      let the next redeploy place a range the band forbids. A band that excludes the live width
-    ///      therefore reverts `OutOfBounds` — the admin passes a compatible band, or the proposer
-    ///      `rerange`s into the intended one first.
-    /// @param minWidth_ New lower bound for a proposer-supplied rerange width, in ticks.
-    /// @param maxWidth_ New upper bound, in ticks.
+    /// @notice The BODY of `LeveragedAerodromeCLStrategy.setWidthBounds`, on both ladders `applyVenue` runs.
+    /// @dev `checkBands` is the band's shape; `checkRange` is the stored-width containment rule.
     function setWidthBoundsImpl(uint24 minWidth_, uint24 maxWidth_) public {
         Layout storage $ = _layout();
         int24 spacing = $.tickSpacing;

--- a/src/leveraged-aero/LeveragedAeroVenue.sol
+++ b/src/leveraged-aero/LeveragedAeroVenue.sol
@@ -60,6 +60,16 @@ library LeveragedAeroVenue {
     /// @dev Re-declared with the strategy's signature (so the same `topic0`): without it an owner-staged
     ///      migration could silently restore a target the proposer had just ratcheted down.
     event TargetLtvUpdated(uint16 previousBps, uint16 newBps);
+    /// @notice The fund's OPERATIONAL LTV ceiling changed through the admin's standalone `setMaxLtv`.
+    /// @dev Re-declared with the strategy's signature (so the same `topic0`): `setMaxLtvImpl` is
+    ///      delegatecalled, so the log carries the STRATEGY's address. `applyVenue` writes `maxLtvBps`
+    ///      too but announces nothing there — that path is already announced as `VenueMigrated`, whose
+    ///      byte-committed params a monitor reads in full; this setter has no such envelope.
+    event MaxLtvUpdated(uint16 previousBps, uint16 newBps);
+    /// @notice The rerange width band changed through the admin's standalone `setWidthBounds`.
+    /// @dev Same delegatecall/topic0 mirroring as above; `applyVenue` rewrites the band inside a
+    ///      `VenueMigrated` and emits nothing band-specific.
+    event WidthBoundsUpdated(uint24 previousMinWidth, uint24 previousMaxWidth, uint24 newMinWidth, uint24 newMaxWidth);
 
     /// @notice An async-redeem request was escrowed. Re-declared with the strategy's signature (same `topic0`).
     event RedeemRequested(uint256 indexed id, address indexed owner, address indexed recipient, uint256 shares);
@@ -708,6 +718,49 @@ library LeveragedAeroVenue {
         $.wethDecimals = wethDec;
         $.wethIsToken0 = wethIsToken0_;
         $.legBIsAsset = legBIsAsset_;
+    }
+
+    // ── Standalone ADMIN band setters (bodies of the strategy's `setMaxLtv` / `setWidthBounds`,
+    //    hosted here for the strategy's EIP-170 budget; delegatecalled, so they write the strategy's
+    //    storage and log from its address) ──
+
+    /// @notice The BODY of `LeveragedAerodromeCLStrategy.setMaxLtv`: rewrite the operational LTV ceiling
+    ///         after re-running the WHOLE band ladder against the LIVE collateral factor.
+    /// @dev Validation is `LeveragedAeroValuation.checkLtvBand` — the SAME four rungs `applyVenue` and the
+    ///      init ladder run, not an ad-hoc pair of comparisons, so a rung added there is inherited here.
+    ///      The collateral factor is read FRESH from the comptroller: Moonwell governance can lower USDC's
+    ///      CF after init, and validating against the init-time snapshot could approve a ceiling that now
+    ///      sits above the live liquidation line. `$.usdcCollateralFactorBps` is deliberately NOT rewritten
+    ///      — it is the init/migration RECORD of the venue adoption, not a cache anything reads.
+    /// @param maxLtvBps_ The new ceiling in bps.
+    function setMaxLtvImpl(uint16 maxLtvBps_) public {
+        Layout storage $ = _layout();
+        uint16 cfBps = LeveragedAeroValuation.readCollateralFactor($.comptroller, $.mUsdc);
+        LeveragedAeroValuation.checkLtvBand($.targetLtvBps, maxLtvBps_, $.minHealthBps, cfBps);
+        emit MaxLtvUpdated($.maxLtvBps, maxLtvBps_);
+        $.maxLtvBps = maxLtvBps_;
+    }
+
+    /// @notice The BODY of `LeveragedAerodromeCLStrategy.setWidthBounds`: rewrite the rerange width band
+    ///         after re-running BOTH range ladders `applyVenue` runs, in the same order.
+    /// @dev `checkBands` is the band's own shape; `checkRange` then re-validates the CURRENTLY STORED
+    ///      `(width, skewBps)` inside the candidate band. The second call is load-bearing:
+    ///      `redeployImpl` / `rerangeImpl` size from the STORED width, so a band that excluded it would
+    ///      let the next redeploy place a range the band forbids. A band that excludes the live width
+    ///      therefore reverts `OutOfBounds` — the admin passes a compatible band, or the proposer
+    ///      `rerange`s into the intended one first.
+    /// @param minWidth_ New lower bound for a proposer-supplied rerange width, in ticks.
+    /// @param maxWidth_ New upper bound, in ticks.
+    function setWidthBoundsImpl(uint24 minWidth_, uint24 maxWidth_) public {
+        Layout storage $ = _layout();
+        int24 spacing = $.tickSpacing;
+        uint16 minSkew = $.minSkewBps;
+        uint16 maxSkew = $.maxSkewBps;
+        LeveragedAeroValuation.checkBands(spacing, minWidth_, maxWidth_, minSkew, maxSkew);
+        LeveragedAeroValuation.checkRange($.width, $.skewBps, spacing, minWidth_, maxWidth_, minSkew, maxSkew);
+        emit WidthBoundsUpdated($.minWidth, $.maxWidth, minWidth_, maxWidth_);
+        $.minWidth = minWidth_;
+        $.maxWidth = maxWidth_;
     }
 
     /// @notice The strategy's full `LayoutView` read out of diamond storage — the BODY of

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -154,6 +154,17 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///      next `adjustLeverage` / `deployIdle` / `compound` sizes at the new value.
     event TargetLtvUpdated(uint16 previousBps, uint16 newBps);
 
+    /// @dev The admin re-set the fund's OPERATIONAL LTV CEILING through `setMaxLtv`. Emitted from THIS
+    ///      address by the delegatecalled `LeveragedAeroVenue.setMaxLtvImpl` (mirror-declared there with
+    ///      the same signature, so the same `topic0`). LOWERING is a risk ratchet-down and moves nothing by
+    ///      itself; the `_assertHealthy` belt and the fast-redeem LTV gate simply tighten from the next op.
+    event MaxLtvUpdated(uint16 previousBps, uint16 newBps);
+
+    /// @dev The admin re-set the rerange WIDTH BAND through `setWidthBounds` — the governance bounds on the
+    ///      proposer's `rerange` width, not the live range. Emitted from THIS address by the delegatecalled
+    ///      `LeveragedAeroVenue.setWidthBoundsImpl` (mirror-declared there, same `topic0`).
+    event WidthBoundsUpdated(uint24 previousMinWidth, uint24 previousMaxWidth, uint24 newMinWidth, uint24 newMaxWidth);
+
     /// @dev A best-effort fee crystallise (deposit / fast redeem / proportional redeem) reverted and was
     ///      deferred; the op proceeded. Reverts on the fee-MINT (vault paused / feeRecipient
     ///      de-whitelisted) — or, near-unreachably, on the config read inside the crystallise (see the
@@ -198,9 +209,22 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///      on the vault carries the strategy's admin rights with it. The POLICY half of the split;
     ///      `onlyProposer` is the operations half, which may lower the target but never raise it and never move
     ///      tokens. Depends on the vault reverting `renounceOwnership` and being `Ownable2Step`.
+    ///      The check is a FUNCTION, not modifier-inline code: four entrypoints carry it and each inline copy
+    ///      pays for the `vault()` read plus the `owner()` staticcall and its decode — 309 bytes across the
+    ///      four, against a contract whose EIP-170 margin is in the low hundreds.
     modifier onlyAdmin() {
-        if (msg.sender != Ownable(vault()).owner()) revert NotAdmin();
+        _requireAdmin();
         _;
+    }
+
+    function _requireAdmin() private view {
+        if (msg.sender != _vaultOwner()) revert NotAdmin();
+    }
+
+    /// @dev One copy of the `vault()` read + `owner()` staticcall, shared with `stageVenue` (which raises a
+    ///      DIFFERENT error off the same authority, so it cannot share `_requireAdmin` itself).
+    function _vaultOwner() private view returns (address) {
+        return Ownable(vault()).owner();
     }
 
     // ── Initialisation params (ABI-encoded → BaseStrategy.initialize → _initialize) ──
@@ -1081,6 +1105,55 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         $.targetLtvBps = targetLtvBps_;
     }
 
+    /// @notice ADMIN-ONLY POLICY: set the fund's OPERATIONAL LTV CEILING — the `maxLtvBps` belt every
+    ///         `_assertHealthy` and the fast-redeem gate measure against. Previously writable ONLY at init
+    ///         and inside the owner-staged `migrateVenue` ceremony; this is the direct knob. `onlyAdmin`
+    ///         for the same reason as `setTargetLtv`, and more sharply: raising the ceiling raises the fund's
+    ///         reachable risk, so the keeper key must never hold it. Body in
+    ///         `LeveragedAeroVenue.setMaxLtvImpl` (EIP-170 budget). NOT state-gated, like `setTargetLtv`.
+    ///
+    ///         LOWERING BELOW THE BOOK'S LIVE LTV IS LEGAL AND INTENDED — a risk ratchet-down. It moves
+    ///         nothing by itself: debt-ADDING ops (`deployIdle` / `compound` / a lever-UP `adjustLeverage`)
+    ///         then fail at their post-op `_assertHealthy` with `UnhealthyPosition` until the book is
+    ///         de-levered, while `adjustLeverage` DOWN keeps working (its own bound is the stored POLICY
+    ///         target, and a lever-down ends healthier). The fast-redeem LTV gate tightens immediately, so
+    ///         a redeemer above the new ceiling routes to `requestRedeem`. Pair it with `setTargetLtv` when
+    ///         the intent is for new tranches to size lower too.
+    ///
+    ///         RAISING is bounded by `checkLtvBand` against the LIVE collateral factor.
+    /// @dev The band is checked from BOTH sides and the two setters compose: `setTargetLtv` refuses a target
+    ///      above the stored `maxLtvBps` (`TargetLtvExceedsMax`), and `checkLtvBand`'s first rung refuses a
+    ///      ceiling below the stored target with the SAME error — so `target <= max` holds whichever knob moves.
+    /// @param maxLtvBps_ New ceiling in bps. Must be `>= targetLtvBps` (`TargetLtvExceedsMax`), strictly
+    ///        below the LIVE Moonwell USDC collateral factor (`MaxLtvExceedsCF`), and satisfy
+    ///        `minHealthBps * maxLtvBps_ < 1e8` (`MinHealthMaxLtvConflict`) — the anti-grief rung that keeps
+    ///        the permissionless deleverage trigger strictly above the ceiling.
+    function setMaxLtv(uint16 maxLtvBps_) external onlyAdmin {
+        LeveragedAeroVenue.setMaxLtvImpl(maxLtvBps_);
+    }
+
+    /// @notice ADMIN-ONLY POLICY: set the `[minWidth, maxWidth]` BAND the proposer's `rerange` width must
+    ///         land in. Previously writable ONLY at init and through `migrateVenue`; this is the direct
+    ///         knob. `onlyAdmin`, never `onlyProposer`: the band is exactly what BOUNDS the proposer, and an
+    ///         operator that can widen its own bounds has no bounds. Body in
+    ///         `LeveragedAeroVenue.setWidthBoundsImpl` (EIP-170 budget). NOT state-gated.
+    ///
+    ///         There is deliberately NO `setWidth`: the live range is the proposer's `rerange` parameter by
+    ///         design — moving it must burn a new position NFT at a calm-gated tick, which is that op, not a
+    ///         storage write. The SKEW band (`[minSkewBps, maxSkewBps]`) stays init-frozen, as decided when it
+    ///         was introduced.
+    /// @dev Validated by the two ladders `applyVenue` runs, in the same order and through the same shared
+    ///      library: `checkBands` (grid alignment, `minWidth >= 2 x tickSpacing`, `min <= max`, `max` inside
+    ///      the tick domain) then `checkRange` on the CURRENTLY STORED `(width, skewBps)`. The second is
+    ///      load-bearing: `redeploy` / `rerange` size from the stored width, so a band excluding it would let
+    ///      the next redeploy place a range this band forbids. Narrowing past the live width therefore reverts
+    ///      `OutOfBounds` — pass a compatible band, or have the proposer `rerange` into it first.
+    /// @param minWidth_ New lower bound on a rerange width, in ticks.
+    /// @param maxWidth_ New upper bound, in ticks.
+    function setWidthBounds(uint24 minWidth_, uint24 maxWidth_) external onlyAdmin {
+        LeveragedAeroVenue.setWidthBoundsImpl(minWidth_, maxWidth_);
+    }
+
     /// @notice Retarget the position's LTV to `targetBps` (borrow/repay; no new USDC enters), via
     ///         `LeveragedAeroManager.adjustLeverageImpl`: lever UP borrows the leg delta and adds it
     ///         (`minLiq`), lever DOWN unwinds the matching CL fraction and repays (residual rebalanced through
@@ -1379,7 +1452,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///         the venue-selection authority, so the hot proposer key can never choose where the fund's liquidity
     ///         goes. Staging is inert until `migrateVenue` runs with the byte-exact params; re-staging replaces.
     function stageVenue(bytes32 venueHash) external {
-        if (msg.sender != Ownable(vault()).owner()) revert NotVaultOwner();
+        if (msg.sender != _vaultOwner()) revert NotVaultOwner();
         LeveragedAeroVenue.stageImpl(venueHash);
     }
 

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -1088,12 +1088,9 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///         `deployIdle` / `compound` / `adjustLeverage` sizes at the new value. NOT state-gated: legal in
     ///         `Pending` (how a multisig corrects an init-time target) and a no-op post-`Settled`.
     /// @param targetLtvBps_ New standing target in bps; must be non-zero (`TargetLtvZero`) and `≤ maxLtvBps`.
+    /// @dev CONSUMES ANY STAGED VENUE HASH (like `redeploy`): the owner staged it under the old policy.
     function setTargetLtv(uint16 targetLtvBps_) external onlyAdmin {
-        Layout storage $ = _layout();
-        if (targetLtvBps_ > $.maxLtvBps) revert TargetLtvExceedsMax();
-        if (targetLtvBps_ == 0) revert TargetLtvZero();
-        emit TargetLtvUpdated($.targetLtvBps, targetLtvBps_);
-        $.targetLtvBps = targetLtvBps_;
+        LeveragedAeroVenue.setTargetLtvImpl(targetLtvBps_);
     }
 
     /// @notice ADMIN-ONLY POLICY: set the OPERATIONAL LTV CEILING — the `maxLtvBps` belt `_assertHealthy`

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -154,8 +154,8 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///      next `adjustLeverage` / `deployIdle` / `compound` sizes at the new value.
     event TargetLtvUpdated(uint16 previousBps, uint16 newBps);
 
-    /// @dev `setMaxLtv` / `setWidthBounds`; both emitted from THIS address by the delegatecalled
-    ///      `LeveragedAeroVenue` impls, which mirror-declare them for the same `topic0`.
+    /// @dev `setMaxLtv` / `setWidthBounds`, and `applyVenue` (init + `migrateVenue`) inequality-guarded;
+    ///      emitted from THIS address by the delegatecalled `LeveragedAeroVenue`, which mirror-declares them.
     event MaxLtvUpdated(uint16 previousBps, uint16 newBps);
     event WidthBoundsUpdated(uint24 previousMinWidth, uint24 previousMaxWidth, uint24 newMinWidth, uint24 newMaxWidth);
 
@@ -1101,6 +1101,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     /// @dev Lowering BELOW the book's live LTV is intended (a risk ratchet-down): debt-adding ops then fail
     ///      their post-op `_assertHealthy` until a lever-DOWN brings the book back inside.
     /// @dev Lowering below the STANDING TARGET needs `setTargetLtv` first — rung 1 refuses it otherwise.
+    /// @dev CONSUMES ANY STAGED VENUE HASH (like `redeploy`): the owner staged it under the old policy.
     /// @param maxLtvBps_ New ceiling in bps, validated by the shared `checkLtvBand` against the LIVE
     ///        collateral factor: Moonwell governance can move CF after init, and the init-time snapshot
     ///        could approve a ceiling now above the liquidation line.
@@ -1114,6 +1115,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///      past it reverts `OutOfBounds` — rerange into the intended width first.
     /// @dev No `setWidth` (the live range moves only by minting at a calm-gated tick, i.e. `rerange`), and
     ///      the SKEW band stays init-frozen by design.
+    /// @dev CONSUMES ANY STAGED VENUE HASH (like `redeploy`): the owner staged it under the old band.
     function setWidthBounds(uint24 minWidth_, uint24 maxWidth_) external onlyAdmin {
         LeveragedAeroVenue.setWidthBoundsImpl(minWidth_, maxWidth_);
     }

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -154,15 +154,9 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///      next `adjustLeverage` / `deployIdle` / `compound` sizes at the new value.
     event TargetLtvUpdated(uint16 previousBps, uint16 newBps);
 
-    /// @dev The admin re-set the fund's OPERATIONAL LTV CEILING through `setMaxLtv`. Emitted from THIS
-    ///      address by the delegatecalled `LeveragedAeroVenue.setMaxLtvImpl` (mirror-declared there with
-    ///      the same signature, so the same `topic0`). LOWERING is a risk ratchet-down and moves nothing by
-    ///      itself; the `_assertHealthy` belt and the fast-redeem LTV gate simply tighten from the next op.
+    /// @dev `setMaxLtv` / `setWidthBounds`; both emitted from THIS address by the delegatecalled
+    ///      `LeveragedAeroVenue` impls, which mirror-declare them for the same `topic0`.
     event MaxLtvUpdated(uint16 previousBps, uint16 newBps);
-
-    /// @dev The admin re-set the rerange WIDTH BAND through `setWidthBounds` — the governance bounds on the
-    ///      proposer's `rerange` width, not the live range. Emitted from THIS address by the delegatecalled
-    ///      `LeveragedAeroVenue.setWidthBoundsImpl` (mirror-declared there, same `topic0`).
     event WidthBoundsUpdated(uint24 previousMinWidth, uint24 previousMaxWidth, uint24 newMinWidth, uint24 newMaxWidth);
 
     /// @dev A best-effort fee crystallise (deposit / fast redeem / proportional redeem) reverted and was
@@ -209,9 +203,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
     ///      on the vault carries the strategy's admin rights with it. The POLICY half of the split;
     ///      `onlyProposer` is the operations half, which may lower the target but never raise it and never move
     ///      tokens. Depends on the vault reverting `renounceOwnership` and being `Ownable2Step`.
-    ///      The check is a FUNCTION, not modifier-inline code: four entrypoints carry it and each inline copy
-    ///      pays for the `vault()` read plus the `owner()` staticcall and its decode — 309 bytes across the
-    ///      four, against a contract whose EIP-170 margin is in the low hundreds.
+    ///      A function, not modifier-inline code: four entrypoints carry it, and each inline copy costs bytes.
     modifier onlyAdmin() {
         _requireAdmin();
         _;
@@ -221,8 +213,7 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         if (msg.sender != _vaultOwner()) revert NotAdmin();
     }
 
-    /// @dev One copy of the `vault()` read + `owner()` staticcall, shared with `stageVenue` (which raises a
-    ///      DIFFERENT error off the same authority, so it cannot share `_requireAdmin` itself).
+    /// @dev Shared with `stageVenue`, which raises a DIFFERENT error off the same authority.
     function _vaultOwner() private view returns (address) {
         return Ownable(vault()).owner();
     }
@@ -1105,51 +1096,24 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         $.targetLtvBps = targetLtvBps_;
     }
 
-    /// @notice ADMIN-ONLY POLICY: set the fund's OPERATIONAL LTV CEILING — the `maxLtvBps` belt every
-    ///         `_assertHealthy` and the fast-redeem gate measure against. Previously writable ONLY at init
-    ///         and inside the owner-staged `migrateVenue` ceremony; this is the direct knob. `onlyAdmin`
-    ///         for the same reason as `setTargetLtv`, and more sharply: raising the ceiling raises the fund's
-    ///         reachable risk, so the keeper key must never hold it. Body in
-    ///         `LeveragedAeroVenue.setMaxLtvImpl` (EIP-170 budget). NOT state-gated, like `setTargetLtv`.
-    ///
-    ///         LOWERING BELOW THE BOOK'S LIVE LTV IS LEGAL AND INTENDED — a risk ratchet-down. It moves
-    ///         nothing by itself: debt-ADDING ops (`deployIdle` / `compound` / a lever-UP `adjustLeverage`)
-    ///         then fail at their post-op `_assertHealthy` with `UnhealthyPosition` until the book is
-    ///         de-levered, while `adjustLeverage` DOWN keeps working (its own bound is the stored POLICY
-    ///         target, and a lever-down ends healthier). The fast-redeem LTV gate tightens immediately, so
-    ///         a redeemer above the new ceiling routes to `requestRedeem`. Pair it with `setTargetLtv` when
-    ///         the intent is for new tranches to size lower too.
-    ///
-    ///         RAISING is bounded by `checkLtvBand` against the LIVE collateral factor.
-    /// @dev The band is checked from BOTH sides and the two setters compose: `setTargetLtv` refuses a target
-    ///      above the stored `maxLtvBps` (`TargetLtvExceedsMax`), and `checkLtvBand`'s first rung refuses a
-    ///      ceiling below the stored target with the SAME error — so `target <= max` holds whichever knob moves.
-    /// @param maxLtvBps_ New ceiling in bps. Must be `>= targetLtvBps` (`TargetLtvExceedsMax`), strictly
-    ///        below the LIVE Moonwell USDC collateral factor (`MaxLtvExceedsCF`), and satisfy
-    ///        `minHealthBps * maxLtvBps_ < 1e8` (`MinHealthMaxLtvConflict`) — the anti-grief rung that keeps
-    ///        the permissionless deleverage trigger strictly above the ceiling.
+    /// @notice ADMIN-ONLY POLICY: set the OPERATIONAL LTV CEILING — the `maxLtvBps` belt `_assertHealthy`
+    ///         and the fast-redeem gate measure against. Not state-gated, like `setTargetLtv`.
+    /// @dev Lowering BELOW the book's live LTV is intended (a risk ratchet-down): debt-adding ops then fail
+    ///      their post-op `_assertHealthy` until a lever-DOWN brings the book back inside.
+    /// @dev Lowering below the STANDING TARGET needs `setTargetLtv` first — rung 1 refuses it otherwise.
+    /// @param maxLtvBps_ New ceiling in bps, validated by the shared `checkLtvBand` against the LIVE
+    ///        collateral factor: Moonwell governance can move CF after init, and the init-time snapshot
+    ///        could approve a ceiling now above the liquidation line.
     function setMaxLtv(uint16 maxLtvBps_) external onlyAdmin {
         LeveragedAeroVenue.setMaxLtvImpl(maxLtvBps_);
     }
 
-    /// @notice ADMIN-ONLY POLICY: set the `[minWidth, maxWidth]` BAND the proposer's `rerange` width must
-    ///         land in. Previously writable ONLY at init and through `migrateVenue`; this is the direct
-    ///         knob. `onlyAdmin`, never `onlyProposer`: the band is exactly what BOUNDS the proposer, and an
-    ///         operator that can widen its own bounds has no bounds. Body in
-    ///         `LeveragedAeroVenue.setWidthBoundsImpl` (EIP-170 budget). NOT state-gated.
-    ///
-    ///         There is deliberately NO `setWidth`: the live range is the proposer's `rerange` parameter by
-    ///         design — moving it must burn a new position NFT at a calm-gated tick, which is that op, not a
-    ///         storage write. The SKEW band (`[minSkewBps, maxSkewBps]`) stays init-frozen, as decided when it
-    ///         was introduced.
-    /// @dev Validated by the two ladders `applyVenue` runs, in the same order and through the same shared
-    ///      library: `checkBands` (grid alignment, `minWidth >= 2 x tickSpacing`, `min <= max`, `max` inside
-    ///      the tick domain) then `checkRange` on the CURRENTLY STORED `(width, skewBps)`. The second is
-    ///      load-bearing: `redeploy` / `rerange` size from the stored width, so a band excluding it would let
-    ///      the next redeploy place a range this band forbids. Narrowing past the live width therefore reverts
-    ///      `OutOfBounds` — pass a compatible band, or have the proposer `rerange` into it first.
-    /// @param minWidth_ New lower bound on a rerange width, in ticks.
-    /// @param maxWidth_ New upper bound, in ticks.
+    /// @notice ADMIN-ONLY POLICY: set the `[minWidth, maxWidth]` band a proposer `rerange` width must land
+    ///         in — `onlyAdmin` because this band is what BOUNDS the proposer. Not state-gated.
+    /// @dev The band must still admit the STORED width: `redeploy` / `rerange` size from it, so narrowing
+    ///      past it reverts `OutOfBounds` — rerange into the intended width first.
+    /// @dev No `setWidth` (the live range moves only by minting at a calm-gated tick, i.e. `rerange`), and
+    ///      the SKEW band stays init-frozen by design.
     function setWidthBounds(uint24 minWidth_, uint24 maxWidth_) external onlyAdmin {
         LeveragedAeroVenue.setWidthBoundsImpl(minWidth_, maxWidth_);
     }

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -1692,10 +1692,6 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     }
 
     // ==================== setMaxLtv (ADMIN-ONLY OPERATIONAL CEILING) ====================
-    //
-    // The ceiling used to be writable ONLY at init and inside the owner-staged `migrateVenue` ceremony.
-    // The setter validates through the SHARED `LeveragedAeroValuation.checkLtvBand`, so every rung below
-    // is the library's, reached through the entrypoint — not an ad-hoc copy.
     // Fixture band: target 5000, max 6500, minHealth 12000, live CF 8800.
 
     /// @dev The admin writes the ceiling; `layout()` reads it back and the event carries (prev, new).
@@ -1713,8 +1709,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.targetLtvBps(), 5000, "the standing target is untouched: this knob is the belt, not policy");
     }
 
-    /// @dev THE ROLES SPLIT: raising the ceiling raises the fund's reachable risk, so the keeper key —
-    ///      which may de-lever and rebalance all day — must not hold this. Admin == `vault().owner()`.
+    /// @dev THE ROLES SPLIT: the keeper key may de-lever all day but must not raise the fund's risk.
     function testSetMaxLtvRevertsForProposerAndStrangers() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
 
@@ -1729,8 +1724,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().maxLtvBps, 6500, "a refused caller stores nothing");
     }
 
-    /// @dev Rung 1, the band from BELOW: a ceiling under the STANDING target is refused with the very error
-    ///      `setTargetLtv` raises from the other side, so `target <= max` holds whichever knob moves.
+    /// @dev Rung 1, the band from BELOW — the same error `setTargetLtv` raises from the other side.
     function testSetMaxLtvRevertsBelowTheStandingTarget() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
 
@@ -1744,8 +1738,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().maxLtvBps, 5000, "the target itself is a legal ceiling");
     }
 
-    /// @dev Rung 3: the ceiling must sit STRICTLY below the collateral factor, or the op ceiling is the
-    ///      liquidation line.
+    /// @dev Rung 3: STRICTLY below the collateral factor, or the op ceiling IS the liquidation line.
     function testSetMaxLtvRevertsAtOrAboveTheCollateralFactor() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
 
@@ -1760,9 +1753,8 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().maxLtvBps, 6500, "neither attempt stored");
     }
 
-    /// @dev Rung 4, THE ANTI-GRIEF RUNG: the permissionless `deleverage()` triggers at
-    ///      `LTV = 1e8 / minHealthBps`, which must stay strictly ABOVE the ceiling. At minHealth 12000 that
-    ///      line is 8333.3 bps, so 8334 opens an in-band range anyone could grief-deleverage.
+    /// @dev Rung 4, ANTI-GRIEF: `deleverage()` triggers at `1e8 / minHealthBps` — 8333.3 bps here — which
+    ///      must stay strictly ABOVE the ceiling or an in-band range is grief-deleverageable.
     function testSetMaxLtvRevertsOnTheMinHealthConflictRung() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
 
@@ -1776,9 +1768,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().maxLtvBps, 8333, "one bps below the conflict is accepted");
     }
 
-    /// @dev THE POINT OF READING THE COMPTROLLER AT CALL TIME: Moonwell governance can move USDC's CF after
-    ///      init, and a setter validating against the init-time snapshot would approve a ceiling that now
-    ///      sits above the live liquidation line. Same argument, same value, both sides of a CF move.
+    /// @dev WHY THE CF IS READ AT CALL TIME: the same argument, both sides of a governance CF move.
     function testSetMaxLtvReadsTheCollateralFactorLive() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
         assertEq(s.layout().usdcCollateralFactorBps, 8800, "init snapshot");
@@ -1795,8 +1785,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().maxLtvBps, 8000, "the SAME argument now clears the SAME rung");
     }
 
-    /// @dev LOWERING is a risk ratchet-down, and it tightens the band for the OTHER setter immediately:
-    ///      `setTargetLtv` then refuses anything above the new ceiling.
+    /// @dev Lowering tightens the OTHER setter immediately — hence the ordering when ratcheting down.
     function testSetMaxLtvLoweringTightensSetTargetLtv() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
 
@@ -1813,10 +1802,6 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     }
 
     // ==================== setWidthBounds (ADMIN-ONLY RERANGE BAND) ====================
-    //
-    // Same story as `setMaxLtv` one layer out: the band the PROPOSER's `rerange` width must land in was
-    // writable only at init / `migrateVenue`. Validated through the two ladders `applyVenue` runs —
-    // `checkBands` then `checkRange` on the STORED (width, skew) — so every rung is the shared library's.
     // Fixture: tickSpacing 100, width 4000, skew 5000, band [200, 20000], skew band [1, 9999].
 
     /// @dev The admin writes the band; the skew band and the live width are left alone.
@@ -1835,8 +1820,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().maxSkewBps, 9999, "...both ends of it");
     }
 
-    /// @dev THE ROLES SPLIT, sharpest form: this band is what BOUNDS the proposer's `rerange`, so an
-    ///      operator able to set it would have no bounds at all.
+    /// @dev THE ROLES SPLIT: an operator that can set its own bounds has none.
     function testSetWidthBoundsRevertsForProposerAndStrangers() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
 
@@ -1852,8 +1836,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().maxWidth, 20_000, "...at either end");
     }
 
-    /// @dev `checkBands` rung 1: BOTH bounds must sit on the tickSpacing grid, or a legal-looking width
-    ///      could not be placed at either end of its own band.
+    /// @dev `checkBands` rung 1: BOTH bounds on the tickSpacing grid.
     function testSetWidthBoundsRevertsOnOffGridBounds() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
 
@@ -1868,8 +1851,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().minWidth, 200, "neither attempt stored");
     }
 
-    /// @dev `checkBands` rung 2: `minWidth >= 2 x tickSpacing`, the rule that keeps an aligned range from
-    ///      being empty after both bounds round DOWN onto the grid.
+    /// @dev `checkBands` rung 2: `minWidth >= 2 x tickSpacing`, so an aligned range is never empty.
     function testSetWidthBoundsRevertsWhenMinWidthIsUnderTwoSpacings() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
 
@@ -1882,9 +1864,7 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().minWidth, 200, "the floor itself is legal");
     }
 
-    /// @dev `checkBands` rung 3: an inverted band admits nothing. DOUBLY refused by construction — an empty
-    ///      band cannot contain the stored width either, so `checkRange` catches it too if the shape rung
-    ///      ever moves.
+    /// @dev `checkBands` rung 3: an inverted band admits nothing (and `checkRange` catches it too).
     function testSetWidthBoundsRevertsOnAnInvertedBand() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
 
@@ -1895,10 +1875,8 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().maxWidth, 20_000, "nothing stored");
     }
 
-    /// @dev `checkBands` rung 4: `maxWidth` must fit the tick domain (`2 x MAX_TICK == MAX_BAND_WIDTH`) —
-    ///      `skewedTickRange` can put the WHOLE width on one side, so a wider band could not be placed at
-    ///      all. Both probes are on the SPACING grid, so it is the domain rung talking and not rung 1
-    ///      (`MAX_BAND_WIDTH` itself is off-grid at spacing 100, hence the nearest aligned width below it).
+    /// @dev `checkBands` rung 4: `maxWidth` inside the tick domain. Both probes are on the grid so rung 1
+    ///      stays quiet — `MAX_BAND_WIDTH` is itself off-grid at spacing 100, hence the aligned value.
     function testSetWidthBoundsRevertsAboveTheTickDomain() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
         uint24 alignedCeiling = (MAX_BAND_WIDTH / 100) * 100; // 1_774_500
@@ -1912,9 +1890,8 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         assertEq(s.layout().maxWidth, alignedCeiling, "the domain edge is admissible");
     }
 
-    /// @dev THE CONTAINMENT RULE. `redeploy` / `rerange` size from the STORED width, so a band excluding it
-    ///      would let the next redeploy place a range the band forbids. Excluding it from EITHER end is
-    ///      refused; the admin passes a compatible band, or the proposer reranges into it first.
+    /// @dev THE CONTAINMENT RULE: `redeploy` / `rerange` size from the STORED width, so a band excluding it
+    ///      from either end is refused.
     function testSetWidthBoundsRefusesABandExcludingTheStoredWidth() public {
         LeveragedAerodromeCLStrategy s = _init(_baseParams());
         assertEq(s.layout().width, 4000, "the stored width the band must admit");

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -1861,7 +1861,9 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
 
         vm.prank(owner);
         s.setWidthBounds(200, 8000); // exactly 2 x spacing is the floor, inclusive
-        assertEq(s.layout().minWidth, 200, "the floor itself is legal");
+        // 200 is also the init default, so the NON-default half is what witnesses the write.
+        assertEq(s.layout().maxWidth, 8000, "the floor itself is legal, and the band landed");
+        assertEq(s.layout().minWidth, 200, "the floor is stored");
     }
 
     /// @dev `checkBands` rung 3: an inverted band admits nothing (and `checkRange` catches it too).

--- a/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroStrategyInit.unit.t.sol
@@ -36,6 +36,8 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
     /// @dev Mirrored from {LeveragedAerodromeCLStrategy} for `vm.expectEmit` / topic matching.
     event FeeCrystallizeDeferred(uint8 op, uint256 navPre);
     event TargetLtvUpdated(uint16 previousBps, uint16 newBps);
+    event MaxLtvUpdated(uint16 previousBps, uint16 newBps);
+    event WidthBoundsUpdated(uint24 previousMinWidth, uint24 previousMaxWidth, uint24 newMinWidth, uint24 newMaxWidth);
     event ProposerUpdated(address indexed oldProposer, address indexed newProposer);
 
     /// @dev The strategy's `OP_COMPOUND` deferral code (private there).
@@ -1687,5 +1689,249 @@ contract LeveragedAeroStrategyInitUnitTest is Test {
         vm.prank(owner);
         s.setTargetLtv(4000);
         assertEq(s.targetLtvBps(), 4000, "the target is settable before execute");
+    }
+
+    // ==================== setMaxLtv (ADMIN-ONLY OPERATIONAL CEILING) ====================
+    //
+    // The ceiling used to be writable ONLY at init and inside the owner-staged `migrateVenue` ceremony.
+    // The setter validates through the SHARED `LeveragedAeroValuation.checkLtvBand`, so every rung below
+    // is the library's, reached through the entrypoint — not an ad-hoc copy.
+    // Fixture band: target 5000, max 6500, minHealth 12000, live CF 8800.
+
+    /// @dev The admin writes the ceiling; `layout()` reads it back and the event carries (prev, new).
+    function testSetMaxLtvPersistsAndEmits() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+        assertEq(s.layout().maxLtvBps, 6500, "the init ceiling is the starting one");
+        assertEq(uint8(s.state()), uint8(BaseStrategy.State.Pending), "and NOT state-gated, like setTargetLtv");
+
+        vm.expectEmit(true, true, true, true, address(s));
+        emit MaxLtvUpdated(6500, 7000);
+        vm.prank(owner);
+        s.setMaxLtv(7000);
+
+        assertEq(s.layout().maxLtvBps, 7000, "the new ceiling persisted");
+        assertEq(s.targetLtvBps(), 5000, "the standing target is untouched: this knob is the belt, not policy");
+    }
+
+    /// @dev THE ROLES SPLIT: raising the ceiling raises the fund's reachable risk, so the keeper key —
+    ///      which may de-lever and rebalance all day — must not hold this. Admin == `vault().owner()`.
+    function testSetMaxLtvRevertsForProposerAndStrangers() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
+        s.setMaxLtv(7000);
+
+        vm.prank(lp);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
+        s.setMaxLtv(7000);
+
+        assertEq(s.layout().maxLtvBps, 6500, "a refused caller stores nothing");
+    }
+
+    /// @dev Rung 1, the band from BELOW: a ceiling under the STANDING target is refused with the very error
+    ///      `setTargetLtv` raises from the other side, so `target <= max` holds whichever knob moves.
+    function testSetMaxLtvRevertsBelowTheStandingTarget() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvExceedsMax.selector);
+        s.setMaxLtv(4999); // targetLtvBps == 5000
+        assertEq(s.layout().maxLtvBps, 6500, "a rejected ceiling stores nothing");
+
+        vm.prank(owner);
+        s.setMaxLtv(5000); // the bound is inclusive, exactly as it is in setTargetLtv
+        assertEq(s.layout().maxLtvBps, 5000, "the target itself is a legal ceiling");
+    }
+
+    /// @dev Rung 3: the ceiling must sit STRICTLY below the collateral factor, or the op ceiling is the
+    ///      liquidation line.
+    function testSetMaxLtvRevertsAtOrAboveTheCollateralFactor() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.MaxLtvExceedsCF.selector);
+        s.setMaxLtv(8800); // CF is 8800 bps — equality is already refused
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.MaxLtvExceedsCF.selector);
+        s.setMaxLtv(9000);
+
+        assertEq(s.layout().maxLtvBps, 6500, "neither attempt stored");
+    }
+
+    /// @dev Rung 4, THE ANTI-GRIEF RUNG: the permissionless `deleverage()` triggers at
+    ///      `LTV = 1e8 / minHealthBps`, which must stay strictly ABOVE the ceiling. At minHealth 12000 that
+    ///      line is 8333.3 bps, so 8334 opens an in-band range anyone could grief-deleverage.
+    function testSetMaxLtvRevertsOnTheMinHealthConflictRung() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.MinHealthMaxLtvConflict.selector);
+        s.setMaxLtv(8334); // 12000 * 8334 == 1.00008e8 >= 1e8
+        assertEq(s.layout().maxLtvBps, 6500, "the conflicting ceiling stored nothing");
+
+        vm.prank(owner);
+        s.setMaxLtv(8333); // 12000 * 8333 == 9.9996e7 — the last legal bps below the trigger
+        assertEq(s.layout().maxLtvBps, 8333, "one bps below the conflict is accepted");
+    }
+
+    /// @dev THE POINT OF READING THE COMPTROLLER AT CALL TIME: Moonwell governance can move USDC's CF after
+    ///      init, and a setter validating against the init-time snapshot would approve a ceiling that now
+    ///      sits above the live liquidation line. Same argument, same value, both sides of a CF move.
+    function testSetMaxLtvReadsTheCollateralFactorLive() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+        assertEq(s.layout().usdcCollateralFactorBps, 8800, "init snapshot");
+
+        comptroller.setCollateralFactorMantissa(0.75e18); // Moonwell governance tightens USDC to 75%
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.MaxLtvExceedsCF.selector);
+        s.setMaxLtv(8000); // legal against the 8800 SNAPSHOT, illegal against the 7500 LIVE factor
+        assertEq(s.layout().maxLtvBps, 6500, "nothing stored");
+
+        comptroller.setCollateralFactorMantissa(0.88e18); // ...and back
+        vm.prank(owner);
+        s.setMaxLtv(8000);
+        assertEq(s.layout().maxLtvBps, 8000, "the SAME argument now clears the SAME rung");
+    }
+
+    /// @dev LOWERING is a risk ratchet-down, and it tightens the band for the OTHER setter immediately:
+    ///      `setTargetLtv` then refuses anything above the new ceiling.
+    function testSetMaxLtvLoweringTightensSetTargetLtv() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(owner);
+        s.setMaxLtv(5500);
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.TargetLtvExceedsMax.selector);
+        s.setTargetLtv(5501);
+
+        vm.prank(owner);
+        s.setTargetLtv(5500); // the new ceiling is reachable, nothing above it is
+        assertEq(s.targetLtvBps(), 5500, "policy can meet the lowered ceiling");
+    }
+
+    // ==================== setWidthBounds (ADMIN-ONLY RERANGE BAND) ====================
+    //
+    // Same story as `setMaxLtv` one layer out: the band the PROPOSER's `rerange` width must land in was
+    // writable only at init / `migrateVenue`. Validated through the two ladders `applyVenue` runs —
+    // `checkBands` then `checkRange` on the STORED (width, skew) — so every rung is the shared library's.
+    // Fixture: tickSpacing 100, width 4000, skew 5000, band [200, 20000], skew band [1, 9999].
+
+    /// @dev The admin writes the band; the skew band and the live width are left alone.
+    function testSetWidthBoundsPersistsAndEmits() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.expectEmit(true, true, true, true, address(s));
+        emit WidthBoundsUpdated(200, 20_000, 400, 8000);
+        vm.prank(owner);
+        s.setWidthBounds(400, 8000);
+
+        assertEq(s.layout().minWidth, 400, "the new lower bound persisted");
+        assertEq(s.layout().maxWidth, 8000, "...and the upper");
+        assertEq(s.layout().width, 4000, "the LIVE width is untouched: moving it is the proposer's rerange");
+        assertEq(s.layout().minSkewBps, 1, "the skew band stays init-frozen");
+        assertEq(s.layout().maxSkewBps, 9999, "...both ends of it");
+    }
+
+    /// @dev THE ROLES SPLIT, sharpest form: this band is what BOUNDS the proposer's `rerange`, so an
+    ///      operator able to set it would have no bounds at all.
+    function testSetWidthBoundsRevertsForProposerAndStrangers() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
+        s.setWidthBounds(400, 8000);
+
+        vm.prank(lp);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
+        s.setWidthBounds(400, 8000);
+
+        assertEq(s.layout().minWidth, 200, "a refused caller stores nothing");
+        assertEq(s.layout().maxWidth, 20_000, "...at either end");
+    }
+
+    /// @dev `checkBands` rung 1: BOTH bounds must sit on the tickSpacing grid, or a legal-looking width
+    ///      could not be placed at either end of its own band.
+    function testSetWidthBoundsRevertsOnOffGridBounds() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.setWidthBounds(250, 8000); // 250 % 100 != 0
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.setWidthBounds(400, 8050); // 8050 % 100 != 0
+
+        assertEq(s.layout().minWidth, 200, "neither attempt stored");
+    }
+
+    /// @dev `checkBands` rung 2: `minWidth >= 2 x tickSpacing`, the rule that keeps an aligned range from
+    ///      being empty after both bounds round DOWN onto the grid.
+    function testSetWidthBoundsRevertsWhenMinWidthIsUnderTwoSpacings() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.setWidthBounds(100, 8000); // on-grid, but one spacing — half the floor
+
+        vm.prank(owner);
+        s.setWidthBounds(200, 8000); // exactly 2 x spacing is the floor, inclusive
+        assertEq(s.layout().minWidth, 200, "the floor itself is legal");
+    }
+
+    /// @dev `checkBands` rung 3: an inverted band admits nothing. DOUBLY refused by construction — an empty
+    ///      band cannot contain the stored width either, so `checkRange` catches it too if the shape rung
+    ///      ever moves.
+    function testSetWidthBoundsRevertsOnAnInvertedBand() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.setWidthBounds(8000, 400);
+
+        assertEq(s.layout().maxWidth, 20_000, "nothing stored");
+    }
+
+    /// @dev `checkBands` rung 4: `maxWidth` must fit the tick domain (`2 x MAX_TICK == MAX_BAND_WIDTH`) —
+    ///      `skewedTickRange` can put the WHOLE width on one side, so a wider band could not be placed at
+    ///      all. Both probes are on the SPACING grid, so it is the domain rung talking and not rung 1
+    ///      (`MAX_BAND_WIDTH` itself is off-grid at spacing 100, hence the nearest aligned width below it).
+    function testSetWidthBoundsRevertsAboveTheTickDomain() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+        uint24 alignedCeiling = (MAX_BAND_WIDTH / 100) * 100; // 1_774_500
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.setWidthBounds(400, alignedCeiling + 100); // one spacing past the domain
+
+        vm.prank(owner);
+        s.setWidthBounds(400, alignedCeiling); // the widest aligned band the domain admits
+        assertEq(s.layout().maxWidth, alignedCeiling, "the domain edge is admissible");
+    }
+
+    /// @dev THE CONTAINMENT RULE. `redeploy` / `rerange` size from the STORED width, so a band excluding it
+    ///      would let the next redeploy place a range the band forbids. Excluding it from EITHER end is
+    ///      refused; the admin passes a compatible band, or the proposer reranges into it first.
+    function testSetWidthBoundsRefusesABandExcludingTheStoredWidth() public {
+        LeveragedAerodromeCLStrategy s = _init(_baseParams());
+        assertEq(s.layout().width, 4000, "the stored width the band must admit");
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.setWidthBounds(4100, 8000); // floor above the live width
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        s.setWidthBounds(400, 3900); // ceiling below it
+
+        assertEq(s.layout().minWidth, 200, "neither attempt stored");
+        assertEq(s.layout().maxWidth, 20_000, "...at either end");
+
+        vm.prank(owner);
+        s.setWidthBounds(4000, 4000); // the degenerate band that admits exactly the live width
+        assertEq(s.layout().minWidth, 4000, "a band pinned to the live width is legal");
     }
 }

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -554,7 +554,134 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         );
     }
 
+    /**
+     * @dev THE RATCHET-DOWN STORY for the admin's `setMaxLtv`, on a LIVE levered book. Lowering the ceiling
+     *      under the book's own LTV is legal and moves nothing by itself; what changes is that every op
+     *      ending in `_assertHealthy` now fails until the book is de-levered. A lever-DOWN is the way out,
+     *      and it still works — which is the whole point of the direction being safe to take at any time.
+     */
+    function testLoweringMaxLtvBlocksDebtAddingOpsUntilTheBookDeLevers() public {
+        _execute(SEED);
+        assertApproxEqAbs(_ltvBps(), uint256(TARGET_LTV_BPS), 2, "the book opens on the init target");
+
+        // The ratchet: policy first (the band is checked from both sides, so the ceiling cannot go under
+        // the standing target), then the ceiling — DOWN THROUGH the book's live 5000 LTV.
+        vm.startPrank(owner);
+        strategy.setTargetLtv(4000);
+        strategy.setMaxLtv(4500);
+        vm.stopPrank();
+        assertApproxEqAbs(_ltvBps(), uint256(TARGET_LTV_BPS), 2, "lowering the ceiling moved no debt");
+
+        // A debt-ADDING op now fails at the POST-op gate: a 100k tranche sized at the new 4000 target still
+        // leaves the blend at ~4909 bps, above the fresh 4500 ceiling.
+        uint256 topUp = 100_000e6;
+        usdc.mint(address(strategy), topUp);
+        vm.prank(proposer);
+        vm.expectPartialRevert(LeveragedAerodromeCLStrategy.UnhealthyPosition.selector);
+        strategy.deployIdle(topUp, 0);
+        assertApproxEqAbs(_ltvBps(), uint256(TARGET_LTV_BPS), 2, "the refused op rolled back whole");
+
+        // The way out is a lever-DOWN, and it is NOT blocked: its own bound is the stored POLICY target, and
+        // it ends under the new ceiling.
+        vm.prank(proposer);
+        strategy.adjustLeverage(4000, 0, 0);
+        assertApproxEqAbs(_ltvBps(), 4000, 2, "the keeper de-levered to the new policy with no admin signature");
+
+        // ...and once the book is inside the band again the same tranche deploys.
+        vm.prank(proposer);
+        strategy.deployIdle(topUp, 0);
+        assertApproxEqAbs(_ltvBps(), 4000, 2, "the redeployed book sits on the new target, under the ceiling");
+    }
+
+    /// @dev A lever-UP back to the OLD level is refused for as long as the ceiling stays low — the ceiling,
+    ///      not the target, is what makes the de-risk durable against a keeper that re-raises policy... which
+    ///      it cannot do either (`setTargetLtv` is admin-only). Both halves pinned here.
+    function testLoweredMaxLtvKeepsTheKeeperFromLeveringBackUp() public {
+        _execute(SEED);
+
+        vm.startPrank(owner);
+        strategy.setTargetLtv(3000);
+        strategy.setMaxLtv(3500);
+        vm.stopPrank();
+
+        // Down to the new policy first, so the book is healthy and the ONLY thing under test is the re-lever.
+        vm.prank(proposer);
+        strategy.adjustLeverage(3000, 0, 0);
+        assertApproxEqAbs(_ltvBps(), 3000, 2, "de-levered");
+
+        // The keeper cannot pass the old 5000, because the POLICY bound bites first...
+        vm.prank(proposer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LeveragedAerodromeCLStrategy.TargetLtvExceedsPolicy.selector, uint16(5000), uint16(3000)
+            )
+        );
+        strategy.adjustLeverage(5000, 0, 0);
+
+        // ...and it cannot raise the policy either.
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
+        strategy.setTargetLtv(5000);
+
+        // Nor the ceiling that would let a future policy raise go anywhere.
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
+        strategy.setMaxLtv(6500);
+
+        assertEq(strategy.layout().maxLtvBps, 3500, "the ceiling the admin set is the ceiling that stands");
+    }
+
     // ==================== RERANGE SKEW (two borrowed legs) ====================
+
+    /// @dev The admin's `setWidthBounds` is what BOUNDS the proposer's `rerange`, and it binds immediately:
+    ///      a width outside the fresh band is refused, one inside it mints.
+    function testSetWidthBoundsTightensWhatTheProposerMayRerangeTo() public {
+        _execute(SEED);
+
+        vm.prank(owner);
+        strategy.setWidthBounds(2000, 6000);
+
+        // 1000 was legal under the init band [200, 20000]; it is not under [2000, 6000].
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAeroValuation.OutOfBounds.selector);
+        strategy.rerange(1000, SKEW_CENTERED, 0, 0);
+
+        // ...and neither is the other side.
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAeroValuation.OutOfBounds.selector);
+        strategy.rerange(8000, SKEW_CENTERED, 0, 0);
+
+        assertEq(strategy.layout().width, WIDTH, "a refused rerange stored no width");
+
+        // Inside the band the op runs normally.
+        vm.prank(proposer);
+        strategy.rerange(6000, SKEW_CENTERED, 0, 0);
+        assertEq(strategy.layout().width, 6000, "the band's own ceiling is reachable");
+        assertGt(npm.liquidityOf(strategy.layout().tokenId), 0, "and it minted a real position");
+    }
+
+    /// @dev THE CONTAINMENT RULE against a live book: the band cannot orphan the STORED width, because
+    ///      `redeploy` / `rerange` size from it. The admin's move is gated until the proposer reranges into
+    ///      the intended width — then the exact same band change lands.
+    function testSetWidthBoundsRefusesToStrandTheStoredWidthUntilARerange() public {
+        _execute(SEED);
+        assertEq(strategy.layout().width, WIDTH, "stored width is 4000");
+
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAeroValuation.OutOfBounds.selector);
+        strategy.setWidthBounds(5000, 8000); // would exclude the live 4000
+        assertEq(strategy.layout().minWidth, 200, "the refused band stored nothing");
+
+        // The proposer reranges into the width the admin is aiming the band at (still legal under the OLD
+        // band, which is exactly why the ordering works).
+        vm.prank(proposer);
+        strategy.rerange(6000, SKEW_CENTERED, 0, 0);
+
+        vm.prank(owner);
+        strategy.setWidthBounds(5000, 8000);
+        assertEq(strategy.layout().minWidth, 5000, "the same band change now lands");
+        assertEq(strategy.layout().maxWidth, 8000, "...both ends");
+    }
 
     /// @dev The re-range mints at the SKEWED range, not the centred one, and persists BOTH knobs.
     function testRerangeSkewedMintsTheSkewedRange() public {

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -554,26 +554,20 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         );
     }
 
-    /**
-     * @dev THE RATCHET-DOWN STORY for the admin's `setMaxLtv`, on a LIVE levered book. Lowering the ceiling
-     *      under the book's own LTV is legal and moves nothing by itself; what changes is that every op
-     *      ending in `_assertHealthy` now fails until the book is de-levered. A lever-DOWN is the way out,
-     *      and it still works — which is the whole point of the direction being safe to take at any time.
-     */
+    /// @dev THE RATCHET-DOWN, on a live levered book: the ceiling drops under the book's own LTV, ops that
+    ///      end in `_assertHealthy` fail until a lever-DOWN — which is not blocked — brings it back inside.
     function testLoweringMaxLtvBlocksDebtAddingOpsUntilTheBookDeLevers() public {
         _execute(SEED);
         assertApproxEqAbs(_ltvBps(), uint256(TARGET_LTV_BPS), 2, "the book opens on the init target");
 
-        // The ratchet: policy first (the band is checked from both sides, so the ceiling cannot go under
-        // the standing target), then the ceiling — DOWN THROUGH the book's live 5000 LTV.
+        // Policy first (the band is checked from both sides), then the ceiling, through the live 5000 LTV.
         vm.startPrank(owner);
         strategy.setTargetLtv(4000);
         strategy.setMaxLtv(4500);
         vm.stopPrank();
         assertApproxEqAbs(_ltvBps(), uint256(TARGET_LTV_BPS), 2, "lowering the ceiling moved no debt");
 
-        // A debt-ADDING op now fails at the POST-op gate: a 100k tranche sized at the new 4000 target still
-        // leaves the blend at ~4909 bps, above the fresh 4500 ceiling.
+        // A 100k tranche at the new 4000 target still blends to ~4909 bps, above the fresh 4500 ceiling.
         uint256 topUp = 100_000e6;
         usdc.mint(address(strategy), topUp);
         vm.prank(proposer);
@@ -581,21 +575,17 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         strategy.deployIdle(topUp, 0);
         assertApproxEqAbs(_ltvBps(), uint256(TARGET_LTV_BPS), 2, "the refused op rolled back whole");
 
-        // The way out is a lever-DOWN, and it is NOT blocked: its own bound is the stored POLICY target, and
-        // it ends under the new ceiling.
+        // The way out: a lever-DOWN, bounded by the stored POLICY target, ending under the new ceiling.
         vm.prank(proposer);
         strategy.adjustLeverage(4000, 0, 0);
         assertApproxEqAbs(_ltvBps(), 4000, 2, "the keeper de-levered to the new policy with no admin signature");
 
-        // ...and once the book is inside the band again the same tranche deploys.
         vm.prank(proposer);
         strategy.deployIdle(topUp, 0);
         assertApproxEqAbs(_ltvBps(), 4000, 2, "the redeployed book sits on the new target, under the ceiling");
     }
 
-    /// @dev A lever-UP back to the OLD level is refused for as long as the ceiling stays low — the ceiling,
-    ///      not the target, is what makes the de-risk durable against a keeper that re-raises policy... which
-    ///      it cannot do either (`setTargetLtv` is admin-only). Both halves pinned here.
+    /// @dev The keeper's three closed doors after a ratchet-down: re-lever, raise policy, raise the ceiling.
     function testLoweredMaxLtvKeepsTheKeeperFromLeveringBackUp() public {
         _execute(SEED);
 
@@ -604,12 +594,11 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         strategy.setMaxLtv(3500);
         vm.stopPrank();
 
-        // Down to the new policy first, so the book is healthy and the ONLY thing under test is the re-lever.
+        // Down to the new policy first, so only the re-lever is under test.
         vm.prank(proposer);
         strategy.adjustLeverage(3000, 0, 0);
         assertApproxEqAbs(_ltvBps(), 3000, 2, "de-levered");
 
-        // The keeper cannot pass the old 5000, because the POLICY bound bites first...
         vm.prank(proposer);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -618,12 +607,10 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         );
         strategy.adjustLeverage(5000, 0, 0);
 
-        // ...and it cannot raise the policy either.
         vm.prank(proposer);
         vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
         strategy.setTargetLtv(5000);
 
-        // Nor the ceiling that would let a future policy raise go anywhere.
         vm.prank(proposer);
         vm.expectRevert(LeveragedAerodromeCLStrategy.NotAdmin.selector);
         strategy.setMaxLtv(6500);
@@ -633,8 +620,7 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
 
     // ==================== RERANGE SKEW (two borrowed legs) ====================
 
-    /// @dev The admin's `setWidthBounds` is what BOUNDS the proposer's `rerange`, and it binds immediately:
-    ///      a width outside the fresh band is refused, one inside it mints.
+    /// @dev A tightened band binds the proposer's `rerange` immediately, at both ends.
     function testSetWidthBoundsTightensWhatTheProposerMayRerangeTo() public {
         _execute(SEED);
 
@@ -646,23 +632,19 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         vm.expectRevert(LeveragedAeroValuation.OutOfBounds.selector);
         strategy.rerange(1000, SKEW_CENTERED, 0, 0);
 
-        // ...and neither is the other side.
         vm.prank(proposer);
         vm.expectRevert(LeveragedAeroValuation.OutOfBounds.selector);
         strategy.rerange(8000, SKEW_CENTERED, 0, 0);
 
         assertEq(strategy.layout().width, WIDTH, "a refused rerange stored no width");
 
-        // Inside the band the op runs normally.
         vm.prank(proposer);
         strategy.rerange(6000, SKEW_CENTERED, 0, 0);
         assertEq(strategy.layout().width, 6000, "the band's own ceiling is reachable");
         assertGt(npm.liquidityOf(strategy.layout().tokenId), 0, "and it minted a real position");
     }
 
-    /// @dev THE CONTAINMENT RULE against a live book: the band cannot orphan the STORED width, because
-    ///      `redeploy` / `rerange` size from it. The admin's move is gated until the proposer reranges into
-    ///      the intended width — then the exact same band change lands.
+    /// @dev THE CONTAINMENT RULE on a live book: gated until the proposer reranges into the target width.
     function testSetWidthBoundsRefusesToStrandTheStoredWidthUntilARerange() public {
         _execute(SEED);
         assertEq(strategy.layout().width, WIDTH, "stored width is 4000");
@@ -672,8 +654,7 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         strategy.setWidthBounds(5000, 8000); // would exclude the live 4000
         assertEq(strategy.layout().minWidth, 200, "the refused band stored nothing");
 
-        // The proposer reranges into the width the admin is aiming the band at (still legal under the OLD
-        // band, which is exactly why the ordering works).
+        // Still legal under the OLD band — which is why the ordering works and this is not a deadlock.
         vm.prank(proposer);
         strategy.rerange(6000, SKEW_CENTERED, 0, 0);
 

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -585,6 +585,66 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
         assertApproxEqAbs(_ltvBps(), 4000, 2, "the redeployed book sits on the new target, under the ceiling");
     }
 
+    /// @dev `compound` is the OTHER debt-adding op the ceiling gates: its redeployed harvest borrows at the
+    ///      target, and the blended book is still over the fresh ceiling, so the same post-op gate fires.
+    function testLoweringMaxLtvAlsoBlocksCompoundUntilTheBookDeLevers() public {
+        _execute(SEED);
+
+        vm.startPrank(owner);
+        strategy.setTargetLtv(4000);
+        strategy.setMaxLtv(4500);
+        vm.stopPrank();
+
+        _armAeroRouter();
+        _armHarvest(40_000e6);
+
+        vm.prank(proposer);
+        vm.expectPartialRevert(LeveragedAerodromeCLStrategy.UnhealthyPosition.selector);
+        strategy.compound(1, 0);
+        assertApproxEqAbs(_ltvBps(), uint256(TARGET_LTV_BPS), 2, "the refused harvest rolled back whole");
+
+        vm.prank(proposer);
+        strategy.adjustLeverage(4000, 0, 0);
+        vm.prank(proposer);
+        strategy.compound(1, 0); // inside the band the same harvest lands
+        assertLe(_ltvBps(), 4500, "the compounded book sits under the ceiling");
+    }
+
+    /// @dev The FAST-REDEEM gate reads `$.maxLtvBps` LIVE: the same draw flips from allowed to refused when
+    ///      the admin lowers the ceiling under it, and back when the ceiling is raised again. An init-cached
+    ///      copy would give the same answer all three times.
+    function testLoweringMaxLtvTightensTheFastRedeemGateImmediately() public {
+        _execute(SEED);
+        uint256 supply = 1_000_000e12;
+        vm.prank(address(strategy));
+        vault.strategyMint(lp, supply);
+        vm.prank(lp);
+        vault.approve(address(strategy), supply);
+        uint256 shares = supply / 10; // a draw that lands the post-redeem LTV around 5263 bps
+
+        uint256 snapA = vm.snapshotState();
+        vm.prank(lp);
+        strategy.redeem(shares, 0); // ceiling 6500: the fast path is open
+        vm.revertToState(snapA);
+
+        vm.prank(owner);
+        strategy.setMaxLtv(5100); // still above the book's live 5000, below the POST-draw LTV
+        uint256 snapB = vm.snapshotState();
+        vm.prank(lp);
+        vm.expectPartialRevert(LeveragedAeroVenue.FastRedeemExceedsLtv.selector);
+        strategy.redeem(shares, 0);
+
+        // ...and the documented fallback is open: the same shares still queue.
+        vm.prank(lp);
+        strategy.requestRedeem(shares, 0);
+        vm.revertToState(snapB);
+
+        vm.prank(owner);
+        strategy.setMaxLtv(5500); // back above the post-draw LTV
+        vm.prank(lp);
+        strategy.redeem(shares, 0);
+    }
+
     /// @dev The keeper's three closed doors after a ratchet-down: re-lever, raise policy, raise the ceiling.
     function testLoweredMaxLtvKeepsTheKeeperFromLeveringBackUp() public {
         _execute(SEED);

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -636,7 +636,7 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
 
         // ...and the documented fallback is open: the same shares still queue.
         vm.prank(lp);
-        strategy.requestRedeem(shares, 0);
+        strategy.requestRedeem(shares, 0, address(0)); // recipient 0 == the redeemer
         vm.revertToState(snapB);
 
         vm.prank(owner);

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -1317,6 +1317,103 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         assertEq(strategy.layout().targetLtvBps, TARGET_LTV_BPS, "the staged target won, loudly");
     }
 
+    /// @dev The ceiling and the width band get the SAME inequality-guarded announcement as the target —
+    ///      `VenueMigrated` carries only the two pools, so without these a migration moves them in silence.
+    function testMigrateAnnouncesTheCeilingAndTheWidthBandItRestores() public {
+        _execute(SEED);
+        vm.startPrank(owner);
+        strategy.setTargetLtv(3000);
+        strategy.setMaxLtv(3500);
+        strategy.setWidthBounds(400, 8000);
+        vm.stopPrank();
+
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueAParams(); // restores 6500 and [200, 20000]
+        _stage(v);
+        vm.expectEmit(false, false, false, true, address(strategy));
+        emit LeveragedAerodromeCLStrategy.WidthBoundsUpdated(400, 8000, 200, 20_000);
+        vm.expectEmit(false, false, false, true, address(strategy));
+        emit LeveragedAerodromeCLStrategy.MaxLtvUpdated(3500, 6500);
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+
+        assertEq(strategy.layout().maxLtvBps, 6500, "the staged ceiling won, loudly");
+        assertEq(strategy.layout().minWidth, 200, "...and the staged band");
+    }
+
+    /// @dev An UNCHANGED ceiling / band stays quiet, so the events mean "it moved", not "a migration ran".
+    function testMigrateStaysQuietWhenTheCeilingAndBandAreUnchanged() public {
+        _execute(SEED);
+        _flatten();
+        LeveragedAeroVenue.VenueParams memory v = _venueAParams(); // byte-identical to what is stored
+        _stage(v);
+
+        vm.recordLogs();
+        vm.prank(proposer);
+        strategy.migrateVenue(v);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bool sawMigrated;
+        for (uint256 i = 0; i < logs.length; i++) {
+            assertTrue(
+                logs[i].topics[0] != LeveragedAerodromeCLStrategy.MaxLtvUpdated.selector,
+                "an unchanged ceiling must not announce a change"
+            );
+            assertTrue(
+                logs[i].topics[0] != LeveragedAerodromeCLStrategy.WidthBoundsUpdated.selector,
+                "...nor an unchanged band"
+            );
+            if (logs[i].topics[0] == LeveragedAeroVenue.VenueMigrated.selector) sawMigrated = true;
+        }
+        assertTrue(sawMigrated, "the migration itself did run -- the assertions above are not vacuous");
+    }
+
+    /// @dev THE STALE-AUTHORIZATION CLOSE. An owner stage carries a ceiling picked under the policy standing
+    ///      at stage time; an admin ratchet-down moves that policy, so the setter consumes the stage exactly
+    ///      as `redeploy` does. Without it the proposer alone could restore the pre-ratchet ceiling.
+    function testSetMaxLtvConsumesAStaleVenueStageSoAMigrationCannotUndoTheRatchet() public {
+        _execute(SEED);
+        LeveragedAeroVenue.VenueParams memory v = _venueAParams(); // carries the init 6500 ceiling
+        _stage(v);
+        assertEq(strategy.layout().stagedVenueHash, keccak256(abi.encode(v)), "owner authorization armed");
+
+        // Markets turn: the admin ratchets policy and the ceiling down.
+        vm.startPrank(owner);
+        strategy.setTargetLtv(3000);
+        strategy.setMaxLtv(3500);
+        vm.stopPrank();
+        assertEq(strategy.layout().stagedVenueHash, bytes32(0), "the ratchet consumed the stale authorization");
+
+        // The proposer's migration now has nothing to fire.
+        _flatten();
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.VenueNotStaged.selector);
+        strategy.migrateVenue(v);
+        assertEq(strategy.layout().maxLtvBps, 3500, "the ceiling the admin set still stands");
+
+        // The owner can still re-authorize deliberately, under the policy now standing.
+        _stage(v);
+        _migrate(v);
+        assertEq(strategy.layout().maxLtvBps, 6500, "a FRESH owner stage migrates as before");
+    }
+
+    /// @dev Same close on the band setter.
+    function testSetWidthBoundsConsumesAStaleVenueStage() public {
+        _execute(SEED);
+        LeveragedAeroVenue.VenueParams memory v = _venueAParams();
+        _stage(v);
+
+        vm.prank(owner);
+        strategy.setWidthBounds(400, 8000);
+        assertEq(strategy.layout().stagedVenueHash, bytes32(0), "the band write consumed the stage");
+
+        _flatten();
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.VenueNotStaged.selector);
+        strategy.migrateVenue(v);
+        assertEq(strategy.layout().minWidth, 400, "the admin's band still stands");
+    }
+
     // ==================== migrate: happy paths ====================
 
     function testMigratePreservesNavSharesAndHwm() public {

--- a/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroVenueMigration.unit.t.sol
@@ -1299,7 +1299,9 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         assertEq(strategy.layout().targetLtvBps, TARGET_LTV_BPS, "target unchanged");
     }
 
-    /// @dev THE SCENARIO THE EVENT EXISTS FOR: a migration RESTORING a target the admin lowered.
+    /// @dev THE SCENARIO THE EVENT EXISTS FOR: a migration RESTORING a target the admin lowered. The stage
+    ///      is armed AFTER the ratchet on purpose — a stage predating it is consumed by `setTargetLtv`, so
+    ///      this is the owner deliberately re-authorising the restore, which is the only way to reach it.
     function testMigrateAnnouncesRestoringALoweredTarget() public {
         _execute(SEED);
         vm.prank(owner);
@@ -1308,7 +1310,7 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
 
         _flatten();
         LeveragedAeroVenue.VenueParams memory v = _venueAParams(); // same venue, target back to 5000
-        _stage(v);
+        _stage(v); // AFTER the ratchet: a fresh, deliberate owner authorisation
         vm.expectEmit(false, false, false, true, address(strategy));
         emit LeveragedAerodromeCLStrategy.TargetLtvUpdated(3000, TARGET_LTV_BPS);
         vm.prank(proposer);
@@ -1395,6 +1397,30 @@ contract LeveragedAeroVenueMigrationUnitTest is Test {
         _stage(v);
         _migrate(v);
         assertEq(strategy.layout().maxLtvBps, 6500, "a FRESH owner stage migrates as before");
+    }
+
+    /// @dev The THIRD policy setter closes the same way: an armed stage carries a target the owner picked
+    ///      under the old policy, so moving policy consumes it.
+    function testSetTargetLtvConsumesAStaleVenueStageSoAMigrationCannotUndoTheRatchet() public {
+        _execute(SEED);
+        LeveragedAeroVenue.VenueParams memory v = _venueAParams(); // carries the init 5000 target
+        _stage(v);
+        assertEq(strategy.layout().stagedVenueHash, keccak256(abi.encode(v)), "owner authorization armed");
+
+        vm.prank(owner);
+        strategy.setTargetLtv(3000);
+        assertEq(strategy.layout().stagedVenueHash, bytes32(0), "the ratchet consumed the stale authorization");
+
+        _flatten();
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.VenueNotStaged.selector);
+        strategy.migrateVenue(v);
+        assertEq(strategy.layout().targetLtvBps, 3000, "the target the admin set still stands");
+
+        // The owner can still re-authorize deliberately, under the policy now standing.
+        _stage(v);
+        _migrate(v);
+        assertEq(strategy.layout().targetLtvBps, TARGET_LTV_BPS, "a FRESH owner stage migrates as before");
     }
 
     /// @dev Same close on the band setter.


### PR DESCRIPTION
## Why

`LeveragedAerodromeCLStrategy` carries two governance bands that today have **no direct write path**:

| band | written at | standalone setter |
|---|---|---|
| `targetLtvBps` (policy target) | init, `applyVenue`, `setTargetLtv` | yes, admin |
| `maxLtvBps` (operational ceiling) | init, `applyVenue` | **none** |
| `[minWidth, maxWidth]` (rerange band) | init, `applyVenue` | **none** |

So the only way for the multisig to move the op ceiling or the width band is a full `migrateVenue` ceremony: `stageVenue(keccak256(abi.encode(VenueParams)))` as the vault owner, a proposer `flatten()` to make the book flat, then `migrateVenue(p)` byte-exact, then `redeploy`. That is a whole-book unwind-and-reopen to change one `uint16`. This PR adds the two knobs:

```solidity
function setMaxLtv(uint16 maxLtvBps_) external onlyAdmin;
function setWidthBounds(uint24 minWidth_, uint24 maxWidth_) external onlyAdmin;
```

Both sit next to `setTargetLtv` and mirror its shape: NOT state-gated (legal in `Pending`, which is how a multisig corrects an init-time value), policy-only (they move no tokens), event on every write.

## Validation — the shared ladders, nothing ad-hoc

**`setMaxLtv`** calls `LeveragedAeroValuation.checkLtvBand(storedTarget, maxLtvBps_, storedMinHealth, cfBps)` — the same four rungs `applyVenue` and the init ladder run:

1. `target <= newMax` -> `TargetLtvExceedsMax`
2. `minHealthBps >= 10500` -> `MinHealthTooLow`
3. `newMax < cfBps` -> `MaxLtvExceedsCF`
4. `minHealthBps * newMax < 1e8` -> `MinHealthMaxLtvConflict` — the anti-grief rung: the permissionless `deleverage()` trigger sits at `1e8 / minHealthBps`, which must stay strictly above the op ceiling or there is an in-band range anyone can grief-deleverage.

**`cfBps` is read LIVE**, via the existing `LeveragedAeroValuation.readCollateralFactor($.comptroller, $.mUsdc)` (reused, not duplicated) — the same reader `applyVenue` uses, for the same reason. Moonwell governance can lower USDC's collateral factor after init; a setter validating against the init-time snapshot (`$.usdcCollateralFactorBps`, still 8800 from adoption) would happily approve a ceiling that now sits **above the live liquidation line**. `testSetMaxLtvReadsTheCollateralFactorLive` pins this from both sides of a CF move, and it is the one test killed *uniquely* by mutating the live read back to the snapshot.

`$.usdcCollateralFactorBps` is deliberately NOT rewritten by the setter: it is the init/migration record of the venue adoption, and nothing reads it as a cache.

**`setWidthBounds`** runs both ladders `applyVenue` runs (lines 644-646 there), in the same order:

* `checkBands($.tickSpacing, minWidth_, maxWidth_, $.minSkewBps, $.maxSkewBps)` — grid alignment on both bounds, `minWidth >= 2 x tickSpacing`, `min <= max`, `max` inside the tick domain.
* `checkRange($.width, $.skewBps, $.tickSpacing, minWidth_, maxWidth_, $.minSkewBps, $.maxSkewBps)` — the **containment rule**: the CURRENTLY STORED width/skew must remain valid inside the new band. This one is load-bearing. `redeployImpl` and `rerangeImpl` size from the stored width, so a band that excluded it would let the next redeploy place a range the band forbids. Narrowing past the live width therefore reverts `OutOfBounds`: the admin passes a compatible band, or has the proposer `rerange` into the intended width first (which is legal under the old band — that ordering is why the gate is not a deadlock). Documented in the natspec on both the entrypoint and the impl.

## Roles-split invariant preserved

`onlyAdmin` resolves to **`Ownable(vault()).owner()`** — the vault owner, i.e. the MAMO multisig. It is DERIVED, never stored, so an owner handover on the vault carries the strategy's admin rights with it.

Both setters are `onlyAdmin`, never `onlyProposer`:

* `setMaxLtv` — raising the ceiling raises the fund's reachable risk. The documented split is that the keeper/backend key may rebalance and de-lever all day but can never raise fund risk; a proposer-callable ceiling would break it outright. `testLoweredMaxLtvKeepsTheKeeperFromLeveringBackUp` pins the whole closed door: the keeper cannot pass the policy bound in `adjustLeverage`, cannot raise the target, and cannot raise the ceiling.
* `setWidthBounds` — sharper still: this band is *exactly what bounds* the proposer's `rerange`, so an operator that can set it has no bounds.

## Ratchet-down semantics (`setMaxLtv`)

**Lowering below the book's live LTV is legal and intended.** It moves nothing by itself; what changes is that everything ending in `_assertHealthy` now fails until the book is de-levered:

* debt-adding ops (`deployIdle`, `compound` — and anything else ending in `_assertHealthy`) revert `UnhealthyPosition` at the post-op gate. A lever-UP `adjustLeverage` cannot be the op that trips the ceiling: its own bound is `target <= max`, so the pre-existing `TargetLtvExceedsPolicy` closes that door first;
* `adjustLeverage` DOWN keeps working — its own bound is the stored POLICY target, and a lever-down ends healthier — so the keeper can de-lever into the new band with no multisig signature;
* the fast-redeem LTV gate tightens immediately, so a redeemer above the new ceiling routes to `requestRedeem` (`FastRedeemExceedsLtv`);
* once the book is inside the band the ops resume.

The band is checked **from both sides** and the two setters compose: `setTargetLtv` refuses a target above the stored ceiling (`TargetLtvExceedsMax`), and `checkLtvBand`'s first rung refuses a ceiling below the stored target with the same error — so `target <= max` holds whichever knob moves. Consequence worth knowing operationally: to ratchet the ceiling below the current target you lower the target first, which is the correct ordering anyway (policy, then belt).

Raising is bounded by rung 3 (live CF) and rung 4 (the minHealth conflict).

## Decisions worth a reviewer's eye

* **No `setWidth`.** Width itself stays the proposer's `rerange` parameter by design — moving the live range means burning a new position NFT at a calm-gated tick, which is that op, not a storage write. Adding a raw width setter would create a second, un-gated path to a range change.
* **The skew band `[minSkewBps, maxSkewBps]` is intentionally excluded** — init-frozen non-migratable core config, per the earlier design call when it was introduced. `testSetWidthBoundsPersistsAndEmits` asserts both ends are untouched by a band write.
* **Events.** New `MaxLtvUpdated(prev, new)` and `WidthBoundsUpdated(prevMin, prevMax, newMin, newMax)`, following `TargetLtvUpdated`'s convention and mirror-declared in `LeveragedAeroVenue` with identical signatures (same `topic0`) because the impls are delegatecalled and log from the strategy's address. `applyVenue` emits the same pair inequality-guarded (review fix — `VenueMigrated` carries only the two pools, so without it a migration moved these fields past a monitor in silence).
* **`src/interfaces/ILeveragedAeroCLStrategy.sol` unchanged**: it is the deliberately narrow surface `MamoLeveragedAeroStrategy` drives (deposit / redeem / request / cancel / emergency / previews) and declares no admin setters at all, `setTargetLtv` included. Adding them there would widen a wrapper-facing interface for no consumer.

## Size margins (EIP-170)

`FOUNDRY_PROFILE=ci forge build --sizes`, runtime bytes with margin in bold:

| contract | before | after |
|---|---|---|
| `LeveragedAerodromeCLStrategy` | 24,084 (**492**) | 24,061 (**515**) |
| `LeveragedAeroVenue` | 19,097 (**5,479**) | 20,813 (**3,763**) |
| `LeveragedAeroManager` | 23,598 (**978**) | 23,598 (**978**) |
| `LeveragedAeroValuation` | 16,658 (**7,918**) | 16,658 (**7,918**) |

**Relocation was needed.** Bodies went to `LeveragedAeroVenue` as `setMaxLtvImpl` / `setWidthBoundsImpl` (the established relief valve — same pattern as `layoutView`, `applyVenueFromInit`, `previewRedeemImpl`), leaving thin `onlyAdmin` entrypoints. That alone still overflowed: two entrypoints with the modifier inlined cost 486 B against a 300 B margin (**-186**, over the cap). Two structural cuts paid for them, both of which also shrink pre-existing code:

* `onlyAdmin`'s check is now a function (`_requireAdmin`) instead of modifier-inline code at what is now four sites — **-309 B**;
* the `vault()` read + `owner()` staticcall is one function (`_vaultOwner`), shared with `stageVenue`, which raises a different error off the same authority — **-107 B**.

Net effect of the whole feature: the strategy ends up **23 B SMALLER than baseline** (515 B margin, up from 492 B), because relocating `setTargetLtv`'s body more than paid for the two new stubs. Venue absorbed 1,716 B and still holds 3,763 B.

Measured on the rebased branch against base tip `5b8cd20`, which now includes #84 and #85 — #85's own relocation of `requestRedeemImpl` into Venue is why the baseline margin is 492 B rather than the 300 B quoted earlier in this PR's history.

## Tests

`forge test --ffi --match-path "test/leveraged-aero/*.unit.t.sol"` -> **418 passed**
`forge test --ffi --match-path "test/LeveragedAeroVault.unit.t.sol"` -> **84 passed**

15 new tests. In `LeveragedAeroStrategyInit.unit.t.sol`, beside the `setTargetLtv` block (fixture: target 5000, max 6500, minHealth 12000, live CF 8800, spacing 100, width 4000, band [200, 20000]):

`setMaxLtv`
* `testSetMaxLtvPersistsAndEmits` — storage + `MaxLtvUpdated(6500, 7000)`, target untouched, legal while `Pending`
* `testSetMaxLtvRevertsForProposerAndStrangers` — `NotAdmin` for both, nothing stored
* `testSetMaxLtvRevertsBelowTheStandingTarget` — 4999 -> `TargetLtvExceedsMax`; 5000 accepted (inclusive)
* `testSetMaxLtvRevertsAtOrAboveTheCollateralFactor` — 8800 and 9000 -> `MaxLtvExceedsCF` (equality already refused)
* `testSetMaxLtvRevertsOnTheMinHealthConflictRung` — 8334 -> `MinHealthMaxLtvConflict`; 8333 accepted
* `testSetMaxLtvReadsTheCollateralFactorLive` — CF to 75%: 8000 reverts `MaxLtvExceedsCF`; CF back to 88%: the same argument clears the same rung
* `testSetMaxLtvLoweringTightensSetTargetLtv` — the band from both sides

`setWidthBounds`
* `testSetWidthBoundsPersistsAndEmits` — storage + `WidthBoundsUpdated(200, 20000, 400, 8000)`; live width and skew band untouched
* `testSetWidthBoundsRevertsForProposerAndStrangers`
* `testSetWidthBoundsRevertsOnOffGridBounds` / `...WhenMinWidthIsUnderTwoSpacings` / `...OnAnInvertedBand` / `...AboveTheTickDomain` — the four `checkBands` rungs, each with its positive control at the inclusive edge
* `testSetWidthBoundsRefusesABandExcludingTheStoredWidth` — excluded from either end reverts; the degenerate band pinned to the live width is legal

In `LeveragedAeroTwoLegLifecycle.unit.t.sol`, against a live levered book:
* `testLoweringMaxLtvBlocksDebtAddingOpsUntilTheBookDeLevers` — target 4000 + ceiling 4500 on a 5000 book: `deployIdle` reverts `UnhealthyPosition` at the post-op gate and rolls back whole, `adjustLeverage(4000)` DOWN succeeds, then the same tranche deploys
* `testLoweredMaxLtvKeepsTheKeeperFromLeveringBackUp` — the keeper's three closed doors
* `testSetWidthBoundsTightensWhatTheProposerMayRerangeTo` — a tightened band binds `rerange` immediately at both ends; inside it mints real liquidity
* `testSetWidthBoundsRefusesToStrandTheStoredWidthUntilARerange` — refused band -> proposer reranges to 6000 -> the same band change lands

Review-fix tests: `testSetMaxLtvConsumesAStaleVenueStageSoAMigrationCannotUndoTheRatchet`, `testSetTargetLtvConsumesAStaleVenueStageSoAMigrationCannotUndoTheRatchet`, `testSetWidthBoundsConsumesAStaleVenueStage`, `testMigrateAnnouncesTheCeilingAndTheWidthBandItRestores`, `testMigrateStaysQuietWhenTheCeilingAndBandAreUnchanged` (migration suite); `testLoweringMaxLtvTightensTheFastRedeemGateImmediately`, `testLoweringMaxLtvAlsoBlocksCompoundUntilTheBookDeLevers` (lifecycle suite). All 8 round-2 mutations kill at least one.

Every new test was mutation-checked (12 mutations: each ladder call dropped, the live CF read swapped for the init snapshot, each emit dropped, each persist dropped, each `onlyAdmin` dropped, and both width ladders dropped together). Each new test is killed by at least one; no existing test was weakened.

## Review fixes (commit `8f2208a`)

* **[MEDIUM] stale venue stage.** A staged hash carries a ceiling / band / target the owner picked under the policy standing AT STAGE TIME, and used to survive an admin write — so an admin ratchet-down followed by a proposer-timed `flatten` + `migrateVenue` could restore the pre-ratchet ceiling with no fresh admin signature. Both setters now consume the stage (`VenueStaged(0)`), the same thing `redeployImpl` already does for the same reason. The matching residual on the pre-existing `setTargetLtv` is **closed** — all three admin policy setters now consume an armed stage. Done by relocating `setTargetLtv`'s body to `LeveragedAeroVenue.setTargetLtvImpl` behind a one-line stub, which is *cheaper* for the strategy than keeping it inline and calling a Venue clear: the removed inline body — packed SSTORE, LOG, two revert paths — costs more than the stub, so the fix buys ~93 B of margin rather than spending any. (Both variants were measured; the inline-plus-clear alternative landed 182 B worse.)
* **[LOW] `applyVenue` silence.** It now emits `MaxLtvUpdated` / `WidthBoundsUpdated` inequality-guarded, next to `TargetLtvUpdated`. The width emit deliberately sits ABOVE the two persists — the guard reads the outgoing band.
* **[LOW] fast-redeem gate untested.** Added a three-way pin (allowed at 6500 → refused at 5100 → allowed at 5500). The reviewer's hypothesised mutant — the gate reading an init-cached ceiling — previously survived the entire suite and now dies on this test.
* **[INFO]** `compound` past a lowered ceiling is now driven directly, not only transitively; the min-width positive control now asserts the non-default half of the band so it actually witnesses the write.

Strategy on the rebased branch: **24,061 / 515 B** margin. Venue 19,097 → 20,813 (3,763 B margin). Manager and Valuation byte-identical to base.

## Note for reviewers

A sibling PR on this audit branch is concurrently adding a `minHealth x CF` rung to `checkLtvBand`. Both setters call the shared library function, so they inherit that rung automatically when the two merge — no coordination needed beyond a trivial merge. Same property in the other direction: any future rung added to `checkBands` / `checkRange` reaches `setWidthBounds` for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

