### PR TITLE
feat: remintRange — explicit-tick remint with optional leg swap

### DIFF
--- a/script/tenderly/create-vnet.sh
+++ b/script/tenderly/create-vnet.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# create-vnet.sh — create a PERSISTENT Tenderly Base-fork vnet (runbook Phase A)
+# ==============================================================================
+# Automates the one step the leveraged-aero harnesses deliberately do not do:
+# creating the persistent vnet they deploy onto (run-leveraged-aero-stack.sh is
+# reuse-only by design). Defaults follow docs/LEVERAGED_AERO_VNET_RUNBOOK.md:
+#
+#   - custom chain id 73578453 (7357-prefix convention; addresses/73578453.json
+#     and EXPECTED_CHAIN=73578453 already accommodate it)
+#   - state-sync DISABLED (constraint 3: a syncing parent re-hydrates the real
+#     Chainlink aggregators over the FreshFeed overrides and corrupts the pool
+#     TWAP ring buffer)
+#   - persistent (never auto-deleted; the delete command is printed at the end)
+#
+# Usage:
+#   ./script/tenderly/create-vnet.sh <slug> [display-name]
+#   VNET_CHAIN_ID=73578453 ./script/tenderly/create-vnet.sh mamo-remint-range
+#
+# Prints the Admin RPC (ops-only — never share), Public RPC, vnet id and fork
+# block. Writes nothing: the stack harness owns leveraged-aero-vnet.json.
+#
+# Requires: curl, jq, cast, and TENDERLY_ACCESS_KEY + account/project slugs in .env.
+# ==============================================================================
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT"
+RESULTS="${HARNESS_RESULTS:-$SCRIPT_DIR/create-vnet.log}"
+: > "$RESULTS"
+KEEP_VNET=1
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+SLUG="${1:?usage: create-vnet.sh <slug> [display-name]}"
+DISPLAY="${2:-$SLUG}"
+VNET_CHAIN_ID="${VNET_CHAIN_ID:-73578453}"
+
+[ -f .env ] && { set -a; . ./.env; set +a; }
+_derive_tenderly_slugs
+{ [ -n "${TENDERLY_ACCESS_KEY:-}" ] && [ -n "${TENDERLY_ACCOUNT_SLUG:-}" ] && [ -n "${TENDERLY_PROJECT_SLUG:-}" ]; } \
+  || die "need TENDERLY_ACCESS_KEY (+ TENDERLY_ACCOUNT_SLUG/TENDERLY_PROJECT_SLUG) in .env"
+
+section "Create persistent Base-fork vnet '$SLUG' (chainId $VNET_CHAIN_ID, state-sync OFF)"
+resp="$(curl -s -X POST "$TENDERLY_API/account/$TENDERLY_ACCOUNT_SLUG/project/$TENDERLY_PROJECT_SLUG/vnets" \
+  -H "X-Access-Key: $TENDERLY_ACCESS_KEY" -H "Content-Type: application/json" -H "Accept: application/json" \
+  -d "{\"slug\":\"$SLUG\",\"display_name\":\"$DISPLAY\",\"fork_config\":{\"network_id\":8453},\"virtual_network_config\":{\"chain_config\":{\"chain_id\":$VNET_CHAIN_ID}},\"sync_state_config\":{\"enabled\":false},\"explorer_page_config\":{\"enabled\":true,\"verification_visibility\":\"src\"}}")"
+VNET_ID="$(echo "$resp" | jq -r '.id // empty')"
+ADMIN_RPC="$(echo "$resp" | jq -r '.rpcs[]? | select(.name=="Admin RPC") | .url')"
+PUBLIC_RPC="$(echo "$resp" | jq -r '.rpcs[]? | select(.name=="Public RPC") | .url')"
+[ -n "$ADMIN_RPC" ] && [ -n "$VNET_ID" ] || die "vnet create failed: $resp"
+
+CID="$(cast chain-id --rpc-url "$ADMIN_RPC" 2>/dev/null)"
+[ "$CID" = "$VNET_CHAIN_ID" ] || die "expected chainId $VNET_CHAIN_ID, got '$CID'"
+BLOCK="$(cast block-number --rpc-url "$ADMIN_RPC" 2>/dev/null)"
+
+section "Summary — vnet '$SLUG' is LIVE (persistent)"
+info "Vnet id    : $VNET_ID"
+info "Chain id   : $CID (fork of Base @ block $BLOCK)"
+info "Admin RPC  : $ADMIN_RPC   (ops-only — cheatcodes; never share)"
+info "Public RPC : $PUBLIC_RPC"
+info "Explorer   : https://dashboard.tenderly.co/$TENDERLY_ACCOUNT_SLUG/$TENDERLY_PROJECT_SLUG/testnet/$VNET_ID"
+info "Delete     : curl -X DELETE $TENDERLY_API/account/$TENDERLY_ACCOUNT_SLUG/project/$TENDERLY_PROJECT_SLUG/vnets/$VNET_ID -H \"X-Access-Key: \$TENDERLY_ACCESS_KEY\""
+info "Next       : TENDERLY_VNET_RPC_URL=$ADMIN_RPC EXPECTED_CHAIN=$CID ./script/tenderly/run-leveraged-aero-stack.sh"

--- a/script/tenderly/remint-range-cycle.sh
+++ b/script/tenderly/remint-range-cycle.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+# remint-range-cycle.sh — drive `remintRange` (explicit-tick remint + optional leg swap) on the
+# leveraged-aero Tenderly vnet, as the proposer.
+#
+# `remintRange` is the placement primitive the rebalancer's d4/2 strategy uses: explicit ticks
+# (width-band-bounded, the SKEW band deliberately does not apply) plus an optional swap of part of
+# the inventory the unwind collects, so the mint can be two-sided at a band spot has left. The swap
+# is bounded by max(minSwapOut, Chainlink cross-rate − maxSlippageBps) — `scenarios` proves both
+# halves: the happy paths AND that `minSwapOut = 0` still reverts on a pool price away from oracle.
+#
+# Usage:
+#   ./remint-range-cycle.sh book                                    # position + inventory snapshot
+#   ./remint-range-cycle.sh remint <tickLo> <tickHi> <zeroForOne> <swapBps> [minSwapOut] [minLiq]
+#   ./remint-range-cycle.sh remint-expect-revert <same args>        # zero-side-effect eth_call probe
+#   ./remint-range-cycle.sh scenarios                               # canned suite (see below)
+#
+# `scenarios` mutates the book (real remints) and the pool (a move-pool round-trip for the floor
+# leg, via compound-cycle.sh) — run it on an instance where that is acceptable. It ends by
+# re-minting a centred band at the restored spot, so the book is left ordinary.
+#
+# RPC: LEVERAGED_AERO_ADMIN_RPC_URL, falling back to TENDERLY_VNET_RPC_URL (same rule and same
+# caveat as compound-cycle.sh: set it explicitly, the .env values may point at a different vnet).
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+CFG="$HERE/leveraged-aero-vnet.json"
+CYCLE="$HERE/compound-cycle.sh"
+
+[[ -f "$ROOT/.env" ]] && set -a && . "$ROOT/.env" && set +a
+RPC="${LEVERAGED_AERO_ADMIN_RPC_URL:-${TENDERLY_VNET_RPC_URL:?set LEVERAGED_AERO_ADMIN_RPC_URL (admin RPC) or TENDERLY_VNET_RPC_URL}}"
+
+eval "$(python3 - "$CFG" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(f'STRAT="{d["pooled"]["strategyClone"]}"')
+print(f'POOL="{d["pooled"]["lpPool"]}"')
+print(f'PROPOSER="{d["pooled"]["proposer"]}"')
+print(f'USDC="{d["usdc"]}"')
+PY
+)"
+
+# NB: identical to compound-cycle.sh — 51 fields, 1-based `lay N`; that header's warning applies.
+LAYOUT_SIG='layout()((address,address,address,address,address,address,address,address,address,address,address,uint256,uint256,uint16,uint32,address,address,address,address,int24,uint16,uint16,uint16,uint16,uint16,uint256,int24,int24,uint16,uint16,address,uint256,uint256,address,uint256,uint8,uint8,bool,bool,int24,int24,uint24,uint24,uint24,bool,uint16,uint16,uint16,uint128,uint128,bytes32))'
+
+c() { cast call --rpc-url "$RPC" "$@" 2>/dev/null; }
+num() { echo "${1%% *}"; }
+lay() { c "$STRAT" "$LAYOUT_SIG" | tr ',' '\n' | sed -n "${1}p" | tr -d ' ()' | sed 's/\[.*//'; }
+spot_tick() { num "$(c "$POOL" 'slot0()(uint160,int24,uint16,uint16,uint16,bool)' | sed -n 2p)"; }
+align() { python3 -c "t=$1; s=$2; r=t % s; r += s if r < 0 else 0; print(t - r)"; }
+
+PASS=0; FAIL=0
+check() { # check <label> <cond-as-python-bool-expr>
+  if python3 -c "import sys; sys.exit(0 if ($2) else 1)"; then
+    echo "  ✓ $1"; PASS=$((PASS+1))
+  else
+    echo "  ✗ $1  [$2]"; FAIL=$((FAIL+1))
+  fi
+}
+
+cmd_book() {
+  local t0 t1 s0 s1
+  t0="$(c "$POOL" 'token0()(address)')"; t1="$(c "$POOL" 'token1()(address)')"
+  s0="$(c "$t0" 'symbol()(string)' | tr -d '"')"; s1="$(c "$t1" 'symbol()(string)' | tr -d '"')"
+  echo "strategy   $STRAT   proposer $PROPOSER"
+  echo "pool       $POOL   token0 $s0  token1 $s1"
+  echo "spot tick  $(spot_tick)   tickSpacing $(lay 20)"
+  echo "position   tokenId $(lay 26)   ticks [$(lay 27), $(lay 28)]   width $(lay 42) (band [$(lay 43), $(lay 44)])   skewBps $(lay 46)"
+  echo "nav        $(num "$(c "$STRAT" 'nav()(uint256)')")"
+  echo "idle       $s0 $(num "$(c "$t0" 'balanceOf(address)(uint256)' "$STRAT")")   $s1 $(num "$(c "$t1" 'balanceOf(address)(uint256)' "$STRAT")")"
+}
+
+cmd_remint() {
+  local lo="$1" hi="$2" z0="$3" bps="$4" minOut="${5:-0}" minLiq="${6:-1}" out
+  echo "remintRange($lo, $hi, $z0, $bps, $minOut, $minLiq) as proposer $PROPOSER"
+  out="$(cast send "$STRAT" 'remintRange(int24,int24,bool,uint16,uint256,uint256)' \
+        "$lo" "$hi" "$z0" "$bps" "$minOut" "$minLiq" \
+        --from "$PROPOSER" --unlocked --gas-limit 14000000 --rpc-url "$RPC" --json 2>&1)"
+  echo "$out" | python3 -c '
+import json,sys
+raw=sys.stdin.read(); i=raw.find("{")
+d=json.loads(raw[i:]) if i>=0 else {}
+ok = d.get("status")=="0x1"
+print("  tx",d.get("transactionHash"),"status",d.get("status"),"gas",int(d.get("gasUsed","0x0"),16))
+sys.exit(0 if ok else 1)
+' || { echo "  REVERT — raw:"; echo "$out" | tail -5; return 1; }
+}
+
+cmd_remint_expect_revert() {
+  local lo="$1" hi="$2" z0="$3" bps="$4" minOut="${5:-0}" minLiq="${6:-1}" out sel
+  echo "remintRange($lo, $hi, $z0, $bps, $minOut, $minLiq) — expecting a revert (eth_call, no state)"
+  out="$(cast call "$STRAT" 'remintRange(int24,int24,bool,uint16,uint256,uint256)' \
+        "$lo" "$hi" "$z0" "$bps" "$minOut" "$minLiq" --from "$PROPOSER" --rpc-url "$RPC" 2>&1)"
+  if [[ "$out" != *"error"* && "$out" != *"revert"* && "$out" != *"Revert"* ]]; then
+    echo "  DID NOT REVERT: $out"; return 1
+  fi
+  echo "$out" | tail -2 | sed 's/^/  /'
+  sel="$(echo "$out" | grep -oE '0x[0-9a-f]{8}' | head -1)"; [[ -n "$sel" ]] && echo "  selector $sel"
+  return 0
+}
+
+# ── the canned suite ─────────────────────────────────────────────────────────────────────────────
+cmd_scenarios() {
+  local spacing width spot lo hi tid0 tid1 nav0 nav1 t0 t1 idle0 oob
+  spacing="$(lay 20)"; width="$(lay 42)"
+  t0="$(c "$POOL" 'token0()(address)')"; t1="$(c "$POOL" 'token1()(address)')"
+  oob="$(cast sig 'OutOfBounds()')"
+
+  echo "══ S0 — book before"; cmd_book; echo
+
+  echo "══ S1 — parity: centred explicit band, swapBps=0 (rerange-equivalent placement)"
+  spot="$(spot_tick)"; lo="$(align $((spot - width / 2)) "$spacing")"; hi=$((lo + width))
+  tid0="$(lay 26)"; nav0="$(num "$(c "$STRAT" 'nav()(uint256)')")"
+  cmd_remint "$lo" "$hi" false 0 0 1 || { FAIL=$((FAIL+1)); echo "S1 send failed"; }
+  tid1="$(lay 26)"; nav1="$(num "$(c "$STRAT" 'nav()(uint256)')")"
+  check "S1 new tokenId minted"            "$tid1 != $tid0 and $tid1 > 0"
+  check "S1 ticks persisted as requested"  "$(lay 27) == $lo and $(lay 28) == $hi"
+  check "S1 width persisted"               "$(lay 42) == $hi - $lo"
+  check "S1 nav conserved within 1%"       "abs($nav1 - $nav0) <= $nav0 // 100"
+  echo
+
+  echo "══ S2 — partial swap 25% token0→token1, centred band"
+  spot="$(spot_tick)"; lo="$(align $((spot - width / 2)) "$spacing")"; hi=$((lo + width))
+  tid0="$tid1"; nav0="$nav1"
+  cmd_remint "$lo" "$hi" true 2500 0 1 || { FAIL=$((FAIL+1)); echo "S2 send failed"; }
+  tid1="$(lay 26)"; nav1="$(num "$(c "$STRAT" 'nav()(uint256)')")"
+  check "S2 new tokenId minted"      "$tid1 != $tid0 and $tid1 > 0"
+  check "S2 nav conserved within 1%" "abs($nav1 - $nav0) <= $nav0 // 100"
+  echo
+
+  echo "══ S3 — partial swap 25% token1→token0, centred band"
+  spot="$(spot_tick)"; lo="$(align $((spot - width / 2)) "$spacing")"; hi=$((lo + width))
+  tid0="$tid1"; nav0="$nav1"
+  cmd_remint "$lo" "$hi" false 2500 0 1 || { FAIL=$((FAIL+1)); echo "S3 send failed"; }
+  tid1="$(lay 26)"; nav1="$(num "$(c "$STRAT" 'nav()(uint256)')")"
+  check "S3 new tokenId minted"      "$tid1 != $tid0 and $tid1 > 0"
+  check "S3 nav conserved within 1%" "abs($nav1 - $nav0) <= $nav0 // 100"
+  echo
+
+  echo "══ S4 — full-notional (10000) token0→token1, band wholly BELOW spot (one-sided, skew-band-free)"
+  # All collected token0 is sold, so the mint is token1-only — legal only at/below spot. The
+  # F05 guard: pre-existing idle token0 must NOT be drawn into the sale (balance can only grow).
+  spot="$(spot_tick)"; hi="$(align "$spot" "$spacing")"; lo=$((hi - width))
+  tid0="$tid1"; nav0="$nav1"; idle0="$(num "$(c "$t0" 'balanceOf(address)(uint256)' "$STRAT")")"
+  cmd_remint "$lo" "$hi" true 10000 0 1 || { FAIL=$((FAIL+1)); echo "S4 send failed"; }
+  tid1="$(lay 26)"; nav1="$(num "$(c "$STRAT" 'nav()(uint256)')")"
+  check "S4 new tokenId minted"          "$tid1 != $tid0 and $tid1 > 0"
+  check "S4 one-sided ticks persisted"   "$(lay 27) == $lo and $(lay 28) == $hi"
+  check "S4 idle token0 not drawn (F05)" "$(num "$(c "$t0" 'balanceOf(address)(uint256)' "$STRAT")") >= $idle0"
+  check "S4 nav conserved within 1%"     "abs($nav1 - $nav0) <= $nav0 // 100"
+  echo
+
+  echo "══ S5 — recentre two-sided with a 50% token1→token0 swap (the d4/2 shape)"
+  spot="$(spot_tick)"; lo="$(align $((spot - width / 2)) "$spacing")"; hi=$((lo + width))
+  tid0="$tid1"; nav0="$nav1"
+  cmd_remint "$lo" "$hi" false 5000 0 1 || { FAIL=$((FAIL+1)); echo "S5 send failed"; }
+  tid1="$(lay 26)"; nav1="$(num "$(c "$STRAT" 'nav()(uint256)')")"
+  check "S5 new tokenId minted"          "$tid1 != $tid0 and $tid1 > 0"
+  check "S5 spot inside the new band"    "$(lay 27) <= $(spot_tick) < $(lay 28)"
+  check "S5 nav conserved within 1%"     "abs($nav1 - $nav0) <= $nav0 // 100"
+  echo
+
+  echo "══ S6 — validation probes (zero-side-effect eth_calls; all must revert)"
+  spot="$(spot_tick)"; lo="$(align $((spot - width / 2)) "$spacing")"; hi=$((lo + width))
+  local minw maxw
+  minw="$(lay 43)"; maxw="$(lay 44)"
+  cmd_remint_expect_revert $((lo + 1)) "$hi" false 0 0 1        && check "S6 misaligned tickLower reverts" "True" || check "S6 misaligned tickLower reverts" "False"
+  cmd_remint_expect_revert "$hi" "$lo" false 0 0 1              && check "S6 inverted ticks revert" "True" || check "S6 inverted ticks revert" "False"
+  cmd_remint_expect_revert "$lo" $((lo + minw - spacing)) false 0 0 1 && check "S6 width below band reverts" "True" || check "S6 width below band reverts" "False"
+  cmd_remint_expect_revert "$lo" $((lo + maxw + spacing)) false 0 0 1 && check "S6 width above band reverts" "True" || check "S6 width above band reverts" "False"
+  cmd_remint_expect_revert "$lo" "$hi" false 10001 0 1          && check "S6 swapBps > 10000 reverts" "True" || check "S6 swapBps > 10000 reverts" "False"
+  local nonprop_out
+  nonprop_out="$(cast call "$STRAT" 'remintRange(int24,int24,bool,uint16,uint256,uint256)' "$lo" "$hi" false 0 0 1 \
+                 --from 0x000000000000000000000000000000000000dEaD --rpc-url "$RPC" 2>&1)"
+  [[ "$nonprop_out" == *"error"* || "$nonprop_out" == *"evert"* ]] \
+    && check "S6 non-proposer caller reverts" "True" || check "S6 non-proposer caller reverts" "False"
+  echo "  (expected selector for the band/bps probes: OutOfBounds() = $oob)"
+  echo
+
+  echo "══ S7 — oracle floor: pool moved −500 ticks off the (unchanged) feeds, minSwapOut=0 must still revert"
+  local twap t_orig
+  twap="$(num "$(lay 15)")"; t_orig="$(spot_tick)"
+  "$CYCLE" move-pool $((t_orig - 500)) || { FAIL=$((FAIL+1)); echo "move-pool failed"; }
+  "$CYCLE" warp $((twap + 60)) >/dev/null || { FAIL=$((FAIL+1)); echo "warp failed"; }
+  "$CYCLE" calm | tail -2
+  spot="$(spot_tick)"; lo="$(align $((spot - width / 2)) "$spacing")"; hi=$((lo + width))
+  # tick DOWN = token1 RICHER on the pool than at the (unchanged) Chainlink cross rate. Selling
+  # token0 INTO the overpriced leg under-fills the always-on floor → must revert at minSwapOut=0;
+  # selling token1 WITH the divergence over-fills it → must pass. The floor is directional.
+  cmd_remint_expect_revert "$lo" "$hi" true 5000 0 1 \
+    && check "S7 floor blocks minSwapOut=0 selling INTO the divergence" "True" \
+    || check "S7 floor blocks minSwapOut=0 selling INTO the divergence" "False"
+  local with_out
+  with_out="$(cast call "$STRAT" 'remintRange(int24,int24,bool,uint16,uint256,uint256)' "$lo" "$hi" false 5000 0 1 \
+              --from "$PROPOSER" --rpc-url "$RPC" 2>&1)"
+  [[ "$with_out" != *"error"* && "$with_out" != *"evert"* ]] \
+    && check "S7 selling WITH the divergence still passes (floor is directional)" "True" \
+    || check "S7 selling WITH the divergence still passes (floor is directional)" "False"
+  echo "  restoring pool to tick $t_orig"
+  "$CYCLE" move-pool "$t_orig" >/dev/null || { FAIL=$((FAIL+1)); echo "restore move-pool failed"; }
+  "$CYCLE" warp $((twap + 60)) >/dev/null || { FAIL=$((FAIL+1)); echo "restore warp failed"; }
+  "$CYCLE" calm | tail -2
+  echo
+
+  echo "══ S8 — leave the book ordinary: centred remint at the restored spot, swapBps=0"
+  spot="$(spot_tick)"; lo="$(align $((spot - width / 2)) "$spacing")"; hi=$((lo + width))
+  nav0="$nav1"
+  cmd_remint "$lo" "$hi" false 0 0 1 || { FAIL=$((FAIL+1)); echo "S8 send failed"; }
+  nav1="$(num "$(c "$STRAT" 'nav()(uint256)')")"
+  check "S8 spot inside the final band" "$(lay 27) <= $(spot_tick) < $(lay 28)"
+  check "S8 nav conserved within 1%"    "abs($nav1 - $nav0) <= $nav0 // 100"
+  echo; echo "══ book after"; cmd_book
+
+  echo; echo "════ scenarios: $PASS passed, $FAIL failed ════"
+  [[ "$FAIL" == 0 ]]
+}
+
+case "${1:-}" in
+  book)                 cmd_book ;;
+  remint)               shift; cmd_remint "$@" ;;
+  remint-expect-revert) shift; cmd_remint_expect_revert "$@" ;;
+  scenarios)            cmd_scenarios ;;
+  *) sed -n '3,22p' "$0"; exit 2 ;;
+esac

--- a/src/leveraged-aero/LeveragedAeroManager.sol
+++ b/src/leveraged-aero/LeveragedAeroManager.sol
@@ -504,21 +504,9 @@ library LeveragedAeroManager {
         Layout storage $ = _layout();
         if ($.tokenId == 0) return; // flat book — nothing to re-range (width/skew already stored)
 
-        // 1. Calm-gate BEFORE touching the pool — never recenter at a manipulated tick.
-        LeveragedAeroValuation.calmGate($.pool, $.twapWindow, $.calmDeviationTicks);
-
-        // 2. Unstake + remove 100% liquidity + collect (num==den → no restake). The old NFT is
-        //    left empty + unstaked; a recenter needs a fresh range == fresh tokenId.
-        //    ASSET-MODE: snapshot leg B BEFORE the unwind (as `redeemUnwindImpl` does `idleUsdcBefore`) —
-        //    it IS the unit of account there, so its raw balance is idle deposits, not what this op
-        //    collected; only the DELTA is this op's own principal. Zero in the two-borrowed-legs shape.
-        uint256 legBBefore = $.legBIsAsset ? IERC20($.cbBTC).balanceOf(address(this)) : 0;
-        _unwindLiquidity(1, 1);
-
-        // 3. SIZE FIRST: the legs THIS op collected — full leg A, leg B net of the pre-unwind snapshot.
-        //    Raw balances would let unlevered idle USDC count as a populated side in asset-mode (F05).
-        (uint256 amt0, uint256 amt1) =
-            _amounts01(IERC20($.cbBTC).balanceOf(address(this)) - legBBefore, IERC20($.weth).balanceOf(address(this)));
+        // 1-3. Calm-gate, snapshot leg B, unwind 100% + collect, size — shared with `remintRangeImpl`.
+        (, uint256 cbAmt, uint256 wethAmt) = _calmUnwindAll();
+        (uint256 amt0, uint256 amt1) = _amounts01(cbAmt, wethAmt);
 
         // 4. Derive the range from the stored width/skew AND what the unwind collected: two-sided → the
         //    ordinary skewed band around spot; ONE-SIDED → a band wholly on the populated side, the only
@@ -538,6 +526,82 @@ library LeveragedAeroManager {
 
         // 7. Debt + collateral untouched by rerange → health preserved; assert as a belt.
         _assertHealthy();
+    }
+
+    /// @notice Body of the strategy's `remintRange`: the shared re-range prologue → an optional `swapBps`
+    ///         swap between the legs → mint at `[tickLower, tickUpper]` → restake → assert health. At
+    ///         `swapBps == 0` this IS `rerangeImpl` at a caller-chosen band. Params: see `remintRange`.
+    function remintRangeImpl(
+        int24 tickLower,
+        int24 tickUpper,
+        bool zeroForOne,
+        uint16 swapBps,
+        uint256 minSwapOut,
+        uint256 minLiquidity
+    ) public {
+        Layout storage $ = _layout();
+        // DELIBERATE DEVIATION from `rerangeImpl`'s silent flat-book return: that exists to persist
+        // width/skew, and here there is nothing to persist — a silent success would mislead the keeper.
+        if ($.tokenId == 0) revert LeveragedAeroValuation.NothingToRerange();
+
+        (uint256 legBBefore, uint256 cbAmt, uint256 wethAmt) = _calmUnwindAll();
+
+        // `zeroForOne` is POOL order, so the input is leg A exactly when it agrees with `wethIsToken0`.
+        if (swapBps != 0) {
+            bool inIsLegA = zeroForOne == $.wethIsToken0;
+            _remintSwap(zeroForOne, inIsLegA, (inIsLegA ? wethAmt : cbAmt) * uint256(swapBps) / 10000, minSwapOut);
+            // The output landed in the balance and IS this op's inventory, so the same snapshot rule
+            // re-derives both legs — this is how the swap feeds the mint.
+            (cbAmt, wethAmt) = _collectedLegs(legBBefore);
+        }
+
+        _mintAndStake(cbAmt, wethAmt, tickLower, tickUpper, minLiquidity);
+
+        // `width` IS rewritten — `setWidthBounds` / venue migration re-check the STORED width, and the span
+        // was validated in-band. `skewBps` stays UNTOUCHED: explicit ticks carry no skew, and the stored
+        // value remains inside its init-frozen band for later `checkRange` calls.
+        $.width = uint24(uint256(int256(tickUpper - tickLower)));
+        _assertHealthy(); // debt + collateral untouched ⇒ health preserved; belt only
+    }
+
+    /// @dev Sell `amountIn` of one LP leg into the other at `max(minOut, oracle cross rate − slippage)`.
+    ///      The swap venue's tickSpacing is the LP POOL's — the legA/legB pair IS that pool — NOT
+    ///      `_legSwapSpacing`, which serves the leg↔USDC pools. Prices come off the SHARED
+    ///      `_readAllPrices` bundle, so this fails closed on a stale feed exactly as the debt/health/sweep
+    ///      paths do. `amountIn == 0` is a clean no-op.
+    function _remintSwap(bool zeroForOne, bool inIsLegA, uint256 amountIn, uint256 minOut) private {
+        if (amountIn == 0) return;
+        Layout storage $ = _layout();
+        (uint256 pB, uint256 pA,) = _readAllPrices();
+        (uint256 pIn, uint256 pOut) = inIsLegA ? (pA, pB) : (pB, pA);
+        (uint8 decIn, uint8 decOut) = inIsLegA ? ($.wethDecimals, $.cbBTCDecimals) : ($.cbBTCDecimals, $.wethDecimals);
+        uint256 floor =
+            LeveragedAeroValuation.legSwapFloor(amountIn, decIn, pIn, decOut, pOut, uint256($.maxSlippageBps), minOut);
+        (address tok0, address tok1) = _tokens01();
+        (address tokenIn, address tokenOut) = zeroForOne ? (tok0, tok1) : (tok1, tok0);
+        LeveragedAeroValuation.swapExactIn($.swapRouter, tokenIn, tokenOut, $.tickSpacing, amountIn, floor);
+    }
+
+    /// @dev The shared re-range prologue: calm-gate BEFORE touching the pool (never recenter, or swap, at a
+    ///      manipulated tick) → snapshot leg B → unstake + remove 100% liquidity + collect (num==den ⇒ no
+    ///      restake; a fresh range needs a fresh tokenId) → size. `legBBefore` is returned so
+    ///      `remintRangeImpl` can re-derive the legs against the same snapshot after its swap.
+    function _calmUnwindAll() private returns (uint256 legBBefore, uint256 cbAmt, uint256 wethAmt) {
+        Layout storage $ = _layout();
+        LeveragedAeroValuation.calmGate($.pool, $.twapWindow, $.calmDeviationTicks);
+        // ASSET-MODE (F05): leg B IS the unit of account, so its raw balance is idle deposits and the
+        // redeem-cover float — only the DELTA across the unwind is this op's own principal (as
+        // `redeemUnwindImpl` does with `idleUsdcBefore`). Zero in the two-borrowed-legs shape.
+        legBBefore = $.legBIsAsset ? IERC20($.cbBTC).balanceOf(address(this)) : 0;
+        _unwindLiquidity(1, 1);
+        (cbAmt, wethAmt) = _collectedLegs(legBBefore);
+    }
+
+    /// @dev What the unwind collected, in LEG order: leg B NET of the snapshot, and the FULL leg A balance —
+    ///      a pre-existing idle leg A is a previous rerange's remainder, deliberately folded back in.
+    function _collectedLegs(uint256 legBBefore) private view returns (uint256 cbAmt, uint256 wethAmt) {
+        Layout storage $ = _layout();
+        return (IERC20($.cbBTC).balanceOf(address(this)) - legBBefore, IERC20($.weth).balanceOf(address(this)));
     }
 
     /// @notice Retarget the position's LTV to `targetLtvBps_` (body of the strategy's `adjustLeverage`,

--- a/src/leveraged-aero/LeveragedAeroValuation.sol
+++ b/src/leveraged-aero/LeveragedAeroValuation.sol
@@ -402,6 +402,26 @@ library LeveragedAeroValuation {
         if (lowerSpan < spacing || upperSpan < spacing) revert OutOfBounds();
     }
 
+    /// @notice `checkRange`'s twin for an EXPLICIT `(tickLower, tickUpper)`: on the grid, ordered, inside
+    ///         the aligned tick domain, span inside `[minWidth_, maxWidth_]`.
+    /// @dev The SKEW band deliberately does NOT apply — explicit placement IS the feature, and a skew only
+    ///      means anything for a band derived from spot. The width band still bounds the proposer.
+    function checkExplicitRange(
+        int24 tickLower,
+        int24 tickUpper,
+        int24 tickSpacing_,
+        uint24 minWidth_,
+        uint24 maxWidth_
+    ) public pure {
+        if (tickSpacing_ <= 0) revert OutOfBounds();
+        if (tickLower % tickSpacing_ != 0 || tickUpper % tickSpacing_ != 0) revert OutOfBounds();
+        if (tickLower >= tickUpper) revert OutOfBounds();
+        int24 maxAligned = _alignTick(TickMath.MAX_TICK, tickSpacing_);
+        if (tickLower < -maxAligned || tickUpper > maxAligned) revert OutOfBounds();
+        uint24 w = uint24(uint256(int256(tickUpper - tickLower)));
+        if (w < minWidth_ || w > maxWidth_) revert OutOfBounds();
+    }
+
     /// @notice The tickSpacing-aligned range around `pool`'s current tick, SKEWED by `skewBps`: that
     ///         fraction of `width` (1e4 scale) is placed BELOW the current tick and the EXACT COMPLEMENT
     ///         above, so 5000 is centred and 3500 puts 35% of the width below spot.
@@ -1199,6 +1219,26 @@ library LeveragedAeroValuation {
         if (wethAmt > 0) {
             wethFloor = _usdcValue(wethAmt, c.wethDecimals, _readUsd8(c, c.wethFeed), pUsdc) * (10000 - slipBps) / 10000;
         }
+    }
+
+    /// @notice The min-out a LEG↔LEG swap must clear (`LeveragedAeroManager.remintRangeImpl`):
+    ///         `max(minOut, amountIn at the two legs' Chainlink CROSS rate × (1 − slipBps))`. Pure — the
+    ///         caller supplies the hardened prices, as `coverBounds` does.
+    /// @dev THE ORACLE HALF IS LOAD-BEARING: `remintRange` is the only path that swaps PRINCIPAL between
+    ///      the legs under the PROPOSER key, so a `minOut` of 0 must still bound the fill.
+    /// @param slipBps `maxSlippageBps`; bounded to (0, 1000] at init so `10000 - slipBps` can't underflow.
+    function legSwapFloor(
+        uint256 amountIn,
+        uint8 decIn,
+        uint256 pIn,
+        uint8 decOut,
+        uint256 pOut,
+        uint256 slipBps,
+        uint256 minOut
+    ) public pure returns (uint256) {
+        uint256 usd8 = Math.mulDiv(amountIn, pIn, 10 ** uint256(decIn));
+        uint256 fl = Math.mulDiv(usd8, 10 ** uint256(decOut), pOut) * (10000 - slipBps) / 10000;
+        return fl > minOut ? fl : minOut;
     }
 
     /// @dev Spot-vs-TWAP calm-gate (fail-closed). Reverts `CalmGateBreached` when the pool

--- a/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
+++ b/src/leveraged-aero/LeveragedAerodromeCLStrategy.sol
@@ -986,6 +986,34 @@ contract LeveragedAerodromeCLStrategy is BaseStrategy, ReentrancyGuardTransient,
         LeveragedAeroManager.rerangeImpl(minLiq0, minLiq1);
     }
 
+    /// @notice Re-mint the CL position at EXPLICIT ticks with an OPTIONAL partial swap between the LP legs,
+    ///         via `LeveragedAeroManager.remintRangeImpl()`. Where `rerange` derives its band from
+    ///         `(width, skew)` around spot and swaps nothing, this takes the band and may move part of the
+    ///         collected inventory ACROSS the legs, so the mint can be balanced at a range spot has left.
+    ///         Calm-gated FIRST; debt + collateral untouched. NO fee crystallisation, for `rerange`'s reason:
+    ///         neither supply nor NAV changes, so the fee defers and the HWM is unaffected.
+    /// @param tickUpper  `tickUpper - tickLower` must land inside `[minWidth, maxWidth]`; the SKEW band does
+    ///                   NOT apply, and the validated span is PERSISTED as `width` (`skewBps` untouched).
+    /// @param zeroForOne Swap direction in POOL TOKEN ORDER (true = token0 → token1).
+    /// @param swapBps    Fraction of the collected input side to swap, 1e4 scale; 10000 is a one-sided mint.
+    /// @param minSwapOut May only TIGHTEN the always-on Chainlink cross-rate floor, so `0` is safe.
+    /// @param minLiquidity Minimum CL liquidity, in liquidity units — a swap makes `rerange`'s two per-amount
+    ///                   floors a moving target.
+    function remintRange(
+        int24 tickLower,
+        int24 tickUpper,
+        bool zeroForOne,
+        uint16 swapBps,
+        uint256 minSwapOut,
+        uint256 minLiquidity
+    ) external onlyProposer nonReentrant {
+        if (_state != State.Executed) revert NotExecuted();
+        Layout storage $ = _layout();
+        LeveragedAeroValuation.checkExplicitRange(tickLower, tickUpper, $.tickSpacing, $.minWidth, $.maxWidth);
+        if (swapBps > 10000) revert OutOfBounds();
+        LeveragedAeroManager.remintRangeImpl(tickLower, tickUpper, zeroForOne, swapBps, minSwapOut, minLiquidity);
+    }
+
     /// @notice ADMIN-ONLY POLICY: set the fund's STANDING target LTV, in EITHER direction. Only the admin can
     ///         RAISE it, which is the point of `onlyAdmin`: a compromised rebalancer key can rebalance and
     ///         de-lever, but cannot lever the fund up toward the cap. Sets policy ONLY — the next `execute` /

--- a/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroAssetModeLifecycle.unit.t.sol
@@ -531,6 +531,74 @@ contract LeveragedAeroAssetModeLifecycleUnitTest is Test {
         assertGt(npm.liquidityOf(strategy.layout().tokenId), 0, "the recenter still minted real liquidity");
     }
 
+    // ============ REMINT RANGE MUST NOT DRAW IDLE USDC EITHER (F05, asset-mode) ============
+    // The new hazard `remintRange` adds over `rerange` is the SWAP: it is sized off the collected inventory,
+    // and in asset-mode leg B (USDC) is also user deposits. Both the swap sizing AND the mint must ignore them.
+
+    /// @dev The centred band this fixture's `rerange` would derive — used as the explicit band below.
+    int24 internal constant REMINT_LOWER = TICK - int24(uint24(WIDTH)) / 2;
+    int24 internal constant REMINT_UPPER = TICK + int24(uint24(WIDTH)) / 2;
+
+    /// @dev `zeroForOne == true` sells token0, which IS the unit of account here (USDC is token0) — the
+    ///      leaking shape. A pre-existing idle balance must change the outcome by EXACTLY itself.
+    function testRemintRangeSwapDoesNotDrawIdleUsdc() public {
+        _execute(SEED);
+
+        uint256 snap = vm.snapshotState();
+        vm.prank(proposer);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, true, 5000, 0, 0);
+        uint256 baselineIdle = usdc.balanceOf(address(strategy));
+        uint256 baselineLegABought = router.boughtOf(address(legA));
+        vm.revertToState(snap);
+        assertGt(baselineLegABought, 0, "the baseline actually swapped, or the equality below is vacuous");
+
+        uint256 idleSeed = 400_000e6;
+        usdc.mint(address(strategy), idleSeed);
+        uint256 tokenIdBefore = strategy.layout().tokenId;
+
+        vm.prank(proposer);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, true, 5000, 0, 0);
+
+        assertEq(
+            usdc.balanceOf(address(strategy)),
+            baselineIdle + idleSeed,
+            "the idle USDC was neither swapped nor drawn into the LP"
+        );
+        assertEq(
+            router.boughtOf(address(legA)),
+            baselineLegABought,
+            "the swap was sized off the COLLECTED USDC only, not the raw balance"
+        );
+        assertTrue(strategy.layout().tokenId != tokenIdBefore, "the re-mint still minted a fresh position");
+        assertGt(npm.liquidityOf(strategy.layout().tokenId), 0, "...with real liquidity in it");
+    }
+
+    /// @dev The mirror direction (selling leg A INTO the unit of account) adds USDC to the balance. Only that
+    ///      swap output may reach the mint — the reservation still holds off the PRE-unwind snapshot.
+    function testRemintRangeSwapIntoTheAssetLegStillReservesIdleUsdc() public {
+        _execute(SEED);
+
+        uint256 snap = vm.snapshotState();
+        vm.prank(proposer);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, false, 5000, 0, 0);
+        uint256 baselineIdle = usdc.balanceOf(address(strategy));
+        vm.revertToState(snap);
+
+        uint256 idleSeed = 250_000e6;
+        usdc.mint(address(strategy), idleSeed);
+
+        vm.prank(proposer);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, false, 5000, 0, 0);
+
+        assertEq(
+            usdc.balanceOf(address(strategy)),
+            baselineIdle + idleSeed,
+            "idle USDC untouched: only the swap's own output fed the mint"
+        );
+        assertGt(router.boughtOf(address(usdc)), 0, "a leg-A -> USDC swap really ran");
+        assertGt(npm.liquidityOf(strategy.layout().tokenId), 0, "the re-mint minted real liquidity");
+    }
+
     // ============ RERANGE WITH SPOT OUTSIDE THE BAND: THE ONE-SIDED REOPEN (F06) ============
     // A rerange swaps nothing, so once spot leaves the old band the position is 100% one leg and the
     // straddling band's mint reverted on zero liquidity. `rerangeTickRange` now anchors the populated side.

--- a/test/leveraged-aero/LeveragedAeroExplicitRange.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroExplicitRange.unit.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {LeveragedAeroValuation} from "@contracts/leveraged-aero/LeveragedAeroValuation.sol";
+import {TickMath} from "@contracts/leveraged-aero/sherwood/libraries/TickMath.sol";
+
+import {Test} from "@forge-std/Test.sol";
+
+/**
+ * @title EXPLICIT-RANGE predicate (`LeveragedAeroValuation.checkExplicitRange`)
+ * @notice The gate on `remintRange`'s caller-supplied `(tickLower, tickUpper)`. It is the counterpart of
+ *         `checkRange` for the DERIVED `(width, skew)` pair, and every rejection shares the one
+ *         `OutOfBounds` selector.
+ *
+ * @dev Pure — no venue mocks at all. The SKEW band is deliberately absent from the signature: explicit
+ *      placement is the feature `remintRange` exists for, and a skew is only meaningful for a band derived
+ *      from spot. The WIDTH band still binds, which is what keeps the proposer inside governance policy.
+ */
+contract LeveragedAeroExplicitRangeUnitTest is Test {
+    int24 internal constant SPACING = 100;
+    uint24 internal constant MIN_WIDTH = 200;
+    uint24 internal constant MAX_WIDTH = 20_000;
+
+    function _check(int24 lower, int24 upper) internal pure {
+        LeveragedAeroValuation.checkExplicitRange(lower, upper, SPACING, MIN_WIDTH, MAX_WIDTH);
+    }
+
+    function _expectOutOfBounds() internal {
+        vm.expectRevert(LeveragedAeroValuation.OutOfBounds.selector);
+    }
+
+    /// @dev The aligned domain edge the predicate clamps against, for `SPACING`.
+    function _maxAligned() internal pure returns (int24) {
+        return TickMath.MAX_TICK - (TickMath.MAX_TICK % SPACING);
+    }
+
+    // ==================== ACCEPTED ====================
+
+    function testAcceptsAnOnGridBandInsideTheWidthBand() public pure {
+        _check(-2000, 2000); // width 4000, brackets 0
+        _check(69_000, 73_000); // a positive band, nowhere near spot — placement is free
+        _check(-73_000, -69_000);
+    }
+
+    /// @dev BOTH width-band edges are reachable: the band is inclusive at both ends.
+    function testAcceptsTheExactWidthBandBoundaries() public pure {
+        _check(0, int24(uint24(MIN_WIDTH))); // exactly minWidth
+        _check(0, int24(uint24(MAX_WIDTH))); // exactly maxWidth
+    }
+
+    /// @dev The aligned tick domain edges themselves are inside, not outside.
+    function testAcceptsTheAlignedDomainEdges() public pure {
+        int24 maxAligned = _maxAligned();
+        _check(maxAligned - int24(uint24(MAX_WIDTH)), maxAligned);
+        _check(-maxAligned, -maxAligned + int24(uint24(MAX_WIDTH)));
+    }
+
+    // ==================== REJECTED ====================
+
+    function testRejectsOffGridTicks() public {
+        _expectOutOfBounds();
+        _check(-2050, 2000); // lower off grid
+        _expectOutOfBounds();
+        _check(-2000, 2050); // upper off grid
+    }
+
+    /// @dev Negative ticks are the easy place to get `%` wrong, so they get their own case.
+    function testRejectsOffGridNegativeTicks() public {
+        _expectOutOfBounds();
+        _check(-2001, -1000);
+    }
+
+    function testRejectsAnInvertedOrDegenerateBand() public {
+        _expectOutOfBounds();
+        _check(2000, -2000); // inverted
+        _expectOutOfBounds();
+        _check(2000, 2000); // zero width
+    }
+
+    function testRejectsTicksOutsideTheAlignedDomain() public {
+        // Widths kept legal (200) so it is the DOMAIN clamp being asserted, not the width band.
+        int24 maxAligned = _maxAligned();
+        _expectOutOfBounds();
+        _check(maxAligned - SPACING, maxAligned + SPACING); // upper past the domain
+        _expectOutOfBounds();
+        _check(-maxAligned - SPACING, -maxAligned + SPACING); // lower past the domain
+    }
+
+    function testRejectsWidthsOutsideTheGovernanceBand() public {
+        _expectOutOfBounds();
+        _check(0, int24(uint24(MIN_WIDTH)) - SPACING); // one spacing under minWidth
+        _expectOutOfBounds();
+        _check(0, int24(uint24(MAX_WIDTH)) + SPACING); // one spacing over maxWidth
+    }
+
+    /// @dev A zero/negative spacing is unreachable through the strategy (init rejects it) but the predicate
+    ///      fails closed rather than dividing by zero, mirroring `checkRange`.
+    function testRejectsANonPositiveTickSpacing() public {
+        _expectOutOfBounds();
+        LeveragedAeroValuation.checkExplicitRange(-2000, 2000, 0, MIN_WIDTH, MAX_WIDTH);
+    }
+}

--- a/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
+++ b/test/leveraged-aero/LeveragedAeroTwoLegLifecycle.unit.t.sol
@@ -871,6 +871,250 @@ contract LeveragedAeroTwoLegLifecycleUnitTest is Test {
             + _valueUsdc(legA.balanceOf(address(strategy)), P_LEG_A, 18);
     }
 
+    // ============ REMINT RANGE: EXPLICIT TICKS + AN OPTIONAL LEG SWAP (two borrowed legs) ============
+    // `rerange` derives its band from `(width, skew)` around spot and swaps nothing; `remintRange` takes the
+    // band and may move part of the collected inventory ACROSS the legs. Leg B is token0 in this fixture.
+
+    /// @dev The centred band `rerange(WIDTH, 5000, ...)` would derive — the parity reference below.
+    int24 internal constant REMINT_LOWER = TICK - 2000;
+    int24 internal constant REMINT_UPPER = TICK + 2000;
+
+    /// @dev ORACLE-CONSISTENT legB↔legA rates: `out per in`, 1e18-scaled, spanning the 8dp↔18dp gap
+    ///      (`pIn·10^decOut / (pOut·10^decIn)`). The LP pair is its own swap venue on this path, and setUp
+    ///      only wires the leg↔USDC directions, so a `remintRange` swap needs these.
+    function _setLegSwapRates() internal {
+        router.setRate(address(legB), address(legA), (P_LEG_B * 1e18 * 1e18) / (P_LEG_A * 1e8));
+        router.setRate(address(legA), address(legB), (P_LEG_A * 1e8 * 1e18) / (P_LEG_B * 1e18));
+    }
+
+    /// @dev `remintRange` as the proposer, with the shared explicit band.
+    function _remint(bool zeroForOne, uint16 swapBps, uint256 minSwapOut, uint256 minLiquidity) internal {
+        vm.prank(proposer);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, zeroForOne, swapBps, minSwapOut, minLiquidity);
+    }
+
+    /**
+     * @dev BEHAVIOURAL PARITY AT `swapBps == 0`: pointed at the band `rerange` would derive, a swap-free
+     *      `remintRange` must land the IDENTICAL position — same ticks, same liquidity, same NAV — and touch
+     *      no router. The two paths are run from the same state via a snapshot so this is an equality, not a
+     *      tolerance.
+     */
+    function testRemintRangeWithoutASwapIsRerangeAtAnExplicitBand() public {
+        _execute(SEED);
+        uint256 navBefore = strategy.nav();
+
+        uint256 snap = vm.snapshotState();
+        vm.prank(proposer);
+        strategy.rerange(WIDTH, SKEW_CENTERED, 0, 0);
+        uint256 rerangeTokenId = strategy.layout().tokenId;
+        int24 rerangeLower = strategy.layout().posTickLower;
+        int24 rerangeUpper = strategy.layout().posTickUpper;
+        uint128 rerangeLiq = npm.liquidityOf(rerangeTokenId);
+        uint256 rerangeNav = strategy.nav();
+        vm.revertToState(snap);
+
+        assertEq(rerangeLower, REMINT_LOWER, "the fixture's explicit band IS the centred rerange band");
+        assertEq(rerangeUpper, REMINT_UPPER, "the fixture's explicit band IS the centred rerange band");
+
+        _remint(false, 0, 0, 0);
+
+        assertEq(strategy.layout().posTickLower, REMINT_LOWER, "minted at the explicit lower tick");
+        assertEq(strategy.layout().posTickUpper, REMINT_UPPER, "minted at the explicit upper tick");
+        assertEq(strategy.layout().tokenId, rerangeTokenId, "a fresh NFT, exactly as the re-range mints");
+        assertEq(npm.liquidityOf(strategy.layout().tokenId), rerangeLiq, "identical liquidity: principal conserved");
+        assertEq(strategy.nav(), rerangeNav, "identical NAV");
+        assertApproxEqRel(strategy.nav(), navBefore, 1e16, "a no-swap re-mint is NAV-neutral");
+        assertEq(router.boughtOf(address(legA)) + router.boughtOf(address(legB)), 0, "swapBps == 0 touched no router");
+    }
+
+    /// @dev The validated span is PERSISTED as `width` (so `setWidthBounds` / venue migration keep re-checking a
+    ///      truthful value) while `skewBps` is left alone — explicit ticks carry no skew.
+    function testRemintRangePersistsTheWidthAndLeavesSkewUntouched() public {
+        _execute(SEED);
+
+        vm.prank(proposer);
+        strategy.remintRange(TICK - 1000, TICK + 5000, false, 0, 0, 0);
+
+        assertEq(strategy.layout().width, 6000, "the explicit span became the stored width");
+        assertEq(strategy.layout().skewBps, SKEW_CENTERED, "the stored skew is untouched");
+
+        // The persisted width is the one the band checks now measure: it must be inside a new band.
+        vm.prank(owner);
+        vm.expectRevert(LeveragedAeroValuation.OutOfBounds.selector);
+        strategy.setWidthBounds(200, 5000);
+    }
+
+    /// @dev token0 → token1 (leg B → leg A). The routed venue must be the LP POOL's tickSpacing, not the
+    ///      leg↔USDC one: `remintRange`'s swap IS the LP pair.
+    function testRemintRangeSwapsToken0IntoToken1() public {
+        _execute(SEED);
+        _setLegSwapRates();
+        uint256 routerLegBBefore = legB.balanceOf(address(router));
+
+        _remint(true, 5000, 0, 0);
+
+        assertGt(router.boughtOf(address(legA)), 0, "leg A was bought");
+        assertGt(legB.balanceOf(address(router)), routerLegBBefore, "...and leg B is what paid for it");
+        assertEq(router.lastTickSpacing(), SPACING, "routed through the LP pool's spacing");
+        assertGt(npm.liquidityOf(strategy.layout().tokenId), 0, "the re-mint still opened a real position");
+    }
+
+    /// @dev token1 → token0 (leg A → leg B). Leg A's leg↔USDC pool has a DIFFERENT spacing (200), so the
+    ///      tickSpacing assertion here would fail if the swap borrowed `_legSwapSpacing`.
+    function testRemintRangeSwapsToken1IntoToken0() public {
+        _execute(SEED);
+        _setLegSwapRates();
+        uint256 routerLegABefore = legA.balanceOf(address(router));
+
+        _remint(false, 5000, 0, 0);
+
+        assertGt(router.boughtOf(address(legB)), 0, "leg B was bought");
+        assertGt(legA.balanceOf(address(router)), routerLegABefore, "...and leg A is what paid for it");
+        assertEq(router.lastTickSpacing(), SPACING, "the LP pool's spacing, NOT leg A's USDC-pool 200");
+        assertGt(npm.liquidityOf(strategy.layout().tokenId), 0, "the re-mint still opened a real position");
+    }
+
+    /// @dev FULL NOTIONAL: `swapBps == 10000` empties the input leg, so the only mintable band is one placed
+    ///      wholly on the surviving side — here at/below spot, which a token1-only position fills.
+    function testRemintRangeAtFullNotionalMintsOneSided() public {
+        _execute(SEED);
+        _setLegSwapRates();
+
+        vm.prank(proposer);
+        strategy.remintRange(TICK - 4000, TICK, true, 10_000, 0, 0);
+
+        assertEq(legB.balanceOf(address(strategy)), 0, "the whole leg-B inventory was sold");
+        assertEq(strategy.layout().posTickUpper, TICK, "the band abuts spot from below");
+        assertGt(npm.liquidityOf(strategy.layout().tokenId), 0, "one-sided, but real liquidity");
+        assertEq(gauge.depositCallCount(), 2, "the new NFT was restaked");
+    }
+
+    /// @dev THE TRUST MODEL. `minSwapOut == 0` is NOT a licence to fill at any price: the Chainlink cross-rate
+    ///      floor is always applied, so a router 5% off the oracle reverts even with the caller's guard open.
+    function testRemintRangeOracleFloorBindsEvenWithZeroMinSwapOut() public {
+        _execute(SEED);
+        _setLegSwapRates();
+        // 5% below the oracle cross rate — well past `maxSlippageBps = 100`.
+        router.setRate(address(legB), address(legA), (P_LEG_B * 1e18 * 1e18 * 95) / (P_LEG_A * 1e8 * 100));
+
+        vm.prank(proposer);
+        vm.expectRevert(MockClSwapRouter.MockRouterMinOut.selector);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, true, 5000, 0, 0);
+    }
+
+    /// @dev The caller's own floor may only TIGHTEN the oracle one.
+    function testRemintRangeCallerFloorCanTightenTheOracleFloor() public {
+        _execute(SEED);
+        _setLegSwapRates();
+
+        vm.prank(proposer);
+        vm.expectRevert(MockClSwapRouter.MockRouterMinOut.selector);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, true, 5000, 1_000_000e18, 0);
+    }
+
+    /// @dev `minLiquidity` is a LIQUIDITY-UNITS floor (the `_mintAndStake` guard), not `rerange`'s two
+    ///      per-amount floors — a swap makes the consumed amounts a moving target.
+    function testRemintRangeMinLiquidityFloorBinds() public {
+        _execute(SEED);
+
+        _remint(false, 0, 0, 0); // the achievable liquidity, uncapped
+        uint128 achieved = npm.liquidityOf(strategy.layout().tokenId);
+        assertGt(achieved, 0, "baseline liquidity");
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.InsufficientLiquidity.selector);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, false, 0, 0, type(uint128).max);
+    }
+
+    /// @dev THE DELIBERATE DEVIATION from `rerange`: a flat book REVERTS. `rerange`'s silent return exists to
+    ///      persist width/skew; there is nothing to persist here, so a silent success would mislead the keeper.
+    function testRemintRangeRevertsOnAFlatBook() public {
+        _execute(SEED);
+
+        // Redeem the whole book: `tokenId` goes to 0 while the strategy stays Executed.
+        uint256 supply = 1_000_000e12;
+        vm.prank(address(strategy));
+        vault.strategyMint(lp, supply);
+        vm.prank(lp);
+        vault.approve(address(strategy), supply);
+        vm.prank(lp);
+        uint256 id = strategy.requestRedeem(supply, 0, address(0));
+        vm.prank(proposer);
+        strategy.fulfillRedeem(id, 0);
+        assertEq(strategy.layout().tokenId, 0, "flat book");
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAeroValuation.NothingToRerange.selector);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, false, 0, 0, 0);
+    }
+
+    /// @dev The calm-gate runs FIRST, so neither the swap nor the mint can execute at a shoved tick.
+    function testRemintRangeCalmGateBlocksAShovedTick() public {
+        _execute(SEED);
+        _setLegSwapRates();
+        uint256 tokenIdBefore = strategy.layout().tokenId;
+        uint128 liqBefore = npm.liquidityOf(tokenIdBefore);
+
+        pool.setTick(TICK + 5000);
+        pool.setTwapTick(TICK);
+        pool.setSqrtPriceX96(TickMath.getSqrtRatioAtTick(TICK + 5000));
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAeroValuation.CalmGateBreached.selector);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, true, 5000, 0, 0);
+
+        assertEq(strategy.layout().tokenId, tokenIdBefore, "the position was never touched");
+        assertEq(npm.liquidityOf(tokenIdBefore), liqBefore, "no liquidity was removed");
+        assertEq(router.boughtOf(address(legA)), 0, "and nothing was swapped");
+    }
+
+    /// @dev The three entrypoint gates: auth, lifecycle state, and `swapBps <= 100%`.
+    function testRemintRangeEntrypointGates() public {
+        // Not yet Executed — the state gate, reached by the proposer.
+        vm.prank(proposer);
+        vm.expectRevert(BaseStrategy.NotExecuted.selector);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, false, 0, 0, 0);
+
+        _execute(SEED);
+
+        vm.prank(lp);
+        vm.expectRevert(BaseStrategy.NotProposer.selector);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, false, 0, 0, 0);
+
+        vm.prank(owner); // the admin is not the proposer either
+        vm.expectRevert(BaseStrategy.NotProposer.selector);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, false, 0, 0, 0);
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAerodromeCLStrategy.OutOfBounds.selector);
+        strategy.remintRange(REMINT_LOWER, REMINT_UPPER, false, 10_001, 0, 0);
+    }
+
+    /// @dev The width band still bounds explicit placement — the SKEW band deliberately does not.
+    function testRemintRangeIsBoundedByTheWidthBand() public {
+        _execute(SEED);
+
+        vm.prank(owner);
+        strategy.setWidthBounds(2000, 6000);
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAeroValuation.OutOfBounds.selector);
+        strategy.remintRange(TICK - 500, TICK + 500, false, 0, 0, 0); // 1000 < minWidth
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAeroValuation.OutOfBounds.selector);
+        strategy.remintRange(TICK - 4000, TICK + 4000, false, 0, 0, 0); // 8000 > maxWidth
+
+        vm.prank(proposer);
+        vm.expectRevert(LeveragedAeroValuation.OutOfBounds.selector);
+        strategy.remintRange(TICK - 2050, TICK + 2000, false, 0, 0, 0); // off the tickSpacing grid
+
+        // A skew the `[minSkewBps, maxSkewBps]` band would refuse for `rerange` is legal HERE.
+        vm.prank(proposer);
+        strategy.remintRange(TICK - 5900, TICK + 100, false, 0, 0, 0);
+        assertEq(strategy.layout().width, 6000, "an all-but-one-spacing-below band is legal explicitly");
+    }
+
     // ==================== LEVER-DOWN COVER IS NEED-SIZED ====================
 
     /// @dev THE IDLE REMAINDER A LEVER-DOWN MUST NOT LIQUIDATE. `_rebalanceCover` sells the surplus leg to buy the

--- a/test/leveraged-aero/LeveragedAeroVenuesHarness.sol
+++ b/test/leveraged-aero/LeveragedAeroVenuesHarness.sol
@@ -576,6 +576,9 @@ contract MockClSwapRouter {
     /// @notice Cumulative `tokenOut` bought per token: proves a cover swap happened without net-balance inference.
     mapping(address => uint256) public boughtOf;
 
+    /// @notice tickSpacing of the LAST `exactInputSingle` — the routed VENUE, which rates alone cannot pin.
+    int24 public lastTickSpacing;
+
     error MockRouterNoRate();
     error MockRouterMinOut();
     error MockRouterMaxIn();
@@ -607,6 +610,7 @@ contract MockClSwapRouter {
     }
 
     function exactInputSingle(ExactInputSingleParams calldata p) external payable returns (uint256 amountOut) {
+        lastTickSpacing = p.tickSpacing;
         uint256 rate = rateE18[p.tokenIn][p.tokenOut];
         if (rate == 0) revert MockRouterNoRate();
         amountOut = (p.amountIn * rate) / 1e18;


### PR DESCRIPTION
Rebalancer-requested placement primitive for the d4/2 strategy. The existing swap-free `rerange(width, skew, …)` is unchanged; `remintRange` takes EXPLICIT ticks and may swap a fraction of the inventory the unwind collects between the two LP legs, so the mint can be two-sided at a band spot has left.

```solidity
function remintRange(
    int24 tickLower, int24 tickUpper,
    bool zeroForOne,           // swap direction in POOL token order
    uint16 swapBps,            // fraction of collected inventory to swap; 0 = none, 10000 = full notional
    uint256 minSwapOut,
    uint256 minLiquidity       // liquidity-units floor on the mint
) external onlyProposer nonReentrant;
```

Flow (mirrors `rerangeImpl`): validate band → calm-gate → unwind 100% → size collected legs → optional swap → mint at the explicit ticks → restake → persist (`width` updated, `skewBps` untouched) → `_assertHealthy`. Flat book reverts `NothingToRerange` (unlike `rerange`'s silent persist-only return — there is nothing to persist here).

## Trust-model notes (reviewers: start here)

- **This is the first proposer-key path that swaps PRINCIPAL between the legs.** The swap's min-out is `max(minSwapOut, Chainlink cross-rate × (1 − maxSlippageBps))` — the always-on floor (`LeveragedAeroValuation.legSwapFloor`) is load-bearing: without it a compromised keeper key could set `minSwapOut = 0` and sandwich the full notional. Proven live on the vnet: with the pool pushed 5% off the unchanged feeds, `minSwapOut = 0` selling into the divergence reverts; selling with it passes (directional, as intended).
- **The SKEW band deliberately does not bound `remintRange`** — explicit placement is the feature. The proposer can now open a band entirely on one side of spot; the bounds that remain are the width band, the calm gate, the oracle swap floor, `minLiquidity`, the always-on `depositMins` mint floor, and `_assertHealthy`. This is a genuine widening of proposer authority and the reason for the trust-model paragraph in the natspec.
- Two deviations from the requesting dev's literal spec, both flagged to them: (1) leg-A sizing keeps `rerange` parity — pre-existing idle leg A (the previous remint's remainder) is folded back in rather than stranded; asset-mode idle USDC stays excluded (the F05 rule, now single-definition). (2) `minSwapOut` may only tighten the oracle floor, never replace it.

## `rerangeImpl` is refactored in this PR, not just added-next-to

The straightforward implementation left the manager 803 B over EIP-170. The fix extracts a shared `_calmUnwindAll` / `_collectedLegs` prologue that both `rerangeImpl` and `remintRangeImpl` use — behaviour-identical (the 15 removed lines are exactly the code now in the helpers), and it collapses the F05 snapshot rule to one definition. Please diff that refactor explicitly.

**EIP-170 after:** manager 276 B / strategy 1,348 B / valuation 7,467 B of runtime margin. The manager is now the size-critical contract — the next feature touching it will not fit; the next relief valve is `LeveragedAeroVenue` (3,800 B free). Local sizes only — the known CI/local via-IR skew can eat ~137 B, so watch the CI size gate.

## Testing

- Forkless suites: **444/444** (`forge test --ffi --match-path "test/leveraged-aero/*.t.sol"`; +23 new — explicit-range predicate unit tests, two-leg + asset-mode lifecycle behaviourals incl. an F05 regression and floor tests). Layout parity untouched (no new Layout copies).
- Live vnet: fresh Tenderly Base-fork instance (`mamo-remint-range`, chainId 73578453) deployed from this head via the stack harness; `script/tenderly/remint-range-cycle.sh scenarios` **25/25 green** — swap-free parity, 25% swaps both directions, full-notional one-sided mint, two-sided recentre, all validation probes, and the directional oracle-floor proof. NAV drift across ~13 remints + swaps: 0.033% (swap fees).
- New tooling in this PR: `script/tenderly/create-vnet.sh` (runbook Phase A automation) + `script/tenderly/remint-range-cycle.sh` (proposer-side scenario driver).
- Note for keepers: `swapBps` is a fraction of COLLECTED inventory, not NAV — size against `positions()`/balances. A stale Chainlink feed fails the swap branch closed, consistent with every other priced path.

Pre-existing base-branch issue (not this PR): `testRewardReadOkIsFalseWhenTheGaugeHasNoCode` fails under `-vvv` on `aero-audit-2` (`vm.expectRevert(bytes(""))` vs a codeless target) — makes `make test-unit` red on base; one-line separate fix.

LoC: src +176/−15 (87 code / 49 comment), tests +418, tooling +290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)